### PR TITLE
Implement standard binary interfaces in Go output

### DIFF
--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -177,7 +177,6 @@ module Xdrgen
           render_binary_interface out, name(defn)
         when AST::Definitions::Const ;
           render_const out, defn
-          render_binary_interface out, name(defn)
         end
       end
 

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -315,7 +315,7 @@ module Xdrgen
         out.puts "// MarshalBinary implements encoding.BinaryMarshaler."
         out.puts "func (s #{name}) MarshalBinary() ([]byte, error) {"
         out.puts "  b := new(bytes.Buffer)"
-        out.puts "  _, err := Marshal(&b, s)"
+        out.puts "  _, err := Marshal(b, s)"
         out.puts "  return b.Bytes(), err"
         out.puts "}"
         out.break
@@ -324,6 +324,11 @@ module Xdrgen
         out.puts "  _, err := Unmarshal(bytes.NewReader(inp), s)"
         out.puts "  return err"
         out.puts "}"
+        out.break
+        out.puts "var ("
+        out.puts "  _ encoding.BinaryMarshaler   = (*#{name})(nil)"
+        out.puts "  _ encoding.BinaryUnmarshaler = (*#{name})(nil)"
+        out.puts ")"
         out.break
       end
 
@@ -338,6 +343,7 @@ module Xdrgen
 
           import (
             "bytes"
+            "encoding"
             "io"
             "fmt"
 

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -165,17 +165,20 @@ module Xdrgen
         case defn
         when AST::Definitions::Struct ;
           render_struct out, defn
+          render_binary_interface out, name(defn)
         when AST::Definitions::Enum ;
           render_enum out, defn
+          render_binary_interface out, name(defn)
         when AST::Definitions::Union ;
           render_union out, defn
+          render_binary_interface out, name(defn)
         when AST::Definitions::Typedef ;
           render_typedef out, defn
+          render_binary_interface out, name(defn)
         when AST::Definitions::Const ;
           render_const out, defn
+          render_binary_interface out, name(defn)
         end
-
-        render_binary_interface out, name(defn)
       end
 
       def render_source_comment(out, defn)

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -174,6 +174,8 @@ module Xdrgen
         when AST::Definitions::Const ;
           render_const out, defn
         end
+
+        render_binary_interface out, name(defn)
       end
 
       def render_source_comment(out, defn)
@@ -307,6 +309,22 @@ module Xdrgen
         out.break
       end
 
+      def render_binary_interface(out, name)
+        out.puts "// MarshalBinary implements encoding.BinaryMarshaler."
+        out.puts "func (s #{name}) MarshalBinary() ([]byte, error) {"
+        out.puts "  b := new(bytes.Buffer)"
+        out.puts "  _, err := Marshal(&b, s)"
+        out.puts "  return b.Bytes(), err"
+        out.puts "}"
+        out.break
+        out.puts "// UnmarshalBinary implements encoding.BinaryUnmarshaler."
+        out.puts "func (s *#{name}) UnmarshalBinary(inp []byte) error {"
+        out.puts "  _, err := Unmarshal(bytes.NewReader(inp), s)"
+        out.puts "  return err"
+        out.puts "}"
+        out.break
+      end
+
       def render_top_matter(out)
         out.puts <<-EOS.strip_heredoc
           // Package #{@namespace || "main"} is generated from:
@@ -317,6 +335,7 @@ module Xdrgen
           package #{@namespace || "main"}
 
           import (
+            "bytes"
             "io"
             "fmt"
 


### PR DESCRIPTION
Adds `MarshalBinary` and `UnmarshalBinary` for each rendered definition, implementing the binary interfaces from [the standard encoding package](https://golang.org/pkg/encoding/).