### PR TITLE
Improve the performance of Go generated marshaling/encoding code

### DIFF
--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -177,28 +177,28 @@ module Xdrgen
         case defn
         when AST::Definitions::Struct ;
           render_struct out, defn
-          render_struct_encode_to out, defn
+          render_struct_encode_to_interface out, defn
           render_binary_interface out, name(defn)
-          render_xdr_type_func out, name(defn)
+          render_xdr_type_interface out, name(defn)
         when AST::Definitions::Enum ;
           render_enum out, defn
-          render_enum_encode_to out, defn
+          render_enum_encode_to_interface out, defn
           render_binary_interface out, name(defn)
-          render_xdr_type_func out, name(defn)
+          render_xdr_type_interface out, name(defn)
         when AST::Definitions::Union ;
           render_union out, defn
-          render_union_encode_to out, defn
+          render_union_encode_to_interface out, defn
           render_binary_interface out, name(defn)
-          render_xdr_type_func out, name(defn)
+          render_xdr_type_interface out, name(defn)
         when AST::Definitions::Typedef ;
           render_typedef out, defn
           # Typedefs that wrap a pointer type are not supported in Go because Go
           # does not allow pointer types to have methods. Don't define methods
           # for the type because that will be a Go compiler error.
           if defn.sub_type != :optional
-            render_typedef_encode_to out, defn
+            render_typedef_encode_to_interface out, defn
             render_binary_interface out, name(defn)
-            render_xdr_type_func out, name(defn)
+            render_xdr_type_interface out, name(defn)
           end
         when AST::Definitions::Const ;
           render_const out, defn
@@ -336,7 +336,7 @@ module Xdrgen
         out.break
       end
 
-      def render_struct_encode_to(out, struct)
+      def render_struct_encode_to_interface(out, struct)
         name = name(struct)
         out.puts "// EncodeTo encodes this value using the Encoder."
         out.puts "func (s *#{name}) EncodeTo(e *xdr.Encoder) error {"
@@ -360,7 +360,7 @@ module Xdrgen
         out.break
       end
 
-      def render_union_encode_to(out, union)
+      def render_union_encode_to_interface(out, union)
         name = name(union)
         out.puts "// EncodeTo encodes this value using the Encoder."
         out.puts "func (s #{name}) EncodeTo(e *xdr.Encoder) error {"
@@ -393,7 +393,7 @@ module Xdrgen
         out.break
       end
 
-      def render_enum_encode_to(out, typedef)
+      def render_enum_encode_to_interface(out, typedef)
         name = name(typedef)
         type = AST::Typespecs::Int
         out.puts "// EncodeTo encodes this value using the Encoder."
@@ -405,7 +405,7 @@ module Xdrgen
         out.break
       end
 
-      def render_typedef_encode_to(out, typedef)
+      def render_typedef_encode_to_interface(out, typedef)
         name = name(typedef)
         type = typedef.declaration.type
         out.puts "// EncodeTo encodes this value using the Encoder."
@@ -501,7 +501,7 @@ module Xdrgen
         out.puts "  }"
       end
 
-      def render_xdr_type_func(out, name)
+      def render_xdr_type_interface(out, name)
         out.puts "// xdrType signals that this type is an type representing"
         out.puts "// representing XDR values defined by this package."
         out.puts "func (s #{name}) xdrType() {}"

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -174,7 +174,11 @@ module Xdrgen
           render_binary_interface out, name(defn)
         when AST::Definitions::Typedef ;
           render_typedef out, defn
-          render_binary_interface out, name(defn)
+          # TODO: Support defining binary interface on typedefs with optional
+          # types. https://github.com/stellar/xdrgen/issues/61
+          if defn.sub_type != :optional
+            render_binary_interface_typedef out, defn
+          end
         when AST::Definitions::Const ;
           render_const out, defn
         end

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -321,27 +321,17 @@ module Xdrgen
         out.puts "  var err error"
         struct.members.each do |m|
           mn = name(m)
