### PR TITLE
Fix pad() method in XdrInputStream

### DIFF
--- a/lib/xdrgen/generators/java/XdrDataInputStream.erb
+++ b/lib/xdrgen/generators/java/XdrDataInputStream.erb
@@ -119,7 +119,7 @@ public class XdrDataInputStream extends DataInputStream {
             }
 
             while (pad-- > 0) {
-                int b = mIn.read();
+                int b = read();
                 if (b != 0) {
                     throw new IOException("non-zero padding");
                 }


### PR DESCRIPTION
`XdrInputStream.pad()` method was calling internal `InputStream` `read()`
method without updating the internal `mCount` counter. This was fixed by
using `XdrInputStream.read()` wrapper that handles counter updates.

CC: https://github.com/stellar/java-stellar-sdk/issues/48