### PR TITLE
Represent XDR strings as bytes

### DIFF
--- a/lib/xdrgen/generators/java.rb
+++ b/lib/xdrgen/generators/java.rb
@@ -683,19 +683,19 @@ module Xdrgen
           out.puts <<-EOS.strip_heredoc
             #{value}.#{member.name} = new #{type_string member.type}[#{member.name}size];
             for (int i = 0; i < #{member.name}size; i++) {
-              #{value}.#{member.name}[i] = #{decode_type member.declaration.type};
+              #{value}.#{member.name}[i] = #{decode_type member.declaration};
             }
           EOS
         else
-          out.puts "#{value}.#{member.name} = #{decode_type member.declaration.type};"
+          out.puts "#{value}.#{member.name} = #{decode_type member.declaration};"
         end
         if member.type.sub_type == :optional
           out.puts "}"
         end
       end
 
-      def decode_type(type)
-        case type
+      def decode_type(decl)
+        case decl.type
         when AST::Typespecs::Int ;
           "stream.readInt()"
         when AST::Typespecs::UnsignedInt ;
@@ -713,13 +713,13 @@ module Xdrgen
         when AST::Typespecs::Bool ;
           "stream.readInt() == 1 ? true : false"
         when AST::Typespecs::String ;
-          "XdrString.decode(stream)"
+          "XdrString.decode(stream, #{decl.size})"
         when AST::Typespecs::Simple ;
-          "#{name type.resolved_type}.decode(stream)"
+          "#{name decl.type.resolved_type}.decode(stream)"
         when AST::Concerns::NestedDefinition ;
-          "#{name type}.decode(stream)"
+          "#{name decl.type}.decode(stream)"
         else
-          raise "Unknown typespec: #{type.class.name}"
+          raise "Unknown typespec: #{decl.type.class.name}"
         end
       end
 

--- a/lib/xdrgen/generators/java/XdrDataInputStream.erb
+++ b/lib/xdrgen/generators/java/XdrDataInputStream.erb
@@ -21,13 +21,6 @@ public class XdrDataInputStream extends DataInputStream {
         mIn = (XdrInputStream) super.in;
     }
 
-    public String readString() throws IOException {
-        int l = readInt();
-        byte[] bytes = new byte[l];
-        read(bytes);
-        return new String(bytes, Charset.forName("UTF-8"));
-    }
-
     public int[] readIntArray() throws IOException {
         int l = readInt();
         return readIntArray(l);

--- a/lib/xdrgen/generators/java/XdrDataOutputStream.erb
+++ b/lib/xdrgen/generators/java/XdrDataOutputStream.erb
@@ -14,12 +14,6 @@ public class XdrDataOutputStream extends DataOutputStream {
         mOut = (XdrOutputStream) super.out;
     }
 
-    public void writeString(String s) throws IOException {
-        byte[] chars = s.getBytes(Charset.forName("UTF-8"));
-        writeInt(chars.length);
-        write(chars);
-    }
-
     public void writeIntArray(int[] a) throws IOException {
         writeInt(a.length);
         writeIntArray(a, a.length);

--- a/lib/xdrgen/generators/java/XdrString.erb
+++ b/lib/xdrgen/generators/java/XdrString.erb
@@ -1,21 +1,19 @@
 package <%= @namespace %>;
 
 import java.io.IOException;
+import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
-    private String text;
 
     public XdrString(byte[] bytes) {
         this.bytes = bytes;
-        this.text = new String(bytes, Charset.forName("UTF-8"));
     }
 
     public XdrString(String text) {
         this.bytes = text.getBytes(Charset.forName("UTF-8"));
-        this.text = text;
     }
 
     @Override
@@ -24,8 +22,11 @@ public class XdrString implements XdrElement {
         stream.write(this.bytes, 0, this.bytes.length);
     }
 
-    public static XdrString decode(XdrDataInputStream stream) throws IOException {
+    public static XdrString decode(XdrDataInputStream stream, int maxSize) throws IOException {
         int size = stream.readInt();
+        if (size > maxSize) {
+            throw new InvalidClassException("String length "+size+" exceeds max size "+maxSize);
+        }
         byte[] bytes = new byte[size];
         stream.read(bytes);
         return new XdrString(bytes);
@@ -52,6 +53,6 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toString() {
-        return this.text;
+        return new String(bytes, Charset.forName("UTF-8"));
     }
 }

--- a/lib/xdrgen/generators/java/XdrString.erb
+++ b/lib/xdrgen/generators/java/XdrString.erb
@@ -1,0 +1,57 @@
+package <%= @namespace %>;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+
+public class XdrString implements XdrElement {
+    private byte[] bytes;
+    private String text;
+
+    public XdrString(byte[] bytes) {
+        this.bytes = bytes;
+        this.text = new String(bytes, Charset.forName("UTF-8"));
+    }
+
+    public XdrString(String text) {
+        this.bytes = text.getBytes(Charset.forName("UTF-8"));
+        this.text = text;
+    }
+
+    @Override
+    public void encode(XdrDataOutputStream stream) throws IOException {
+        stream.writeInt(this.bytes.length);
+        stream.write(this.bytes, 0, this.bytes.length);
+    }
+
+    public static XdrString decode(XdrDataInputStream stream) throws IOException {
+        int size = stream.readInt();
+        byte[] bytes = new byte[size];
+        stream.read(bytes);
+        return new XdrString(bytes);
+    }
+
+    public byte[] getBytes() {
+        return this.bytes;
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(this.bytes);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (object == null || !(object instanceof XdrString)) {
+          return false;
+        }
+
+        XdrString other = (XdrString) object;
+        return Arrays.equals(this.bytes, other.bytes);
+    }
+
+    @Override
+    public String toString() {
+        return this.text;
+    }
+}


### PR DESCRIPTION
According to https://github.com/stellar/go/issues/2022 XDR strings are equivalent to XDR opaque fields. The Java XDR code generator represents XDR strings as Java Strings. This representation is incorrect because an XDR string has no restrictions on the byte format. It is possible for an XDR string to contain invalid ASCII or invalid unicode bytes. The safest representation of an XDR string is a byte array.