### PR TITLE
Fix grammar to support multiline union header

### DIFF
--- a/lib/xdrgen/grammar/union.treetop
+++ b/lib/xdrgen/grammar/union.treetop
@@ -12,7 +12,11 @@ grammar XdrUnionGrammar
   rule union_body
     "switch"
     space?
-    "(" discriminant:declaration ")"
+    "("
+    space?
+    discriminant:declaration
+    space?
+    ")"
     space?
     "{"
     space?

--- a/spec/fixtures/parser/union.x
+++ b/spec/fixtures/parser/union.x
@@ -8,3 +8,14 @@ union MyUnion switch (UnionKey type)
 
 
 };
+
+union SomeVeryLongUnionNamePushingSwitchParamToNewLine switch (
+	SomeLongUnionKeyType type)
+{
+    case ERROR:
+        Error error;
+    case MULTI:
+        Multi things<>;
+    default:
+		void;
+};


### PR DESCRIPTION
Fixes #50.

Otherwise generate is failing for cases like this: https://github.com/stellar/stellar-core/blob/master/src/xdr/Stellar-transaction.x#L703-L704

```
union PathPaymentStrictReceiveResult switch (
    PathPaymentStrictReceiveResultCode code)
{
case PATH_PAYMENT_STRICT_RECEIVE_SUCCESS:
    struct
    {
        ClaimOfferAtom offers<>;
        SimplePaymentResult last;
    } success;
case PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER:
    Asset noIssuer; // the asset that caused the error
default:
    void;
};
```