### PR TITLE
Switch to Stellar managed fork of go-xdr

### DIFF
--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -347,7 +347,7 @@ module Xdrgen
             "io"
             "fmt"
 
-            "github.com/nullstyle/go-xdr/xdr3"
+            "github.com/stellar/go-xdr/xdr3"
           )
 
           // Unmarshal reads an xdr element from `r` into `v`.


### PR DESCRIPTION
Some background: https://github.com/nullstyle/go-xdr/pull/8

/cc @bartekn 