### PR TITLE
Java parent interface for xdr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ mkmf.log
 spec/fixtures/hayashi/
 gen/
 .DS_Store
+.ruby-version

--- a/lib/xdrgen/generators/java/XdrElement.erb
+++ b/lib/xdrgen/generators/java/XdrElement.erb
@@ -1,0 +1,10 @@
+package <%= @namespace %>;
+
+import java.io.IOException;
+
+/**
+ * Common parent interface for all generated classes. 
+ */
+interface XdrElement {
+    void encode(XdrDataOutputStream stream) throws IOException;
+}


### PR DESCRIPTION
Add a common parent XdrElement interface.

Currently has a single convenience method so you can call encode directly on any XDR element without having to call the static method on the right class.

The main use for this is being able to reflect on classes and doing e.g. some kotlin extension functions.

Currently the java code does not compile because of #36 but this issue also occurs on master. My ruby is a bit rusty so would appreciate some help with that issue.