### PR TITLE
Downcase value when comparing if the source is plural or singular.

### DIFF
--- a/lib/xdrgen/generators/elixir.rb
+++ b/lib/xdrgen/generators/elixir.rb
@@ -164,7 +164,7 @@ module Xdrgen
         parent = name named.parent_defn if named.is_a?(AST::Concerns::NestedDefinition)
 
         # NOTE: classify will strip plurality, so we restore it if necessary
-        plural = named.name.pluralize == named.name
+        plural = named.name.downcase.pluralize == named.name.downcase
         base   = named.name.underscore.classify
         result = plural ? base.pluralize : base
 
@@ -172,10 +172,7 @@ module Xdrgen
       end
 
       def const_name(named)
-        # NOTE: classify will strip plurality, so we restore it if necessary
-        plural = named.name.pluralize == named.name
-        base   = named.name.underscore.upcase
-        plural ? base.pluralize : base
+        named.name.underscore.upcase
       end
 
       def member_name(member)

--- a/lib/xdrgen/generators/javascript.rb
+++ b/lib/xdrgen/generators/javascript.rb
@@ -170,7 +170,15 @@ module Xdrgen
         parent = name named.parent_defn if named.is_a?(AST::Concerns::NestedDefinition)
 
         # NOTE: classify will strip plurality, so we restore it if necessary
-        plural = named.name.pluralize == named.name
+        #
+        # Downcase the value since pluralize adds a lower case `s`.
+        #
+        # Without downcasing, the following appears as singular, but it's plural:
+        #
+        #  "BEGIN_SPONSORING_FUTURE_RESERVEs" == "BEGIN_SPONSORING_FUTURE_RESERVES"
+        #  => false
+        #
+        plural = named.name.downcase.pluralize == named.name.downcase
         base   = named.name.underscore.classify
         result = plural ? base.pluralize : base
 
@@ -178,10 +186,7 @@ module Xdrgen
       end
 
       def const_name(named)
-        # NOTE: classify will strip plurality, so we restore it if necessary
-        plural = named.name.pluralize == named.name
-        base   = named.name.underscore.upcase
-        plural ? base.pluralize : base
+        named.name.underscore.upcase
       end
 
       def member_name(member)


### PR DESCRIPTION
While generating protocol 14 XDRs,  I noticed a weird output for CAP33 related enums and ops.

The following:

```
 beginSponsoringFutureReserf: 16,
 endSponsoringFutureReserf: 17,
```

Should have been 

```
 beginSponsoringFutureReserves: 16,
 endSponsoringFutureReserves: 17,
```

After investigating, I found a bug in this library, which was comparing the pluralized version of the name with the original, the problem is that it didn't keep into account the letter casing - leading to incorrect results in scenarios like this one

```
"BEGIN_SPONSORING_FUTURE_RESERVEs" == "BEGIN_SPONSORING_FUTURE_RESERVES"
```

This PR fixes this issue, making both values down case. 

