### PR TITLE
Checking an upper-bound of bytes a string may contain in go

### DIFF
--- a/lib/xdrgen/ast/declarations/string.rb
+++ b/lib/xdrgen/ast/declarations/string.rb
@@ -3,9 +3,11 @@ module Xdrgen::AST::Declarations
     delegate :name, to: :identifier
 
     def size
-      size_str = size_spec.size_t.text_value
+      size_spec.size
+    end
 
-      size_str.to_i if size_str.present?
+    def fixed?
+      size_spec.is_a?(Xdrgen::AST::VarSize)
     end
   end
 end

--- a/lib/xdrgen/ast/typespecs/string.rb
+++ b/lib/xdrgen/ast/typespecs/string.rb
@@ -4,6 +4,7 @@ module Xdrgen::AST::Typespecs
     
     delegate :size, to: :decl
     delegate :name, to: :decl
+    delegate :fixed?, to: :decl
 
   end
 end


### PR DESCRIPTION
This PR adds support for checking an upper-bound of bytes that strings may contain, like:
```xdr
string text<28>;
```

To achieve this:
* A container for `string` with upper-bound type was changed to `[m]rune` where `m` is an upper-bound of bytes that a string may contain,
* Getters: `Get#{name arm}` and `Must#{name arm}` have a different body for `[m]rune` fields: they convert `[m]rune` and return `string`.
* Setters: `New#{name union}` have a different body for `[m]rune` fields: they convert `string` and save `[m]rune`.

The previous version of generated code did not check an upper-bound of the strings during decoding and encoding thus allowing to decode and encode objects with string fields that exceeded the maximum length specified in XDR files.