### PR TITLE
Generate `DecodeFrom()` methods for Golang

### DIFF
--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -566,7 +566,9 @@ module Xdrgen
           out2.puts "  return n, nil"
           out2.string
         end
-        out.puts "  return n, fmt.Errorf(\"#{name(union.discriminant)} (#{reference union.discriminant.type}) switch value '%d' is not valid for union #{name}\", u.#{name(union.discriminant)})"
+        unless union.default_arm.present?
+          out.puts "  return n, fmt.Errorf(\"#{name(union.discriminant)} (#{reference union.discriminant.type}) switch value '%d' is not valid for union #{name}\", u.#{name(union.discriminant)})"
+        end
         out.puts "}"
         out.break
       end

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -625,10 +625,10 @@ module Xdrgen
       # encode.
       def render_decode_from_body(out, var, type, declared_variables:, self_encode:)
         tail = <<-EOS.strip_heredoc
+          n += nTmp
           if err != nil {
             return n, err
           }
-          n += nTmp
         EOS
         optional = type.sub_type == :optional
         if optional

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -709,7 +709,7 @@ module Xdrgen
             out.puts tail
             if !type.decl.resolved_size.nil?
                out.puts "  if l > #{type.decl.resolved_size} {"
-               out.puts "    return n, fmt.Errorf(\"data size (%d) exceeds max slice limit (#{type.decl.resolved_size})\", l)"
+               out.puts "    return n, fmt.Errorf(\"data size (%d) exceeds size limit (#{type.decl.resolved_size}) of #{name type}\", l)"
                out.puts "  }"
             end
             out.puts "  #{var} = nil"

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -563,7 +563,7 @@ module Xdrgen
             out2.string
           end
         end
-        out.puts "  return err"
+        out.puts "  return nil"
         out.puts "}"
         out.break
       end

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -554,16 +554,17 @@ module Xdrgen
         switch_for(out, union, "u.#{name(union.discriminant)}") do |arm, kase|
           out2 = StringIO.new
           if arm.void?
-            "// Void"
+            out2.puts "// Void"
           else
             mn = name(arm)
             type = arm.type
-            out2.puts "u.#{mn} = new(#{reference arm.type})"
+            out2.puts "  u.#{mn} = new(#{reference arm.type})"
             render_decode_from_body(out2, "(*u.#{mn})",type, declared_variables: [], self_encode: false)
-            out2.string
           end
+          out2.puts "  return nil"
+          out2.string
         end
-        out.puts "  return nil"
+        out.puts "  return fmt.Errorf(\"#{name(union.discriminant)} (#{reference union.discriminant.type}) switch value '%d' is not valid for union #{name}\", u.#{name(union.discriminant)})"
         out.puts "}"
         out.break
       end


### PR DESCRIPTION
This is the decoding counterpart of https://github.com/stellar/xdrgen/pull/65

There is a dramatic performance improvement: ~13x speedup and and ~11x  allocation reduction.

Check https://github.com/stellar/go/pull/4064 for details on the speedup and the generated code.

TODO:
- [ ] Make `EncodeTo()`-related code consistent with the changes in this PR. I intentionally didn't touch `EncodeTo`-code here in order to avoid noise (otherwise it will be more difficult to read the generated code at https://github.com/stellar/go/pull/4064 ). I will update them in a separate PR.