-          mt = reference(m.declaration.type)
-          ptr = m.declaration.type.sub_type == :optional
-          simple = m.declaration.type.sub_type == :simple
-          if (simple || ptr) && mt != "SponsorshipDescriptor" && mt != "string" && mt != "int32" && mt != "[32]byte"
-            if ptr
-              out.puts "  _, err = e.EncodeBool(s.#{mn} != nil)"
-              out.puts "  if err != nil {"
-              out.puts "    return err"
-              out.puts "  }"
-              out.puts "  if s.#{mn} != nil {"
-              out.puts "    err = (*s.#{mn}).EncodeInto(e)"
-              out.puts "  }"
-            else
-              out.puts "  err = s.#{mn}.EncodeInto(e)"
-            end
+          if m.type.sub_type == :optional
+            out.puts "  _, err = e.EncodeBool(s.#{mn} != nil)"
+            out.puts "  if err != nil {"
+            out.puts "    return err"
+            out.puts "  }"
+            out.puts "  if s.#{mn} != nil {"
+            render_encode(out, "(*s.#{mn})", m.declaration.type, self_encode: false)
+            out.puts "  }"
           else
-            out.puts "  _, err = e.Encode(s.#{mn})"
+            render_encode(out, "s.#{mn}", m.declaration.type, self_encode: false)
           end
-          out.puts "  if err != nil {"
-          out.puts "    return err"
-          out.puts "  }"
         end
         out.puts "  return nil"
         out.puts "}"

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -177,7 +177,7 @@ module Xdrgen
           # TODO: Support defining binary interface on typedefs with optional
           # types. https://github.com/stellar/xdrgen/issues/61
           if defn.sub_type != :optional
-            render_binary_interface_typedef out, defn
+            render_binary_interface out, defn
           end
         when AST::Definitions::Const ;
           render_const out, defn

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -332,20 +332,29 @@ module Xdrgen
         struct.members.each do |m|
           out.puts "  {"
           mn = name(m)
-          binding.pry if mn == "Sequence"
           mt = reference(m.declaration.type)
-          if m.sub_type == :simple && name(m.type) == "Int64"
-            out.puts "    d := xdr.NewDecoder(r)"
-            out.puts "    v, _, err := d.DecodeInt()"
-            out.puts "    if err != nil {"
-            out.puts "      return err"
-            out.puts "    }"
-            out.puts "    s.#{mn} = #{mt}(v)"
-          else
-            out.puts "    _, err := Unmarshal(r, &s.#{mn})"
-            out.puts "    if err != nil {"
-            out.puts "      return err"
-            out.puts "    }"
+          if m.sub_type == :simple
+            case name(m.type)
+            when "Int64"
+              out.puts "    d := xdr.NewDecoder(r)"
+              out.puts "    v, _, err := d.DecodeInt()"
+              out.puts "    if err != nil {"
+              out.puts "      return err"
+              out.puts "    }"
+              out.puts "    s.#{mn} = #{mt}(v)"
+            when "Uint64"
+              out.puts "    d := xdr.NewDecoder(r)"
+              out.puts "    v, _, err := d.DecodeUint()"
+              out.puts "    if err != nil {"
+              out.puts "      return err"
+              out.puts "    }"
+              out.puts "    s.#{mn} = #{mt}(v)"
+            else
+              out.puts "    _, err := Unmarshal(r, &s.#{mn})"
+              out.puts "    if err != nil {"
+              out.puts "      return err"
+              out.puts "    }"
+            end
           end
           out.puts "  }"
         end

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -1,5 +1,3 @@
-require 'pry'
-
 module Xdrgen
   module Generators
 

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -543,8 +543,8 @@ module Xdrgen
 
       private
 
-      def base_reference(type)
-        case type
+      def reference(type)
+        baseReference = case type
         when AST::Typespecs::Bool
           "bool"
         when AST::Typespecs::Double
@@ -578,10 +578,7 @@ module Xdrgen
         else
           raise "Unknown reference type: #{type.class.name}, #{type.class.ancestors}"
         end
-      end
 
-      def reference(type)
-        baseReference = base_reference(type)
         case type.sub_type
         when :simple
           baseReference

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -349,10 +349,10 @@ module Xdrgen
             out.puts "    return err"
             out.puts "  }"
             out.puts "  if s.#{mn} != nil {"
-            render_encode(out, "(*s.#{mn})", m.declaration.type, self_encode: false)
+            render_encode_to_body(out, "(*s.#{mn})", m.declaration.type, self_encode: false)
             out.puts "  }"
           else
