### PR TITLE
Skip Go generated binary interface on optional typedefs

### DIFF
--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -174,7 +174,11 @@ module Xdrgen
           render_binary_interface out, name(defn)
         when AST::Definitions::Typedef ;
           render_typedef out, defn
-          render_binary_interface out, name(defn)
+          # TODO: Support defining binary interface on typedefs with optional
+          # types. https://github.com/stellar/xdrgen/issues/61
+          if defn.sub_type != :optional
+            render_binary_interface_typedef out, defn
+          end
         when AST::Definitions::Const ;
           render_const out, defn
         end

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -177,7 +177,7 @@ module Xdrgen
           # TODO: Support defining binary interface on typedefs with optional
           # types. https://github.com/stellar/xdrgen/issues/61
           if defn.sub_type != :optional
-            render_binary_interface_typedef out, defn
+            render_binary_interface out, defn
           end
         when AST::Definitions::Const ;
           render_const out, defn

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -177,7 +177,7 @@ module Xdrgen
           # TODO: Support defining binary interface on typedefs with optional
           # types. https://github.com/stellar/xdrgen/issues/61
           if defn.sub_type != :optional
-            render_binary_interface out, defn
+            render_binary_interface out, name(defn)
           end
         when AST::Definitions::Const ;
           render_const out, defn


### PR DESCRIPTION
### What
Skip the Go generation of the binary interface on optional types.

### Why
xdrgen generates invalid Go code when the input XDR definitions contain an optional typedef in the form:
```
typedef UnderlyingType* NamedType
```

The problem with this for the Go generator is that it results in the following Go type definition:
```go
type NamedType *UnderlyingType
```

That type definition is valid, although uncommon in Go applications, because types that name a pointer type are not allowed to have methods.

Xdrgen defines the `MarshalBinary` and `UnmarshalBinary` functions for every type is generates, and so those generated functions cause the output of xdrgen to have a compile error.

It would be great to solve this problem properly, but it is complex because we need to implement the pointer type as a non-pointer type, and then lift the pointer into any reference location. Fixing this problem is low priority, as evidenced by how long #61 has been open for.

While we wait for the problem to be prioritized it would be preferable if xdrgen generated valid Go code that compiles without modification, because it is very tedious when iterating on generated to XDR to have to manually edit it after every generation. This change achieves that.

Temporary fix for #61.

### Known Limitations

I couldn't see any tests for generated code that could be expanded on to test this, so I've tested this manually with the Stellar XDR definitions. If there's a clear, and narrowly focused, way that I can improve testing here, please let me know.