### PR TITLE
Fix padding in Java

### DIFF
--- a/lib/xdrgen/generators/java/XdrDataInputStream.erb
+++ b/lib/xdrgen/generators/java/XdrDataInputStream.erb
@@ -123,8 +123,12 @@ public class XdrDataInputStream extends DataInputStream {
         }
 
         public void pad() throws IOException {
-            int r = 4 - mCount % 4;
-            skip(r);
+            int pad = 0;
+            int mod = mCount % 4;
+            if (mod > 0) {
+                pad = 4-mod;
+            }
+            skip(pad);
         }
     }
 }

--- a/lib/xdrgen/generators/java/XdrDataOutputStream.erb
+++ b/lib/xdrgen/generators/java/XdrDataOutputStream.erb
@@ -87,7 +87,12 @@ public class XdrDataOutputStream extends DataOutputStream {
         }
 
         public void pad() throws IOException {
-            for (int i = 0; i < (4 - mCount % 4); i++) {
+            int pad = 0;
+            int mod = mCount % 4;
+            if (mod > 0) {
+                pad = 4-mod;
+            }
+            while (pad-- > 0) {
                 write(0);
             }
         }


### PR DESCRIPTION
`pad` methods in both `XdrDataInputStream` and `XdrDataOutputStream` were wrong. For `mCount` equal 4 they should pad/skip 0 bytes but were padding/skipping 4.