### PR TITLE
Improve indentation of generated Java-code

### DIFF
--- a/lib/xdrgen/generators/java.rb
+++ b/lib/xdrgen/generators/java.rb
@@ -188,16 +188,18 @@ module Xdrgen
             this.#{typedef.name} = value;
           }
         EOS
-        out.puts "public static void encode(XdrDataOutputStream stream, #{name typedef}  encoded#{name typedef}) throws IOException {"
-        encode_member "encoded#{name typedef}", typedef, out
+        out.puts "public static void encode(XdrDataOutputStream stream, #{name typedef} encoded#{name typedef}) throws IOException {"
+        out.indent do
+          encode_member "encoded#{name typedef}", typedef, out
+        end
         out.puts "}"
 
         out.puts <<-EOS.strip_heredoc
           public static #{name typedef} decode(XdrDataInputStream stream) throws IOException {
             #{name typedef} decoded#{name typedef} = new #{name typedef}();
         EOS
-        decode_member "decoded#{name typedef}", typedef, out
         out.indent do
+          decode_member "decoded#{name typedef}", typedef, out
           out.puts "return decoded#{name typedef};"
         end
         out.puts "}"


### PR DESCRIPTION
Given a small input file, `sample.tt`:

```
const MY_CONSTANT = 42;
typedef long MyLongs[MY_CONSTANT];
struct MyStructure {
     MyLongs myLongs;
};
```

Invoking Treetop with: `bundle exec xdrgen sample.tt -o generated -l java -n generated`, it generates this Java source file:

```
// Automatically generated by xdrgen 
// DO NOT EDIT or your changes may be overwritten

package generated;


import java.io.IOException;

// === xdr source ============================================================

//  typedef long MyLongs[MY_CONSTANT];

//  ===========================================================================
public class MyLongs  {
  private Long[] MyLongs;
  public Long[] getMyLongs() {
    return this.MyLongs;
  }
  public void setMyLongs(Long[] value) {
    this.MyLongs = value;
  }
  public static void encode(XdrDataOutputStream stream, MyLongs  encodedMyLongs) throws IOException {
  int MyLongssize = encodedMyLongs.getMyLongs().length;
  for (int i = 0; i < MyLongssize; i++) {
    stream.writeLong(encodedMyLongs.MyLongs[i]);
  }
  }
  public static MyLongs decode(XdrDataInputStream stream) throws IOException {
    MyLongs decodedMyLongs = new MyLongs();
  int MyLongssize = MY_CONSTANT;
  decodedMyLongs.MyLongs = new Long[MyLongssize];
  for (int i = 0; i < MyLongssize; i++) {
    decodedMyLongs.MyLongs[i] = stream.readLong();
  }
    return decodedMyLongs;
  }
}
```

Apart from the fact that this code does not compile (#33) it also has some strange indentation choices in its `encode` and `decode` methods. This PR fixes that. 