### PR TITLE
Ensure fixed-opaque types (arrays) implement EncodeTo() by pointer

### DIFF
--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -390,7 +390,7 @@ module Xdrgen
         type = typedef.declaration.type
         out.puts "// EncodeTo encodes this value using the Encoder."
 
-        if type.is_a?(AST::Typespecs::Opaque) and type.fixed?
+        if type.is_a?(AST::Typespecs::Opaque) && type.fixed?
           # Implement EncodeTo by pointer in fixed opaque types (arrays)
           # otherwise (if called by value), Go will make a heap allocation
           # for every by-value call since the copy required by the call
@@ -475,7 +475,7 @@ module Xdrgen
               if type.resolved_type.is_a?(AST::Definitions::Typedef)
                 declared_type = type.resolved_type.declaration.type
                 # Fixed opaque types implement EncodeTo by pointer
-                if declared_type.is_a?(AST::Typespecs::Opaque) and declared_type.fixed?
+                if declared_type.is_a?(AST::Typespecs::Opaque) && declared_type.fixed?
                   newvar = "(*#{name type})(&#{var})"
                 end
               end


### PR DESCRIPTION
This PR switches the  `EncodeTo()` implementation for fixed opaque types (Go arrays) to a pointer received.

Otherwise (if called by value), Go will make a heap allocation for every by-value call since the copy required by the call tends to escape the stack due to the large array sizes.

This finally reduces marhsalling allocations to a bare minimum and speeds up marshaling between 20 and 40%.

Using the benchmarks from stellar/go:

Before:

```
goos: darwin
goarch: amd64
pkg: github.com/stellar/go/benchmarks
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkXDRMarshalWithReflection
BenchmarkXDRMarshalWithReflection-8                   	   95192	     13507 ns/op	    5128 B/op	     156 allocs/op
BenchmarkXDRMarshal
BenchmarkXDRMarshal-8                                 	 1081450	      1048 ns/op	    1352 B/op	      14 allocs/op
BenchmarkXDRMarshalWithEncodingBuffer
BenchmarkXDRMarshalWithEncodingBuffer-8               	 1927026	       707.4 ns/op	     176 B/op	       9 allocs/op
BenchmarkGXDRMarshal
BenchmarkGXDRMarshal-8                                	  132522	      7787 ns/op	    2152 B/op	     157 allocs/op
BenchmarkXDRMarshalHex
BenchmarkXDRMarshalHex-8                              	  481605	      2461 ns/op	    3640 B/op	      19 allocs/op
BenchmarkXDRMarshalHexWithEncodingBuffer
BenchmarkXDRMarshalHexWithEncodingBuffer-8            	  848468	      1620 ns/op	    1072 B/op	      10 allocs/op
BenchmarkXDRUnsafeMarshalHexWithEncodingBuffer
BenchmarkXDRUnsafeMarshalHexWithEncodingBuffer-8      	  997700	      1067 ns/op	     176 B/op	       9 allocs/op
BenchmarkXDRMarshalBase64
BenchmarkXDRMarshalBase64-8                           	  529298	      1968 ns/op	    3000 B/op	      19 allocs/op
BenchmarkXDRMarshalBase64WithEncodingBuffer
BenchmarkXDRMarshalBase64WithEncodingBuffer-8         	  998764	      1349 ns/op	     752 B/op	      10 allocs/op
BenchmarkXDRUnsafeMarshalBase64WithEncodingBuffer
BenchmarkXDRUnsafeMarshalBase64WithEncodingBuffer-8   	 1000000	      1013 ns/op	     176 B/op	       9 allocs/op
PASS
```

After:
```
goos: darwin
goarch: amd64
pkg: github.com/stellar/go/benchmarks
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkXDRMarshalWithReflection
BenchmarkXDRMarshalWithReflection-8                   	  100161	     12249 ns/op	    5128 B/op	     156 allocs/op
BenchmarkXDRMarshal
BenchmarkXDRMarshal-8                                 	 1259341	       954.3 ns/op	    1208 B/op	       6 allocs/op
BenchmarkXDRMarshalWithEncodingBuffer
BenchmarkXDRMarshalWithEncodingBuffer-8               	 2368460	       488.1 ns/op	      32 B/op	       1 allocs/op
BenchmarkGXDRMarshal
BenchmarkGXDRMarshal-8                                	  151405	      7731 ns/op	    2152 B/op	     157 allocs/op
BenchmarkXDRMarshalHex
BenchmarkXDRMarshalHex-8                              	  538134	      1944 ns/op	    3496 B/op	      11 allocs/op
BenchmarkXDRMarshalHexWithEncodingBuffer
BenchmarkXDRMarshalHexWithEncodingBuffer-8            	  965180	      1130 ns/op	     928 B/op	       2 allocs/op
BenchmarkXDRUnsafeMarshalHexWithEncodingBuffer
BenchmarkXDRUnsafeMarshalHexWithEncodingBuffer-8      	 1364654	       879.6 ns/op	      32 B/op	       1 allocs/op
BenchmarkXDRMarshalBase64
BenchmarkXDRMarshalBase64-8                           	  597410	      1833 ns/op	    2856 B/op	      11 allocs/op
BenchmarkXDRMarshalBase64WithEncodingBuffer
BenchmarkXDRMarshalBase64WithEncodingBuffer-8         	 1000000	      1035 ns/op	     608 B/op	       2 allocs/op
BenchmarkXDRUnsafeMarshalBase64WithEncodingBuffer
BenchmarkXDRUnsafeMarshalBase64WithEncodingBuffer-8   	 1393238	       846.7 ns/op	      32 B/op	       1 allocs/op
PASS
```