### PR TITLE
Add lint:file-ignore comments to go generator frontmatter

### DIFF
--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -799,6 +799,9 @@ module Xdrgen
 
       def render_top_matter(out)
         out.puts <<-EOS.strip_heredoc
+          //lint:file-ignore S1005 The issue should be fixed in xdrgen. Unfortunately, there's no way to ignore a single file in staticcheck.
+          //lint:file-ignore U1000 fmtTest is not needed anywhere, should be removed in xdrgen.
+
           // Package #{@namespace || "main"} is generated from:
           //
           //  #{@output.source_paths.join("\n//  ")}


### PR DESCRIPTION
As per https://github.com/stellar/go/pull/4366, simplifies usage from go.