-            render_encode(out, "s.#{mn}", m.declaration.type, self_encode: false)
+            render_encode_to_body(out, "s.#{mn}", m.declaration.type, self_encode: false)
           end
         end
         out.puts "  return nil"
@@ -380,10 +380,10 @@ module Xdrgen
               out2.puts "    return err"
               out2.puts "  }"
               out2.puts "  if s.#{mn} != nil {"
-              render_encode(out2, "(*s.#{mn})", arm.type, self_encode: false)
+              render_encode_to_body(out2, "(*s.#{mn})", arm.type, self_encode: false)
               out2.puts "  }"
             else
-              render_encode(out2, "(*s.#{mn})", arm.type, self_encode: false)
+              render_encode_to_body(out2, "(*s.#{mn})", arm.type, self_encode: false)
             end
             out2.string
           end
@@ -399,7 +399,7 @@ module Xdrgen
         out.puts "// EncodeTo encodes this value using the Encoder."
         out.puts "func (s #{name}) EncodeTo(e *xdr.Encoder) error {"
         out.puts "  var err error"
-        render_encode(out, "s", type, self_encode: true)
+        render_encode_to_body(out, "s", type, self_encode: true)
         out.puts "  return nil"
         out.puts "}"
         out.break
@@ -411,7 +411,7 @@ module Xdrgen
         out.puts "// EncodeTo encodes this value using the Encoder."
         out.puts "func (s #{name}) EncodeTo(e *xdr.Encoder) error {"
         out.puts "  var err error"
-        render_encode(out, "s", type, self_encode: true)
+        render_encode_to_body(out, "s", type, self_encode: true)
         out.puts "  return nil"
         out.puts "}"
         out.break
@@ -439,10 +439,10 @@ module Xdrgen
         out.break
       end
 
-      # render_encode assumes there is an `e` variable containing an
+      # render_encode_to_body assumes there is an `e` variable containing an
       # xdr.Encoder, and a variable defined by `name` that is the value to
       # encode.
-      def render_encode(out, var, type, self_encode:)
+      def render_encode_to_body(out, var, type, self_encode:)
         case type
         when AST::Typespecs::UnsignedHyper
           out.puts "  _, err = e.EncodeUhyper(uint64(#{var}))"

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -541,6 +541,11 @@ module Xdrgen
             "github.com/stellar/go-xdr/xdr3"
           )
 
