### PR TITLE
[v0.1.1] Fix pluralization for strings ending with "tA"

### DIFF
--- a/lib/xdrgen/generators/elixir.rb
+++ b/lib/xdrgen/generators/elixir.rb
@@ -164,7 +164,7 @@ module Xdrgen
         parent = name named.parent_defn if named.is_a?(AST::Concerns::NestedDefinition)
 
         # NOTE: classify will strip plurality, so we restore it if necessary
-        plural = named.name.downcase.pluralize == named.name.downcase
+        plural = named.name.underscore.downcase.pluralize == named.name.underscore.downcase
         base   = named.name.underscore.classify
         result = plural ? base.pluralize : base
 

--- a/lib/xdrgen/generators/javascript.rb
+++ b/lib/xdrgen/generators/javascript.rb
@@ -178,7 +178,7 @@ module Xdrgen
         #  "BEGIN_SPONSORING_FUTURE_RESERVEs" == "BEGIN_SPONSORING_FUTURE_RESERVES"
         #  => false
         #
-        plural = named.name.downcase.pluralize == named.name.downcase
+        plural = named.name.underscore.downcase.pluralize == named.name.underscore.downcase
         base   = named.name.underscore.classify
         result = plural ? base.pluralize : base
 

--- a/lib/xdrgen/version.rb
+++ b/lib/xdrgen/version.rb
@@ -1,3 +1,3 @@
 module Xdrgen
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
While generating protocol 18 XDRs, I noticed a weird output for CAP-38 related attributes:

* `asseta` should have been `assetA`
* `maxAmounta` should have been `maxAmountA`
* `minAmounta` should have been `minAmountA`

I found a (likely) bug in the `pluralize` method where words ending with `ta` (or `tA`) where considered the plural form and `"AssetA".pluralize` results in `"Asseta"`.

To prevent that issue I'm now applying pluralization to the camel case version of the name, so `"ASSET_A".pluralize` results in `"ASSET_AS"`, preventing that error.