### PR TITLE
Fix relative source paths

### DIFF
--- a/lib/xdrgen/output.rb
+++ b/lib/xdrgen/output.rb
@@ -13,7 +13,7 @@ module Xdrgen
     end
 
     def relative_source_paths
-      @source_paths.map { |p| Pathname.new(p).relative_path_from(Dir.pwd) }
+      @source_paths.map { |p| Pathname.new(p).expand_path.relative_path_from(Dir.pwd) }
     end
 
     def open(child_path)


### PR DESCRIPTION
### What
Expand source paths into absolute paths before finding their relative source path.

### Why
Source paths may be absolute or relative, and before we find their relative path we need to have their absolute path. This code that assumes the paths were always absolute.