+          type xdrEncodeable interface {
+            EncodeInto(*xdr.Encoder) error
+            encoding.BinaryMarshaler
+          }
+
           // Unmarshal reads an xdr element from `r` into `v`.
           func Unmarshal(r io.Reader, v interface{}) (int, error) {
             // delegate to xdr package's Unmarshal
@@ -549,7 +554,7 @@ module Xdrgen
 
           // Marshal writes an xdr element `v` into `w`.
           func Marshal(w io.Writer, v interface{}) (int, error) {
-            if bm, ok := v.(encoding.BinaryMarshaler); ok {
+            if bm, ok := v.(xdrEncodeable); ok {
               b, err := bm.MarshalBinary()
               if err != nil {
                 return 0, err

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -395,7 +395,7 @@ module Xdrgen
 
       def render_enum_encode_to_interface(out, typedef)
         name = name(typedef)
-        type = AST::Typespecs::Int
+        type = typedef
         out.puts "// EncodeTo encodes this value using the Encoder."
         out.puts "func (s #{name}) EncodeTo(e *xdr.Encoder) error {"
         out.puts "  var err error"
@@ -450,7 +450,7 @@ module Xdrgen
           out.puts "  _, err = e.EncodeHyper(int64(#{var}))"
         when AST::Typespecs::UnsignedInt
           out.puts "  _, err = e.EncodeUint(uint32(#{var}))"
-        when AST::Typespecs::Int
+        when AST::Typespecs::Int, AST::Definitions::Enum
           out.puts "  _, err = e.EncodeInt(int32(#{var}))"
         when AST::Typespecs::String
           out.puts "  _, err = e.EncodeString(string(#{var}))"

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -380,14 +380,12 @@ module Xdrgen
             "// Void"
           else
             mn = name(arm)
-            ptr = arm.type.sub_type == :optional
-            if ptr
+            if arm.type.sub_type == :optional
               out2.puts "  _, err = e.EncodeBool(s.#{mn} != nil)"
               out2.puts "  if err != nil {"
               out2.puts "    return err"
               out2.puts "  }"
               out2.puts "  if s.#{mn} != nil {"
-              # out2.puts "    err = (*s.#{mn}).EncodeInto(e)"
               render_encode(out2, "(*s.#{mn})", arm.type, self_encode: false)
               out2.puts "  }"
             else

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -16,8 +16,11 @@ module Xdrgen
       private
 
       def render_typedef(out, typedef)
-        out.puts "type #{name typedef} #{reference typedef.declaration.type}"
-
+        if typedef.sub_type == :optional
+          out.puts "type #{name typedef} = #{reference typedef.declaration.type}"
+        else
+          out.puts "type #{name typedef} #{reference typedef.declaration.type}"
+        end
 
         # write sizing restrictions
         case typedef.declaration

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -177,7 +177,7 @@ module Xdrgen
           # TODO: Support defining binary interface on typedefs with optional
           # types. https://github.com/stellar/xdrgen/issues/61
           if defn.sub_type != :optional
-            render_binary_interface out, defn
+            render_binary_interface out, name(defn)
           end
         when AST::Definitions::Const ;
           render_const out, defn

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -452,7 +452,7 @@ module Xdrgen
         when AST::Typespecs::Simple
           case type.sub_type
           when :simple, :optional
-            optional_within = type.is_a?(AST::Identifier) && type.sub_type == :simple && type.resolved_type.sub_type == :optional
+            optional_within = type.is_a?(AST::Identifier) && type.resolved_type.sub_type == :optional
             if optional_within
               out.puts "  _, err = e.EncodeBool(#{var} != nil)"
               out.puts "  if err != nil {"
@@ -468,10 +468,23 @@ module Xdrgen
             end
           when :array
             out.puts "  for i := 0; i < len(#{var}); i++ {"
-            out.puts "    err = #{var}[i].EncodeTo(e)"
-            out.puts "    if err != nil {"
-            out.puts "      return err"
-            out.puts "    }"
+            element_var = "#{var}[i]"
+            optional_within = type.is_a?(AST::Identifier) && type.resolved_type.sub_type == :optional
+            if optional_within
+              out.puts "    _, err = e.EncodeBool(#{element_var} != nil)"
+              out.puts "    if err != nil {"
+              out.puts "      return err"
+              out.puts "    }"
+              out.puts "    if #{element_var} != nil {"
+              var = "(*#{element_var})"
+            end
+            out.puts "      err = #{element_var}.EncodeTo(e)"
+            out.puts "      if err != nil {"
+            out.puts "        return err"
+            out.puts "      }"
+            if optional_within
+              out.puts "    }"
+            end
             out.puts "  }"
           when :var_array
             out.puts "  _, err = e.EncodeUint(uint32(len(#{var})))"
@@ -479,10 +492,23 @@ module Xdrgen
             out.puts "    return err"
             out.puts "  }"
             out.puts "  for i := 0; i < len(#{var}); i++ {"
-            out.puts "    err = #{var}[i].EncodeTo(e)"
-            out.puts "    if err != nil {"
-            out.puts "      return err"
-            out.puts "    }"
+            element_var = "#{var}[i]"
+            optional_within = type.is_a?(AST::Identifier) && type.resolved_type.sub_type == :optional
+            if optional_within
+              out.puts "    _, err = e.EncodeBool(#{element_var} != nil)"
+              out.puts "    if err != nil {"
+              out.puts "      return err"
+              out.puts "    }"
+              out.puts "    if #{element_var} != nil {"
+              var = "(*#{element_var})"
+            end
+            out.puts "      err = #{element_var}.EncodeTo(e)"
+            out.puts "      if err != nil {"
+            out.puts "        return err"
+            out.puts "      }"
+            if optional_within
+              out.puts "    }"
+            end
             out.puts "  }"
           else
             raise "Unknown sub_type: #{type.sub_type}"

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -486,6 +486,8 @@ module Xdrgen
             out.puts "      return err"
             out.puts "    }"
             out.puts "  }"
+          else
+            raise "Unknown sub_type: #{type.sub_type}"
           end
         when AST::Definitions::Base
           if self_encode

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -343,7 +343,7 @@ module Xdrgen
         out.puts "  var err error"
         struct.members.each do |m|
           mn = name(m)
-          if m.type.sub_type == :optional
+          if m.type.sub_type == :optional || (m.type.is_a?(AST::Identifier) && m.type.sub_type == :simple && m.type.resolved_type.sub_type == :optional)
             out.puts "  _, err = e.EncodeBool(s.#{mn} != nil)"
             out.puts "  if err != nil {"
             out.puts "    return err"
@@ -463,6 +463,7 @@ module Xdrgen
         when AST::Typespecs::Simple
           case type.sub_type
           when :simple, :optional
+            # TODO: if m.type.sub_type == :optional || (m.type.is_a?(AST::Identifier) && m.type.sub_type == :simple && m.type.resolved_type.sub_type == :optional)
             if self_encode
               out.puts "  err = #{name type}(#{var}).EncodeTo(e)"
             else
@@ -470,6 +471,7 @@ module Xdrgen
             end
           when :array
             out.puts "  for i := 0; i < len(#{var}); i++ {"
+            # TODO: if m.type.sub_type == :optional || (m.type.is_a?(AST::Identifier) && m.type.sub_type == :simple && m.type.resolved_type.sub_type == :optional)
             out.puts "    err = #{var}[i].EncodeTo(e)"
             out.puts "    if err != nil {"
             out.puts "      return err"
@@ -481,6 +483,7 @@ module Xdrgen
             out.puts "    return err"
             out.puts "  }"
             out.puts "  for i := 0; i < len(#{var}); i++ {"
+            # TODO: if m.type.sub_type == :optional || (m.type.is_a?(AST::Identifier) && m.type.sub_type == :simple && m.type.resolved_type.sub_type == :optional)
             out.puts "    err = #{var}[i].EncodeTo(e)"
             out.puts "    if err != nil {"
             out.puts "      return err"


### PR DESCRIPTION
### What
Change how the generated Go code marshals objects to binary to move logic from runtime to compile time. Specifically:
- Add an `EncodeTo` function to all types that takes an `xdr.Encoder` and uses the encoder to encode itself.
- Have the `EncodeTo` functions call the appropriate lower level encode function for their type, such as `EncodeUint`, instead of `Encode` that will use reflection to figure out the type.
- Have the `EncodeTo` functions of complex types (structs, unions) call the `EncodeTo` function of each of their fields.

For any types not generated, such as `time.Time`, encoding falls back to the current reflection based approach.

This change affects marshaling/encoding only, and not unmarshaling/decoding. 

### Example

For an example of how this changes generated Go code, see stellar/go#3957.

### Why

I noticed while working on stellar/experimental-payment-channels#40 that the application was spending as much time building transactions as it was ed25519 verifying which is a bit of a red flag given that XDR's simple and non-self-descriptive format should be performant.

On inspection the code generated relies on reflection for encoding all types. Reflection is known to not be very performant and results in allocations that would be otherwise unnecessary.

A simple benchmark of calling `MarshalBinary` on `xdr.TransactionEnvelope` from `github.com/stellar/go/xdr` demonstrates this well. The same benchmark running against code generated by this pull request significantly reduces encoding time and allocations.

Before:
```
goos: darwin
goarch: amd64
pkg: github.com/stellar/go
cpu: Intel(R) Core(TM) i7-8569U CPU @ 2.80GHz
BenchmarkXDRUnmarshal-8           107223             10231 ns/op            3536 B/op        149 allocs/op
BenchmarkGXDRUnmarshal-8           71019             16009 ns/op           54185 B/op        172 allocs/op
BenchmarkXDRMarshal-8             162579              6754 ns/op            3280 B/op        118 allocs/op
BenchmarkGXDRMarshal-8            252350              4398 ns/op            1312 B/op         95 allocs/op
PASS
ok      github.com/stellar/go   5.010s
```

After:
```
goos: darwin
goarch: amd64
pkg: github.com/stellar/go
cpu: Intel(R) Core(TM) i7-8569U CPU @ 2.80GHz
BenchmarkXDRUnmarshal-8           104326             10106 ns/op            3536 B/op        149 allocs/op
BenchmarkGXDRUnmarshal-8           67959             16021 ns/op           54185 B/op        172 allocs/op
BenchmarkXDRMarshal-8            1287020               932.7 ns/op          1360 B/op         34 allocs/op
BenchmarkGXDRMarshal-8            288548              4161 ns/op            1312 B/op         95 allocs/op
PASS
ok      github.com/stellar/go   7.053s
```

<details><summary>Benchmark code and some additional tests run inside stellar/go</summary>

```go
package benchmarks

import (
	"bytes"
	"encoding/base64"
	"testing"

	"github.com/stellar/go/gxdr"
	"github.com/stellar/go/strkey"
	"github.com/stellar/go/xdr"
	"github.com/stretchr/testify/require"
	goxdr "github.com/xdrpp/goxdr/xdr"
)

const input64 = "AAAAAgAAAADy2f6v1nv9lXdvl5iZvWKywlPQYsZ1JGmmAfewflnbUAAABLACG4bdAADOYQAAAAEAAAAAAAAAAAAAAABhSLZ9AAAAAAAAAAEAAAABAAAAAF8wDgs7+R5R2uftMvvhHliZOyhZOQWsWr18/Fu6S+g0AAAAAwAAAAJHRE9HRQAAAAAAAAAAAAAAUwsPRQlK+jECWsJLURlsP0qsbA/aIaB/z50U79VSRYsAAAAAAAAAAAAAAYMAAA5xAvrwgAAAAAAAAAAAAAAAAAAAAAJ+WdtQAAAAQCTonAxUHyuVsmaSeGYuVsGRXgxs+wXvKgSa+dapZWN4U9sxGPuApjiv/UWb47SwuFQ+q40bfkPYT1Tff4RfLQe6S+g0AAAAQBlFjwF/wpGr+DWbjCyuolgM1VP/e4ubfUlVnDAdFjJUIIzVakZcr5omRSnr7ClrwEoPj49h+vcLusagC4xFJgg="

var input = func() []byte {
	input, err := base64.StdEncoding.DecodeString(input64)
	if err != nil {
		panic(err)
	}
	return input
}()

func BenchmarkXDRUnmarshal(b *testing.B) {
	te := xdr.TransactionEnvelope{}

	// Make sure the input is valid.
	err := te.UnmarshalBinary(input)
	require.NoError(b, err)

	// Benchmark.
	for i := 0; i < b.N; i++ {
		_ = te.UnmarshalBinary(input)
	}
}

func BenchmarkGXDRUnmarshal(b *testing.B) {
	te := gxdr.TransactionEnvelope{}

	// Make sure the input is valid, note goxdr will panic if there's a
	// marshaling error.
	te.XdrMarshal(&goxdr.XdrIn{In: bytes.NewReader(input)}, "")

	// Benchmark.
	r := bytes.NewReader(input)
	for i := 0; i < b.N; i++ {
		r.Reset(input)
		te.XdrMarshal(&goxdr.XdrIn{In: r}, "")
	}
}

func BenchmarkXDRMarshal(b *testing.B) {
	te := xdr.TransactionEnvelope{}

	// Make sure the input is valid.
	err := te.UnmarshalBinary(input)
	require.NoError(b, err)
	output, err := te.MarshalBinary()
	require.NoError(b, err)
	require.Equal(b, input, output)

	// Benchmark.
	for i := 0; i < b.N; i++ {
		_, _ = te.MarshalBinary()
	}
}

func BenchmarkGXDRMarshal(b *testing.B) {
	te := gxdr.TransactionEnvelope{}

	// Make sure the input is valid, note goxdr will panic if there's a
	// marshaling error.
	te.XdrMarshal(&goxdr.XdrIn{In: bytes.NewReader(input)}, "")
	output := bytes.Buffer{}
	te.XdrMarshal(&goxdr.XdrOut{Out: &output}, "")

	// Benchmark.
	for i := 0; i < b.N; i++ {
		output.Reset()
		te.XdrMarshal(&goxdr.XdrOut{Out: &output}, "")
	}
}

func TestXDRMarshalLedgerEntryExtensionV1(t *testing.T) {
	te := xdr.LedgerEntryExtensionV1{}
	output, err := te.MarshalBinary()
	require.NoError(t, err)
	t.Logf(base64.StdEncoding.EncodeToString(output))

	address := "GBEUFD3PR6DY3JX3QI76GVNUZBOLDNAS6KODSXXKTLJ7TKIK5RF6HESR"
	accountID := xdr.AccountId{}
	accountID.SetAddress(address)

	te = xdr.LedgerEntryExtensionV1{SponsoringId: &accountID}
	output, err = te.MarshalBinary()
	require.NoError(t, err)
	t.Logf(base64.StdEncoding.EncodeToString(output))
}

func TestGXDRMarshalLedgerEntryExtensionV1(t *testing.T) {
	te := gxdr.LedgerEntryExtensionV1{}
	output := bytes.Buffer{}
	te.XdrMarshal(&goxdr.XdrOut{Out: &output}, "")
	t.Logf(base64.StdEncoding.EncodeToString(output.Bytes()))

	address := "GBEUFD3PR6DY3JX3QI76GVNUZBOLDNAS6KODSXXKTLJ7TKIK5RF6HESR"
	accountID := &gxdr.AccountID{Type: gxdr.PUBLIC_KEY_TYPE_ED25519}
	ed25519 := accountID.Ed25519()
	rawEd25519, err := strkey.Decode(strkey.VersionByteAccountID, address)
	require.NoError(t, err)
	copy(ed25519[:], rawEd25519)

	te = gxdr.LedgerEntryExtensionV1{SponsoringID: accountID}
	output = bytes.Buffer{}
	te.XdrMarshal(&goxdr.XdrOut{Out: &output}, "")
	t.Logf(base64.StdEncoding.EncodeToString(output.Bytes()))
}

func TestXDRMarshalAccountEntryExtensionV2(t *testing.T) {
	te := xdr.AccountEntryExtensionV2{}
	output, err := te.MarshalBinary()
	require.NoError(t, err)
	t.Logf(base64.StdEncoding.EncodeToString(output))

	address := "GBEUFD3PR6DY3JX3QI76GVNUZBOLDNAS6KODSXXKTLJ7TKIK5RF6HESR"
	accountID := xdr.AccountId{}
	accountID.SetAddress(address)

	te = xdr.AccountEntryExtensionV2{
		SignerSponsoringIDs: []xdr.SponsorshipDescriptor{
			nil,
			&accountID,
			nil,
		},
	}
	output, err = te.MarshalBinary()
	require.NoError(t, err)
	t.Logf(base64.StdEncoding.EncodeToString(output))
}

func TestGXDRMarshalAccountEntryExtensionV2(t *testing.T) {
	te := gxdr.AccountEntryExtensionV2{}
	output := bytes.Buffer{}
	te.XdrMarshal(&goxdr.XdrOut{Out: &output}, "")
	t.Logf(base64.StdEncoding.EncodeToString(output.Bytes()))

	address := "GBEUFD3PR6DY3JX3QI76GVNUZBOLDNAS6KODSXXKTLJ7TKIK5RF6HESR"
	accountID := &gxdr.AccountID{Type: gxdr.PUBLIC_KEY_TYPE_ED25519}
	ed25519 := accountID.Ed25519()
	rawEd25519, err := strkey.Decode(strkey.VersionByteAccountID, address)
	require.NoError(t, err)
	copy(ed25519[:], rawEd25519)

	te = gxdr.AccountEntryExtensionV2{
		SignerSponsoringIDs: []gxdr.SponsorshipDescriptor{
			nil,
			accountID,
			nil,
		},
	}
	output = bytes.Buffer{}
	te.XdrMarshal(&goxdr.XdrOut{Out: &output}, "")
	t.Logf(base64.StdEncoding.EncodeToString(output.Bytes()))
}
```

</details>

This change only focuses on marshaling/encoding because unmarshaling is significantly more complex and not required for the use cases I'm interested, building and hashing transactions.

Optional types such as `SponsorshipDescriptor` from the Stellar XDR complicate this encoding somewhat, although not significantly.

### Known Limitations
N/A