### PR TITLE
Fix typo in go generation

### DIFF
--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -752,7 +752,7 @@ module Xdrgen
           end
           out.puts tail
         else
-          out.puts "  nTmp, err = e.Decode(#{var})"
+          out.puts "  nTmp, err = d.Decode(#{var})"
           out.puts tail
         end
         if optional


### PR DESCRIPTION
Decoder is `d`, not `e`. Probably copy/paste error from the Encoder func.