### PR TITLE
Add input file SHA256 hash consts to Go/Rust generated code

### DIFF
--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -821,8 +821,8 @@ module Xdrgen
         out.break
         out.puts <<-EOS.strip_heredoc
         // XdrFilesSHA256 is the SHA256 hashes of source files.
-        var XdrFilesSHA256 = [...]string{
-          #{@output.relative_source_path_sha256_hashes.map(){ |path, hash| "/* #{path} */ \"#{hash}\"" }.join(",\n")}
+        var XdrFilesSHA256 = map[string]string{
+          #{@output.relative_source_path_sha256_hashes.map(){ |path, hash| %{"#{path}": "#{hash}"} }.join(",\n")}
         }
         EOS
         out.break

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -820,8 +820,8 @@ module Xdrgen
         EOS
         out.break
         out.puts <<-EOS.strip_heredoc
-        // FilesSHA256 is the SHA256 hashes of source files.
-        var FilesSHA256 = [...]string{
+        // XdrFilesSHA256 is the SHA256 hashes of source files.
+        var XdrFilesSHA256 = [...]string{
           #{@output.relative_source_path_sha256_hashes.map(){ |path, hash| "/* #{path} */ \"#{hash}\"" }.join(",\n")}
         }
         EOS

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -817,7 +817,28 @@ module Xdrgen
 
             "github.com/stellar/go-xdr/xdr3"
           )
-
+        EOS
+        out.break
+        const_name = lambda { |path| "File#{path.gsub(%r{[^\w]}, "_").camelize}SHA256" }
+        out.puts "const ("
+        out.indent do
+          @output.relative_source_path_sha256_hashes.each do |path, hash|
+            out.puts <<-EOS.strip_heredoc
+              // #{const_name.(path)} is the SHA256 hash of source file #{path}.
+              #{const_name.(path)} = "#{hash}"
+            EOS
+          end
+        end
+        out.puts ")"
+        out.puts <<-EOS.strip_heredoc
+        // FilesSHA256 is the SHA256 hashes of source files:
+        //   #{@output.relative_source_paths.join("\n//  ")}
+        var FilesSHA256 = [...]string{
+          #{@output.relative_source_paths.map(){ |path| const_name.(path) }.join(",\n")}
+        }
+        EOS
+        out.break
+        out.puts <<-EOS.strip_heredoc
           type xdrType interface {
             xdrType()
           }

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -820,8 +820,7 @@ module Xdrgen
         EOS
         out.break
         out.puts <<-EOS.strip_heredoc
-        // FilesSHA256 is the SHA256 hashes of source files:
-        //   #{@output.relative_source_paths.join("\n//  ")}
+        // FilesSHA256 is the SHA256 hashes of source files.
         var FilesSHA256 = [...]string{
           #{@output.relative_source_path_sha256_hashes.map(){ |path, hash| "/* #{path} */ \"#{hash}\"" }.join(",\n")}
         }

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -819,22 +819,11 @@ module Xdrgen
           )
         EOS
         out.break
-        const_name = lambda { |path| "File#{path.gsub(%r{[^\w]}, "_").camelize}SHA256" }
-        out.puts "const ("
-        out.indent do
-          @output.relative_source_path_sha256_hashes.each do |path, hash|
-            out.puts <<-EOS.strip_heredoc
-              // #{const_name.(path)} is the SHA256 hash of source file #{path}.
-              #{const_name.(path)} = "#{hash}"
-            EOS
-          end
-        end
-        out.puts ")"
         out.puts <<-EOS.strip_heredoc
         // FilesSHA256 is the SHA256 hashes of source files:
         //   #{@output.relative_source_paths.join("\n//  ")}
         var FilesSHA256 = [...]string{
-          #{@output.relative_source_paths.map(){ |path| const_name.(path) }.join(",\n")}
+          #{@output.relative_source_path_sha256_hashes.map(){ |path, hash| "/* #{path} */ \"#{hash}\"" }.join(",\n")}
         }
         EOS
         out.break

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -63,9 +63,9 @@ module Xdrgen
         out.puts "#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]"
         out.break
         out.puts <<-EOS.strip_heredoc
-          /// `XDR_FILES_SHA256` is the SHA256 hashes of the source files.
-          pub const XDR_FILES_SHA256: &[&str] = &[
-            #{@output.relative_source_path_sha256_hashes.map(){ |path, hash| "/* #{path} */ \"#{hash}\"" }.join(",\n")}
+          /// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
+          pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
+            #{@output.relative_source_path_sha256_hashes.map(){ |path, hash| %{("#{path}", "#{hash}")} }.join(",\n")}
           ];
         EOS
         out.break

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -57,7 +57,7 @@ module Xdrgen
       def render_top_matter(out)
         out.puts <<-EOS.strip_heredoc
           // Module #{@namepsace} is generated from:
-          //   #{@output.relative_source_paths.join("\n//  ")}
+          //  #{@output.relative_source_paths.join("\n//  ")}
         EOS
         out.break
         out.puts "#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]"
@@ -71,8 +71,8 @@ module Xdrgen
         end
         out.puts <<-EOS.strip_heredoc
           /// FILES_SHA256 is the SHA256 hashes of the source files:
-          ///   #{@output.relative_source_paths.join("\n//  ")}
-          pub const FILES_SHA256: &[&str] = [
+          ///   #{@output.relative_source_paths.join("\n///   ")}
+          pub const FILES_SHA256: &[&str] = &[
             #{@output.relative_source_paths.map(){ |path| const_name.(path) }.join(",\n")}
           ];
         EOS

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -62,18 +62,11 @@ module Xdrgen
         out.break
         out.puts "#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]"
         out.break
-        const_name = lambda { |path| "FILE_#{path.gsub(%r{[^\w]}, "_").upcase}_SHA256" }
-        @output.relative_source_path_sha256_hashes.each do |path, hash|
-          out.puts <<-EOS.strip_heredoc
-            /// `#{const_name.(path)}` is the SHA256 hash of source file #{path}.
-            pub const #{const_name.(path)}: &str = "#{hash}";
-          EOS
-        end
         out.puts <<-EOS.strip_heredoc
           /// `FILES_SHA256` is the SHA256 hashes of the source files:
           ///   #{@output.relative_source_paths.join("\n///   ")}
           pub const FILES_SHA256: &[&str] = &[
-            #{@output.relative_source_path_sha256_hashes.map(){ |path, hash| "/* #{path} */ #{hash} }.join(",\n")}
+            #{@output.relative_source_path_sha256_hashes.map(){ |path, hash| "/* #{path} */ \"#{hash}\"" }.join(",\n")}
           ];
         EOS
         out.break

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -57,7 +57,22 @@ module Xdrgen
       def render_top_matter(out)
         out.puts <<-EOS.strip_heredoc
           // Module #{@namepsace} is generated from:
-          //  #{@output.relative_source_paths.join("\n//  ")}
+          //   #{@output.relative_source_paths.join("\n//  ")}
+        EOS
+        out.break
+        const_name = lambda { |path| "FILE_#{path.gsub(%r{[^\w]}, "_").upcase}_SHA256" }
+        @output.relative_source_path_sha256_hashes.each do |path, hash|
+          out.puts <<-EOS.strip_heredoc
+            /// #{const_name.(path)} is the SHA256 hash of source file #{path}.
+            pub const #{const_name.(path)}: &str = "#{hash}";
+          EOS
+        end
+        out.puts <<-EOS.strip_heredoc
+          /// FILES_SHA256 is the SHA256 hashes of the source files:
+          ///   #{@output.relative_source_paths.join("\n//  ")}
+          pub const FILES_SHA256: &[&str] = [
+            #{@output.relative_source_paths.map(){ |path| const_name.(path) }.join(",\n")}
+          ];
         EOS
         out.break
       end

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -65,12 +65,12 @@ module Xdrgen
         const_name = lambda { |path| "FILE_#{path.gsub(%r{[^\w]}, "_").upcase}_SHA256" }
         @output.relative_source_path_sha256_hashes.each do |path, hash|
           out.puts <<-EOS.strip_heredoc
-            /// #{const_name.(path)} is the SHA256 hash of source file #{path}.
+            /// `#{const_name.(path)}` is the SHA256 hash of source file #{path}.
             pub const #{const_name.(path)}: &str = "#{hash}";
           EOS
         end
         out.puts <<-EOS.strip_heredoc
-          /// FILES_SHA256 is the SHA256 hashes of the source files:
+          /// `FILES_SHA256` is the SHA256 hashes of the source files:
           ///   #{@output.relative_source_paths.join("\n///   ")}
           pub const FILES_SHA256: &[&str] = &[
             #{@output.relative_source_paths.map(){ |path| const_name.(path) }.join(",\n")}

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -62,10 +62,11 @@ module Xdrgen
         out.break
         out.puts "#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]"
         out.break
+        source_paths_sha256_hashes = @output.relative_source_path_sha256_hashes
         out.puts <<-EOS.strip_heredoc
           /// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
-          pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
-            #{@output.relative_source_path_sha256_hashes.map(){ |path, hash| %{("#{path}", "#{hash}")} }.join(",\n")}
+          pub const XDR_FILES_SHA256: [(&str, &str); #{source_paths_sha256_hashes.count}] = [
+            #{source_paths_sha256_hashes.map(){ |path, hash| %{("#{path}", "#{hash}")} }.join(",\n")}
           ];
         EOS
         out.break

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -63,8 +63,7 @@ module Xdrgen
         out.puts "#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]"
         out.break
         out.puts <<-EOS.strip_heredoc
-          /// `FILES_SHA256` is the SHA256 hashes of the source files:
-          ///   #{@output.relative_source_paths.join("\n///   ")}
+          /// `FILES_SHA256` is the SHA256 hashes of the source files.
           pub const FILES_SHA256: &[&str] = &[
             #{@output.relative_source_path_sha256_hashes.map(){ |path, hash| "/* #{path} */ \"#{hash}\"" }.join(",\n")}
           ];

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -73,7 +73,7 @@ module Xdrgen
           /// `FILES_SHA256` is the SHA256 hashes of the source files:
           ///   #{@output.relative_source_paths.join("\n///   ")}
           pub const FILES_SHA256: &[&str] = &[
-            #{@output.relative_source_paths.map(){ |path| const_name.(path) }.join(",\n")}
+            #{@output.relative_source_path_sha256_hashes.map(){ |path, hash| "/* #{path} */ #{hash} }.join(",\n")}
           ];
         EOS
         out.break

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -63,8 +63,8 @@ module Xdrgen
         out.puts "#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]"
         out.break
         out.puts <<-EOS.strip_heredoc
-          /// `FILES_SHA256` is the SHA256 hashes of the source files.
-          pub const FILES_SHA256: &[&str] = &[
+          /// `XDR_FILES_SHA256` is the SHA256 hashes of the source files.
+          pub const XDR_FILES_SHA256: &[&str] = &[
             #{@output.relative_source_path_sha256_hashes.map(){ |path, hash| "/* #{path} */ \"#{hash}\"" }.join(",\n")}
           ];
         EOS

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -60,6 +60,8 @@ module Xdrgen
           //   #{@output.relative_source_paths.join("\n//  ")}
         EOS
         out.break
+        out.puts "#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]"
+        out.break
         const_name = lambda { |path| "FILE_#{path.gsub(%r{[^\w]}, "_").upcase}_SHA256" }
         @output.relative_source_path_sha256_hashes.each do |path, hash|
           out.puts <<-EOS.strip_heredoc

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
-
 use core::{fmt, fmt::Debug, slice::Iter};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
-
 use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/lib/xdrgen/output.rb
+++ b/lib/xdrgen/output.rb
@@ -14,7 +14,7 @@ module Xdrgen
     end
 
     def relative_source_paths
-      @source_paths.map { |p| Pathname.new(p).expand_path.relative_path_from(Dir.pwd).to_s }
+      @source_paths.map { |p| Pathname.new(p).expand_path.relative_path_from(Dir.pwd).to_s }.sort
     end
 
     def relative_source_path_sha256_hashes

--- a/lib/xdrgen/output.rb
+++ b/lib/xdrgen/output.rb
@@ -1,4 +1,5 @@
 require 'fileutils'
+require 'digest'
 
 module Xdrgen
   class Output
@@ -13,7 +14,11 @@ module Xdrgen
     end
 
     def relative_source_paths
-      @source_paths.map { |p| Pathname.new(p).expand_path.relative_path_from(Dir.pwd) }
+      @source_paths.map { |p| Pathname.new(p).expand_path.relative_path_from(Dir.pwd).to_s }
+    end
+
+    def relative_source_path_sha256_hashes
+      relative_source_paths.map { |p| [p, Digest::SHA256.file(p).hexdigest] }.to_h
     end
 
     def open(child_path)

--- a/spec/output/generator_spec_go/block_comments.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/block_comments.x/MyXDR_generated.go
@@ -17,6 +17,16 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
+const (
+  // FileSpecFixturesGeneratorBlockCommentsXSHA256 is the SHA256 hash of source file spec/fixtures/generator/block_comments.x.
+  FileSpecFixturesGeneratorBlockCommentsXSHA256 = "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30"
+)
+// FilesSHA256 is the SHA256 hashes of source files:
+//   spec/fixtures/generator/block_comments.x
+var FilesSHA256 = [...]string{
+  FileSpecFixturesGeneratorBlockCommentsXSHA256
+}
+
 type xdrType interface {
   xdrType()
 }

--- a/spec/output/generator_spec_go/block_comments.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/block_comments.x/MyXDR_generated.go
@@ -17,8 +17,8 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-// FilesSHA256 is the SHA256 hashes of source files.
-var FilesSHA256 = [...]string{
+// XdrFilesSHA256 is the SHA256 hashes of source files.
+var XdrFilesSHA256 = [...]string{
   /* spec/fixtures/generator/block_comments.x */ "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30"
 }
 

--- a/spec/output/generator_spec_go/block_comments.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/block_comments.x/MyXDR_generated.go
@@ -17,14 +17,10 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-const (
-  // FileSpecFixturesGeneratorBlockCommentsXSHA256 is the SHA256 hash of source file spec/fixtures/generator/block_comments.x.
-  FileSpecFixturesGeneratorBlockCommentsXSHA256 = "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30"
-)
 // FilesSHA256 is the SHA256 hashes of source files:
 //   spec/fixtures/generator/block_comments.x
 var FilesSHA256 = [...]string{
-  FileSpecFixturesGeneratorBlockCommentsXSHA256
+  /* spec/fixtures/generator/block_comments.x */ "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30"
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/block_comments.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/block_comments.x/MyXDR_generated.go
@@ -17,8 +17,7 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-// FilesSHA256 is the SHA256 hashes of source files:
-//   spec/fixtures/generator/block_comments.x
+// FilesSHA256 is the SHA256 hashes of source files.
 var FilesSHA256 = [...]string{
   /* spec/fixtures/generator/block_comments.x */ "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30"
 }

--- a/spec/output/generator_spec_go/block_comments.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/block_comments.x/MyXDR_generated.go
@@ -18,8 +18,8 @@ import (
 )
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
-var XdrFilesSHA256 = [...]string{
-  /* spec/fixtures/generator/block_comments.x */ "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30"
+var XdrFilesSHA256 = map[string]string{
+  "spec/fixtures/generator/block_comments.x": "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30"
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/const.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/const.x/MyXDR_generated.go
@@ -17,8 +17,7 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-// FilesSHA256 is the SHA256 hashes of source files:
-//   spec/fixtures/generator/const.x
+// FilesSHA256 is the SHA256 hashes of source files.
 var FilesSHA256 = [...]string{
   /* spec/fixtures/generator/const.x */ "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37"
 }

--- a/spec/output/generator_spec_go/const.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/const.x/MyXDR_generated.go
@@ -17,6 +17,16 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
+const (
+  // FileSpecFixturesGeneratorConstXSHA256 is the SHA256 hash of source file spec/fixtures/generator/const.x.
+  FileSpecFixturesGeneratorConstXSHA256 = "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37"
+)
+// FilesSHA256 is the SHA256 hashes of source files:
+//   spec/fixtures/generator/const.x
+var FilesSHA256 = [...]string{
+  FileSpecFixturesGeneratorConstXSHA256
+}
+
 type xdrType interface {
   xdrType()
 }

--- a/spec/output/generator_spec_go/const.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/const.x/MyXDR_generated.go
@@ -17,14 +17,10 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-const (
-  // FileSpecFixturesGeneratorConstXSHA256 is the SHA256 hash of source file spec/fixtures/generator/const.x.
-  FileSpecFixturesGeneratorConstXSHA256 = "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37"
-)
 // FilesSHA256 is the SHA256 hashes of source files:
 //   spec/fixtures/generator/const.x
 var FilesSHA256 = [...]string{
-  FileSpecFixturesGeneratorConstXSHA256
+  /* spec/fixtures/generator/const.x */ "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37"
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/const.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/const.x/MyXDR_generated.go
@@ -18,8 +18,8 @@ import (
 )
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
-var XdrFilesSHA256 = [...]string{
-  /* spec/fixtures/generator/const.x */ "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37"
+var XdrFilesSHA256 = map[string]string{
+  "spec/fixtures/generator/const.x": "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37"
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/const.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/const.x/MyXDR_generated.go
@@ -17,8 +17,8 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-// FilesSHA256 is the SHA256 hashes of source files.
-var FilesSHA256 = [...]string{
+// XdrFilesSHA256 is the SHA256 hashes of source files.
+var XdrFilesSHA256 = [...]string{
   /* spec/fixtures/generator/const.x */ "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37"
 }
 

--- a/spec/output/generator_spec_go/enum.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/enum.x/MyXDR_generated.go
@@ -17,8 +17,7 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-// FilesSHA256 is the SHA256 hashes of source files:
-//   spec/fixtures/generator/enum.x
+// FilesSHA256 is the SHA256 hashes of source files.
 var FilesSHA256 = [...]string{
   /* spec/fixtures/generator/enum.x */ "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f"
 }

--- a/spec/output/generator_spec_go/enum.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/enum.x/MyXDR_generated.go
@@ -17,8 +17,8 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-// FilesSHA256 is the SHA256 hashes of source files.
-var FilesSHA256 = [...]string{
+// XdrFilesSHA256 is the SHA256 hashes of source files.
+var XdrFilesSHA256 = [...]string{
   /* spec/fixtures/generator/enum.x */ "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f"
 }
 

--- a/spec/output/generator_spec_go/enum.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/enum.x/MyXDR_generated.go
@@ -18,8 +18,8 @@ import (
 )
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
-var XdrFilesSHA256 = [...]string{
-  /* spec/fixtures/generator/enum.x */ "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f"
+var XdrFilesSHA256 = map[string]string{
+  "spec/fixtures/generator/enum.x": "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f"
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/enum.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/enum.x/MyXDR_generated.go
@@ -17,6 +17,16 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
+const (
+  // FileSpecFixturesGeneratorEnumXSHA256 is the SHA256 hash of source file spec/fixtures/generator/enum.x.
+  FileSpecFixturesGeneratorEnumXSHA256 = "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f"
+)
+// FilesSHA256 is the SHA256 hashes of source files:
+//   spec/fixtures/generator/enum.x
+var FilesSHA256 = [...]string{
+  FileSpecFixturesGeneratorEnumXSHA256
+}
+
 type xdrType interface {
   xdrType()
 }

--- a/spec/output/generator_spec_go/enum.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/enum.x/MyXDR_generated.go
@@ -17,14 +17,10 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-const (
-  // FileSpecFixturesGeneratorEnumXSHA256 is the SHA256 hash of source file spec/fixtures/generator/enum.x.
-  FileSpecFixturesGeneratorEnumXSHA256 = "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f"
-)
 // FilesSHA256 is the SHA256 hashes of source files:
 //   spec/fixtures/generator/enum.x
 var FilesSHA256 = [...]string{
-  FileSpecFixturesGeneratorEnumXSHA256
+  /* spec/fixtures/generator/enum.x */ "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f"
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/nesting.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/nesting.x/MyXDR_generated.go
@@ -18,8 +18,8 @@ import (
 )
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
-var XdrFilesSHA256 = [...]string{
-  /* spec/fixtures/generator/nesting.x */ "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a"
+var XdrFilesSHA256 = map[string]string{
+  "spec/fixtures/generator/nesting.x": "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a"
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/nesting.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/nesting.x/MyXDR_generated.go
@@ -17,8 +17,7 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-// FilesSHA256 is the SHA256 hashes of source files:
-//   spec/fixtures/generator/nesting.x
+// FilesSHA256 is the SHA256 hashes of source files.
 var FilesSHA256 = [...]string{
   /* spec/fixtures/generator/nesting.x */ "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a"
 }

--- a/spec/output/generator_spec_go/nesting.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/nesting.x/MyXDR_generated.go
@@ -17,14 +17,10 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-const (
-  // FileSpecFixturesGeneratorNestingXSHA256 is the SHA256 hash of source file spec/fixtures/generator/nesting.x.
-  FileSpecFixturesGeneratorNestingXSHA256 = "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a"
-)
 // FilesSHA256 is the SHA256 hashes of source files:
 //   spec/fixtures/generator/nesting.x
 var FilesSHA256 = [...]string{
-  FileSpecFixturesGeneratorNestingXSHA256
+  /* spec/fixtures/generator/nesting.x */ "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a"
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/nesting.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/nesting.x/MyXDR_generated.go
@@ -17,8 +17,8 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-// FilesSHA256 is the SHA256 hashes of source files.
-var FilesSHA256 = [...]string{
+// XdrFilesSHA256 is the SHA256 hashes of source files.
+var XdrFilesSHA256 = [...]string{
   /* spec/fixtures/generator/nesting.x */ "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a"
 }
 

--- a/spec/output/generator_spec_go/nesting.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/nesting.x/MyXDR_generated.go
@@ -17,6 +17,16 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
+const (
+  // FileSpecFixturesGeneratorNestingXSHA256 is the SHA256 hash of source file spec/fixtures/generator/nesting.x.
+  FileSpecFixturesGeneratorNestingXSHA256 = "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a"
+)
+// FilesSHA256 is the SHA256 hashes of source files:
+//   spec/fixtures/generator/nesting.x
+var FilesSHA256 = [...]string{
+  FileSpecFixturesGeneratorNestingXSHA256
+}
+
 type xdrType interface {
   xdrType()
 }

--- a/spec/output/generator_spec_go/optional.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/optional.x/MyXDR_generated.go
@@ -17,6 +17,16 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
+const (
+  // FileSpecFixturesGeneratorOptionalXSHA256 is the SHA256 hash of source file spec/fixtures/generator/optional.x.
+  FileSpecFixturesGeneratorOptionalXSHA256 = "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7"
+)
+// FilesSHA256 is the SHA256 hashes of source files:
+//   spec/fixtures/generator/optional.x
+var FilesSHA256 = [...]string{
+  FileSpecFixturesGeneratorOptionalXSHA256
+}
+
 type xdrType interface {
   xdrType()
 }

--- a/spec/output/generator_spec_go/optional.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/optional.x/MyXDR_generated.go
@@ -17,8 +17,7 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-// FilesSHA256 is the SHA256 hashes of source files:
-//   spec/fixtures/generator/optional.x
+// FilesSHA256 is the SHA256 hashes of source files.
 var FilesSHA256 = [...]string{
   /* spec/fixtures/generator/optional.x */ "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7"
 }

--- a/spec/output/generator_spec_go/optional.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/optional.x/MyXDR_generated.go
@@ -17,14 +17,10 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-const (
-  // FileSpecFixturesGeneratorOptionalXSHA256 is the SHA256 hash of source file spec/fixtures/generator/optional.x.
-  FileSpecFixturesGeneratorOptionalXSHA256 = "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7"
-)
 // FilesSHA256 is the SHA256 hashes of source files:
 //   spec/fixtures/generator/optional.x
 var FilesSHA256 = [...]string{
-  FileSpecFixturesGeneratorOptionalXSHA256
+  /* spec/fixtures/generator/optional.x */ "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7"
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/optional.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/optional.x/MyXDR_generated.go
@@ -18,8 +18,8 @@ import (
 )
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
-var XdrFilesSHA256 = [...]string{
-  /* spec/fixtures/generator/optional.x */ "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7"
+var XdrFilesSHA256 = map[string]string{
+  "spec/fixtures/generator/optional.x": "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7"
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/optional.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/optional.x/MyXDR_generated.go
@@ -17,8 +17,8 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-// FilesSHA256 is the SHA256 hashes of source files.
-var FilesSHA256 = [...]string{
+// XdrFilesSHA256 is the SHA256 hashes of source files.
+var XdrFilesSHA256 = [...]string{
   /* spec/fixtures/generator/optional.x */ "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7"
 }
 

--- a/spec/output/generator_spec_go/struct.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/struct.x/MyXDR_generated.go
@@ -17,8 +17,7 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-// FilesSHA256 is the SHA256 hashes of source files:
-//   spec/fixtures/generator/struct.x
+// FilesSHA256 is the SHA256 hashes of source files.
 var FilesSHA256 = [...]string{
   /* spec/fixtures/generator/struct.x */ "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a"
 }

--- a/spec/output/generator_spec_go/struct.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/struct.x/MyXDR_generated.go
@@ -18,8 +18,8 @@ import (
 )
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
-var XdrFilesSHA256 = [...]string{
-  /* spec/fixtures/generator/struct.x */ "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a"
+var XdrFilesSHA256 = map[string]string{
+  "spec/fixtures/generator/struct.x": "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a"
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/struct.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/struct.x/MyXDR_generated.go
@@ -17,14 +17,10 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-const (
-  // FileSpecFixturesGeneratorStructXSHA256 is the SHA256 hash of source file spec/fixtures/generator/struct.x.
-  FileSpecFixturesGeneratorStructXSHA256 = "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a"
-)
 // FilesSHA256 is the SHA256 hashes of source files:
 //   spec/fixtures/generator/struct.x
 var FilesSHA256 = [...]string{
-  FileSpecFixturesGeneratorStructXSHA256
+  /* spec/fixtures/generator/struct.x */ "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a"
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/struct.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/struct.x/MyXDR_generated.go
@@ -17,6 +17,16 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
+const (
+  // FileSpecFixturesGeneratorStructXSHA256 is the SHA256 hash of source file spec/fixtures/generator/struct.x.
+  FileSpecFixturesGeneratorStructXSHA256 = "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a"
+)
+// FilesSHA256 is the SHA256 hashes of source files:
+//   spec/fixtures/generator/struct.x
+var FilesSHA256 = [...]string{
+  FileSpecFixturesGeneratorStructXSHA256
+}
+
 type xdrType interface {
   xdrType()
 }

--- a/spec/output/generator_spec_go/struct.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/struct.x/MyXDR_generated.go
@@ -17,8 +17,8 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-// FilesSHA256 is the SHA256 hashes of source files.
-var FilesSHA256 = [...]string{
+// XdrFilesSHA256 is the SHA256 hashes of source files.
+var XdrFilesSHA256 = [...]string{
   /* spec/fixtures/generator/struct.x */ "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a"
 }
 

--- a/spec/output/generator_spec_go/test.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/test.x/MyXDR_generated.go
@@ -17,8 +17,8 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-// FilesSHA256 is the SHA256 hashes of source files.
-var FilesSHA256 = [...]string{
+// XdrFilesSHA256 is the SHA256 hashes of source files.
+var XdrFilesSHA256 = [...]string{
   /* spec/fixtures/generator/test.x */ "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41"
 }
 

--- a/spec/output/generator_spec_go/test.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/test.x/MyXDR_generated.go
@@ -17,14 +17,10 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-const (
-  // FileSpecFixturesGeneratorTestXSHA256 is the SHA256 hash of source file spec/fixtures/generator/test.x.
-  FileSpecFixturesGeneratorTestXSHA256 = "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41"
-)
 // FilesSHA256 is the SHA256 hashes of source files:
 //   spec/fixtures/generator/test.x
 var FilesSHA256 = [...]string{
-  FileSpecFixturesGeneratorTestXSHA256
+  /* spec/fixtures/generator/test.x */ "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41"
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/test.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/test.x/MyXDR_generated.go
@@ -17,8 +17,7 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-// FilesSHA256 is the SHA256 hashes of source files:
-//   spec/fixtures/generator/test.x
+// FilesSHA256 is the SHA256 hashes of source files.
 var FilesSHA256 = [...]string{
   /* spec/fixtures/generator/test.x */ "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41"
 }

--- a/spec/output/generator_spec_go/test.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/test.x/MyXDR_generated.go
@@ -17,6 +17,16 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
+const (
+  // FileSpecFixturesGeneratorTestXSHA256 is the SHA256 hash of source file spec/fixtures/generator/test.x.
+  FileSpecFixturesGeneratorTestXSHA256 = "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41"
+)
+// FilesSHA256 is the SHA256 hashes of source files:
+//   spec/fixtures/generator/test.x
+var FilesSHA256 = [...]string{
+  FileSpecFixturesGeneratorTestXSHA256
+}
+
 type xdrType interface {
   xdrType()
 }

--- a/spec/output/generator_spec_go/test.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/test.x/MyXDR_generated.go
@@ -18,8 +18,8 @@ import (
 )
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
-var XdrFilesSHA256 = [...]string{
-  /* spec/fixtures/generator/test.x */ "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41"
+var XdrFilesSHA256 = map[string]string{
+  "spec/fixtures/generator/test.x": "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41"
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/union.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/union.x/MyXDR_generated.go
@@ -17,8 +17,7 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-// FilesSHA256 is the SHA256 hashes of source files:
-//   spec/fixtures/generator/union.x
+// FilesSHA256 is the SHA256 hashes of source files.
 var FilesSHA256 = [...]string{
   /* spec/fixtures/generator/union.x */ "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41"
 }

--- a/spec/output/generator_spec_go/union.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/union.x/MyXDR_generated.go
@@ -17,6 +17,16 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
+const (
+  // FileSpecFixturesGeneratorUnionXSHA256 is the SHA256 hash of source file spec/fixtures/generator/union.x.
+  FileSpecFixturesGeneratorUnionXSHA256 = "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41"
+)
+// FilesSHA256 is the SHA256 hashes of source files:
+//   spec/fixtures/generator/union.x
+var FilesSHA256 = [...]string{
+  FileSpecFixturesGeneratorUnionXSHA256
+}
+
 type xdrType interface {
   xdrType()
 }

--- a/spec/output/generator_spec_go/union.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/union.x/MyXDR_generated.go
@@ -18,8 +18,8 @@ import (
 )
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
-var XdrFilesSHA256 = [...]string{
-  /* spec/fixtures/generator/union.x */ "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41"
+var XdrFilesSHA256 = map[string]string{
+  "spec/fixtures/generator/union.x": "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41"
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/union.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/union.x/MyXDR_generated.go
@@ -17,14 +17,10 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-const (
-  // FileSpecFixturesGeneratorUnionXSHA256 is the SHA256 hash of source file spec/fixtures/generator/union.x.
-  FileSpecFixturesGeneratorUnionXSHA256 = "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41"
-)
 // FilesSHA256 is the SHA256 hashes of source files:
 //   spec/fixtures/generator/union.x
 var FilesSHA256 = [...]string{
-  FileSpecFixturesGeneratorUnionXSHA256
+  /* spec/fixtures/generator/union.x */ "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41"
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/union.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/union.x/MyXDR_generated.go
@@ -17,8 +17,8 @@ import (
   "github.com/stellar/go-xdr/xdr3"
 )
 
-// FilesSHA256 is the SHA256 hashes of source files.
-var FilesSHA256 = [...]string{
+// XdrFilesSHA256 is the SHA256 hashes of source files.
+var XdrFilesSHA256 = [...]string{
   /* spec/fixtures/generator/union.x */ "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41"
 }
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -8,8 +8,6 @@ pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
   ("spec/fixtures/generator/block_comments.x", "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30")
 ];
 
-#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
-
 use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
 /// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
-pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
+pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
   ("spec/fixtures/generator/block_comments.x", "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30")
 ];
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -8,6 +8,8 @@ pub const XDR_FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/block_comments.x */ "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30"
 ];
 
+#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
+
 use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -3,9 +3,9 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `XDR_FILES_SHA256` is the SHA256 hashes of the source files.
-pub const XDR_FILES_SHA256: &[&str] = &[
-  /* spec/fixtures/generator/block_comments.x */ "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30"
+/// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
+pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
+  ("spec/fixtures/generator/block_comments.x", "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30")
 ];
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -3,8 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `FILES_SHA256` is the SHA256 hashes of the source files:
-///   spec/fixtures/generator/block_comments.x
+/// `FILES_SHA256` is the SHA256 hashes of the source files.
 pub const FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/block_comments.x */ "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30"
 ];

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -3,8 +3,8 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `FILES_SHA256` is the SHA256 hashes of the source files.
-pub const FILES_SHA256: &[&str] = &[
+/// `XDR_FILES_SHA256` is the SHA256 hashes of the source files.
+pub const XDR_FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/block_comments.x */ "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30"
 ];
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -1,15 +1,13 @@
 // Module  is generated from:
-//   spec/fixtures/generator/block_comments.x
-
-/// FILE_SPEC_FIXTURES_GENERATOR_BLOCK_COMMENTS_X_SHA256 is the SHA256 hash of source file spec/fixtures/generator/block_comments.x.
-pub const FILE_SPEC_FIXTURES_GENERATOR_BLOCK_COMMENTS_X_SHA256: &str = "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30";
-/// FILES_SHA256 is the SHA256 hashes of the source files:
-///   spec/fixtures/generator/block_comments.x
-pub const FILES_SHA256: &[&str] = [
-  FILE_SPEC_FIXTURES_GENERATOR_BLOCK_COMMENTS_X_SHA256
-];
+//  spec/fixtures/generator/block_comments.x
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
+
+/// `FILES_SHA256` is the SHA256 hashes of the source files:
+///   spec/fixtures/generator/block_comments.x
+pub const FILES_SHA256: &[&str] = &[
+  /* spec/fixtures/generator/block_comments.x */ "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30"
+];
 
 use core::{fmt, fmt::Debug, slice::Iter};
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -1,5 +1,13 @@
 // Module  is generated from:
-//  spec/fixtures/generator/block_comments.x
+//   spec/fixtures/generator/block_comments.x
+
+/// FILE_SPEC_FIXTURES_GENERATOR_BLOCK_COMMENTS_X_SHA256 is the SHA256 hash of source file spec/fixtures/generator/block_comments.x.
+pub const FILE_SPEC_FIXTURES_GENERATOR_BLOCK_COMMENTS_X_SHA256: &str = "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30";
+/// FILES_SHA256 is the SHA256 hashes of the source files:
+///   spec/fixtures/generator/block_comments.x
+pub const FILES_SHA256: &[&str] = [
+  FILE_SPEC_FIXTURES_GENERATOR_BLOCK_COMMENTS_X_SHA256
+];
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -3,9 +3,9 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `XDR_FILES_SHA256` is the SHA256 hashes of the source files.
-pub const XDR_FILES_SHA256: &[&str] = &[
-  /* spec/fixtures/generator/const.x */ "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37"
+/// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
+pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
+  ("spec/fixtures/generator/const.x", "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37")
 ];
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -3,8 +3,8 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `FILES_SHA256` is the SHA256 hashes of the source files.
-pub const FILES_SHA256: &[&str] = &[
+/// `XDR_FILES_SHA256` is the SHA256 hashes of the source files.
+pub const XDR_FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/const.x */ "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37"
 ];
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
 /// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
-pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
+pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
   ("spec/fixtures/generator/const.x", "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37")
 ];
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -8,6 +8,8 @@ pub const XDR_FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/const.x */ "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37"
 ];
 
+#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
+
 use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -1,15 +1,13 @@
 // Module  is generated from:
-//   spec/fixtures/generator/const.x
-
-/// FILE_SPEC_FIXTURES_GENERATOR_CONST_X_SHA256 is the SHA256 hash of source file spec/fixtures/generator/const.x.
-pub const FILE_SPEC_FIXTURES_GENERATOR_CONST_X_SHA256: &str = "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37";
-/// FILES_SHA256 is the SHA256 hashes of the source files:
-///   spec/fixtures/generator/const.x
-pub const FILES_SHA256: &[&str] = [
-  FILE_SPEC_FIXTURES_GENERATOR_CONST_X_SHA256
-];
+//  spec/fixtures/generator/const.x
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
+
+/// `FILES_SHA256` is the SHA256 hashes of the source files:
+///   spec/fixtures/generator/const.x
+pub const FILES_SHA256: &[&str] = &[
+  /* spec/fixtures/generator/const.x */ "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37"
+];
 
 use core::{fmt, fmt::Debug, slice::Iter};
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -3,8 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `FILES_SHA256` is the SHA256 hashes of the source files:
-///   spec/fixtures/generator/const.x
+/// `FILES_SHA256` is the SHA256 hashes of the source files.
 pub const FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/const.x */ "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37"
 ];

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -1,5 +1,13 @@
 // Module  is generated from:
-//  spec/fixtures/generator/const.x
+//   spec/fixtures/generator/const.x
+
+/// FILE_SPEC_FIXTURES_GENERATOR_CONST_X_SHA256 is the SHA256 hash of source file spec/fixtures/generator/const.x.
+pub const FILE_SPEC_FIXTURES_GENERATOR_CONST_X_SHA256: &str = "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37";
+/// FILES_SHA256 is the SHA256 hashes of the source files:
+///   spec/fixtures/generator/const.x
+pub const FILES_SHA256: &[&str] = [
+  FILE_SPEC_FIXTURES_GENERATOR_CONST_X_SHA256
+];
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -8,8 +8,6 @@ pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
   ("spec/fixtures/generator/const.x", "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37")
 ];
 
-#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
-
 use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
 /// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
-pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
+pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
   ("spec/fixtures/generator/enum.x", "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f")
 ];
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -8,6 +8,8 @@ pub const XDR_FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/enum.x */ "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f"
 ];
 
+#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
+
 use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -3,8 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `FILES_SHA256` is the SHA256 hashes of the source files:
-///   spec/fixtures/generator/enum.x
+/// `FILES_SHA256` is the SHA256 hashes of the source files.
 pub const FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/enum.x */ "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f"
 ];

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -3,8 +3,8 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `FILES_SHA256` is the SHA256 hashes of the source files.
-pub const FILES_SHA256: &[&str] = &[
+/// `XDR_FILES_SHA256` is the SHA256 hashes of the source files.
+pub const XDR_FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/enum.x */ "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f"
 ];
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -8,8 +8,6 @@ pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
   ("spec/fixtures/generator/enum.x", "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f")
 ];
 
-#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
-
 use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -1,15 +1,13 @@
 // Module  is generated from:
-//   spec/fixtures/generator/enum.x
-
-/// FILE_SPEC_FIXTURES_GENERATOR_ENUM_X_SHA256 is the SHA256 hash of source file spec/fixtures/generator/enum.x.
-pub const FILE_SPEC_FIXTURES_GENERATOR_ENUM_X_SHA256: &str = "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f";
-/// FILES_SHA256 is the SHA256 hashes of the source files:
-///   spec/fixtures/generator/enum.x
-pub const FILES_SHA256: &[&str] = [
-  FILE_SPEC_FIXTURES_GENERATOR_ENUM_X_SHA256
-];
+//  spec/fixtures/generator/enum.x
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
+
+/// `FILES_SHA256` is the SHA256 hashes of the source files:
+///   spec/fixtures/generator/enum.x
+pub const FILES_SHA256: &[&str] = &[
+  /* spec/fixtures/generator/enum.x */ "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f"
+];
 
 use core::{fmt, fmt::Debug, slice::Iter};
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -1,5 +1,13 @@
 // Module  is generated from:
-//  spec/fixtures/generator/enum.x
+//   spec/fixtures/generator/enum.x
+
+/// FILE_SPEC_FIXTURES_GENERATOR_ENUM_X_SHA256 is the SHA256 hash of source file spec/fixtures/generator/enum.x.
+pub const FILE_SPEC_FIXTURES_GENERATOR_ENUM_X_SHA256: &str = "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f";
+/// FILES_SHA256 is the SHA256 hashes of the source files:
+///   spec/fixtures/generator/enum.x
+pub const FILES_SHA256: &[&str] = [
+  FILE_SPEC_FIXTURES_GENERATOR_ENUM_X_SHA256
+];
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -3,9 +3,9 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `XDR_FILES_SHA256` is the SHA256 hashes of the source files.
-pub const XDR_FILES_SHA256: &[&str] = &[
-  /* spec/fixtures/generator/enum.x */ "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f"
+/// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
+pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
+  ("spec/fixtures/generator/enum.x", "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f")
 ];
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -1,5 +1,13 @@
 // Module  is generated from:
-//  spec/fixtures/generator/nesting.x
+//   spec/fixtures/generator/nesting.x
+
+/// FILE_SPEC_FIXTURES_GENERATOR_NESTING_X_SHA256 is the SHA256 hash of source file spec/fixtures/generator/nesting.x.
+pub const FILE_SPEC_FIXTURES_GENERATOR_NESTING_X_SHA256: &str = "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a";
+/// FILES_SHA256 is the SHA256 hashes of the source files:
+///   spec/fixtures/generator/nesting.x
+pub const FILES_SHA256: &[&str] = [
+  FILE_SPEC_FIXTURES_GENERATOR_NESTING_X_SHA256
+];
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -3,9 +3,9 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `XDR_FILES_SHA256` is the SHA256 hashes of the source files.
-pub const XDR_FILES_SHA256: &[&str] = &[
-  /* spec/fixtures/generator/nesting.x */ "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a"
+/// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
+pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
+  ("spec/fixtures/generator/nesting.x", "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a")
 ];
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -3,8 +3,8 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `FILES_SHA256` is the SHA256 hashes of the source files.
-pub const FILES_SHA256: &[&str] = &[
+/// `XDR_FILES_SHA256` is the SHA256 hashes of the source files.
+pub const XDR_FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/nesting.x */ "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a"
 ];
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -8,8 +8,6 @@ pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
   ("spec/fixtures/generator/nesting.x", "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a")
 ];
 
-#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
-
 use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -1,15 +1,13 @@
 // Module  is generated from:
-//   spec/fixtures/generator/nesting.x
-
-/// FILE_SPEC_FIXTURES_GENERATOR_NESTING_X_SHA256 is the SHA256 hash of source file spec/fixtures/generator/nesting.x.
-pub const FILE_SPEC_FIXTURES_GENERATOR_NESTING_X_SHA256: &str = "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a";
-/// FILES_SHA256 is the SHA256 hashes of the source files:
-///   spec/fixtures/generator/nesting.x
-pub const FILES_SHA256: &[&str] = [
-  FILE_SPEC_FIXTURES_GENERATOR_NESTING_X_SHA256
-];
+//  spec/fixtures/generator/nesting.x
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
+
+/// `FILES_SHA256` is the SHA256 hashes of the source files:
+///   spec/fixtures/generator/nesting.x
+pub const FILES_SHA256: &[&str] = &[
+  /* spec/fixtures/generator/nesting.x */ "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a"
+];
 
 use core::{fmt, fmt::Debug, slice::Iter};
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
 /// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
-pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
+pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
   ("spec/fixtures/generator/nesting.x", "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a")
 ];
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -8,6 +8,8 @@ pub const XDR_FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/nesting.x */ "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a"
 ];
 
+#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
+
 use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -3,8 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `FILES_SHA256` is the SHA256 hashes of the source files:
-///   spec/fixtures/generator/nesting.x
+/// `FILES_SHA256` is the SHA256 hashes of the source files.
 pub const FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/nesting.x */ "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a"
 ];

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -1,15 +1,13 @@
 // Module  is generated from:
-//   spec/fixtures/generator/optional.x
-
-/// FILE_SPEC_FIXTURES_GENERATOR_OPTIONAL_X_SHA256 is the SHA256 hash of source file spec/fixtures/generator/optional.x.
-pub const FILE_SPEC_FIXTURES_GENERATOR_OPTIONAL_X_SHA256: &str = "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7";
-/// FILES_SHA256 is the SHA256 hashes of the source files:
-///   spec/fixtures/generator/optional.x
-pub const FILES_SHA256: &[&str] = [
-  FILE_SPEC_FIXTURES_GENERATOR_OPTIONAL_X_SHA256
-];
+//  spec/fixtures/generator/optional.x
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
+
+/// `FILES_SHA256` is the SHA256 hashes of the source files:
+///   spec/fixtures/generator/optional.x
+pub const FILES_SHA256: &[&str] = &[
+  /* spec/fixtures/generator/optional.x */ "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7"
+];
 
 use core::{fmt, fmt::Debug, slice::Iter};
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -8,6 +8,8 @@ pub const XDR_FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/optional.x */ "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7"
 ];
 
+#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
+
 use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -3,8 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `FILES_SHA256` is the SHA256 hashes of the source files:
-///   spec/fixtures/generator/optional.x
+/// `FILES_SHA256` is the SHA256 hashes of the source files.
 pub const FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/optional.x */ "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7"
 ];

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -1,5 +1,13 @@
 // Module  is generated from:
-//  spec/fixtures/generator/optional.x
+//   spec/fixtures/generator/optional.x
+
+/// FILE_SPEC_FIXTURES_GENERATOR_OPTIONAL_X_SHA256 is the SHA256 hash of source file spec/fixtures/generator/optional.x.
+pub const FILE_SPEC_FIXTURES_GENERATOR_OPTIONAL_X_SHA256: &str = "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7";
+/// FILES_SHA256 is the SHA256 hashes of the source files:
+///   spec/fixtures/generator/optional.x
+pub const FILES_SHA256: &[&str] = [
+  FILE_SPEC_FIXTURES_GENERATOR_OPTIONAL_X_SHA256
+];
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -8,8 +8,6 @@ pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
   ("spec/fixtures/generator/optional.x", "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7")
 ];
 
-#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
-
 use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -3,9 +3,9 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `XDR_FILES_SHA256` is the SHA256 hashes of the source files.
-pub const XDR_FILES_SHA256: &[&str] = &[
-  /* spec/fixtures/generator/optional.x */ "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7"
+/// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
+pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
+  ("spec/fixtures/generator/optional.x", "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7")
 ];
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
 /// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
-pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
+pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
   ("spec/fixtures/generator/optional.x", "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7")
 ];
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -3,8 +3,8 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `FILES_SHA256` is the SHA256 hashes of the source files.
-pub const FILES_SHA256: &[&str] = &[
+/// `XDR_FILES_SHA256` is the SHA256 hashes of the source files.
+pub const XDR_FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/optional.x */ "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7"
 ];
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -3,8 +3,8 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `FILES_SHA256` is the SHA256 hashes of the source files.
-pub const FILES_SHA256: &[&str] = &[
+/// `XDR_FILES_SHA256` is the SHA256 hashes of the source files.
+pub const XDR_FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/struct.x */ "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a"
 ];
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -8,6 +8,8 @@ pub const XDR_FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/struct.x */ "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a"
 ];
 
+#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
+
 use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -8,8 +8,6 @@ pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
   ("spec/fixtures/generator/struct.x", "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a")
 ];
 
-#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
-
 use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -3,9 +3,9 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `XDR_FILES_SHA256` is the SHA256 hashes of the source files.
-pub const XDR_FILES_SHA256: &[&str] = &[
-  /* spec/fixtures/generator/struct.x */ "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a"
+/// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
+pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
+  ("spec/fixtures/generator/struct.x", "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a")
 ];
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -3,8 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `FILES_SHA256` is the SHA256 hashes of the source files:
-///   spec/fixtures/generator/struct.x
+/// `FILES_SHA256` is the SHA256 hashes of the source files.
 pub const FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/struct.x */ "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a"
 ];

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
 /// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
-pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
+pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
   ("spec/fixtures/generator/struct.x", "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a")
 ];
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -1,15 +1,13 @@
 // Module  is generated from:
-//   spec/fixtures/generator/struct.x
-
-/// FILE_SPEC_FIXTURES_GENERATOR_STRUCT_X_SHA256 is the SHA256 hash of source file spec/fixtures/generator/struct.x.
-pub const FILE_SPEC_FIXTURES_GENERATOR_STRUCT_X_SHA256: &str = "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a";
-/// FILES_SHA256 is the SHA256 hashes of the source files:
-///   spec/fixtures/generator/struct.x
-pub const FILES_SHA256: &[&str] = [
-  FILE_SPEC_FIXTURES_GENERATOR_STRUCT_X_SHA256
-];
+//  spec/fixtures/generator/struct.x
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
+
+/// `FILES_SHA256` is the SHA256 hashes of the source files:
+///   spec/fixtures/generator/struct.x
+pub const FILES_SHA256: &[&str] = &[
+  /* spec/fixtures/generator/struct.x */ "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a"
+];
 
 use core::{fmt, fmt::Debug, slice::Iter};
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -1,5 +1,13 @@
 // Module  is generated from:
-//  spec/fixtures/generator/struct.x
+//   spec/fixtures/generator/struct.x
+
+/// FILE_SPEC_FIXTURES_GENERATOR_STRUCT_X_SHA256 is the SHA256 hash of source file spec/fixtures/generator/struct.x.
+pub const FILE_SPEC_FIXTURES_GENERATOR_STRUCT_X_SHA256: &str = "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a";
+/// FILES_SHA256 is the SHA256 hashes of the source files:
+///   spec/fixtures/generator/struct.x
+pub const FILES_SHA256: &[&str] = [
+  FILE_SPEC_FIXTURES_GENERATOR_STRUCT_X_SHA256
+];
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -3,8 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `FILES_SHA256` is the SHA256 hashes of the source files:
-///   spec/fixtures/generator/test.x
+/// `FILES_SHA256` is the SHA256 hashes of the source files.
 pub const FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/test.x */ "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41"
 ];

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -1,15 +1,13 @@
 // Module  is generated from:
-//   spec/fixtures/generator/test.x
-
-/// FILE_SPEC_FIXTURES_GENERATOR_TEST_X_SHA256 is the SHA256 hash of source file spec/fixtures/generator/test.x.
-pub const FILE_SPEC_FIXTURES_GENERATOR_TEST_X_SHA256: &str = "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41";
-/// FILES_SHA256 is the SHA256 hashes of the source files:
-///   spec/fixtures/generator/test.x
-pub const FILES_SHA256: &[&str] = [
-  FILE_SPEC_FIXTURES_GENERATOR_TEST_X_SHA256
-];
+//  spec/fixtures/generator/test.x
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
+
+/// `FILES_SHA256` is the SHA256 hashes of the source files:
+///   spec/fixtures/generator/test.x
+pub const FILES_SHA256: &[&str] = &[
+  /* spec/fixtures/generator/test.x */ "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41"
+];
 
 use core::{fmt, fmt::Debug, slice::Iter};
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -8,8 +8,6 @@ pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
   ("spec/fixtures/generator/test.x", "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41")
 ];
 
-#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
-
 use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -8,6 +8,8 @@ pub const XDR_FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/test.x */ "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41"
 ];
 
+#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
+
 use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
 /// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
-pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
+pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
   ("spec/fixtures/generator/test.x", "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41")
 ];
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -1,5 +1,13 @@
 // Module  is generated from:
-//  spec/fixtures/generator/test.x
+//   spec/fixtures/generator/test.x
+
+/// FILE_SPEC_FIXTURES_GENERATOR_TEST_X_SHA256 is the SHA256 hash of source file spec/fixtures/generator/test.x.
+pub const FILE_SPEC_FIXTURES_GENERATOR_TEST_X_SHA256: &str = "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41";
+/// FILES_SHA256 is the SHA256 hashes of the source files:
+///   spec/fixtures/generator/test.x
+pub const FILES_SHA256: &[&str] = [
+  FILE_SPEC_FIXTURES_GENERATOR_TEST_X_SHA256
+];
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -3,9 +3,9 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `XDR_FILES_SHA256` is the SHA256 hashes of the source files.
-pub const XDR_FILES_SHA256: &[&str] = &[
-  /* spec/fixtures/generator/test.x */ "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41"
+/// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
+pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
+  ("spec/fixtures/generator/test.x", "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41")
 ];
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -3,8 +3,8 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `FILES_SHA256` is the SHA256 hashes of the source files.
-pub const FILES_SHA256: &[&str] = &[
+/// `XDR_FILES_SHA256` is the SHA256 hashes of the source files.
+pub const XDR_FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/test.x */ "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41"
 ];
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -3,8 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `FILES_SHA256` is the SHA256 hashes of the source files:
-///   spec/fixtures/generator/union.x
+/// `FILES_SHA256` is the SHA256 hashes of the source files.
 pub const FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/union.x */ "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41"
 ];

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
 /// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
-pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
+pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
   ("spec/fixtures/generator/union.x", "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41")
 ];
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -3,8 +3,8 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `FILES_SHA256` is the SHA256 hashes of the source files.
-pub const FILES_SHA256: &[&str] = &[
+/// `XDR_FILES_SHA256` is the SHA256 hashes of the source files.
+pub const XDR_FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/union.x */ "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41"
 ];
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -8,6 +8,8 @@ pub const XDR_FILES_SHA256: &[&str] = &[
   /* spec/fixtures/generator/union.x */ "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41"
 ];
 
+#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
+
 use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -1,15 +1,13 @@
 // Module  is generated from:
-//   spec/fixtures/generator/union.x
-
-/// FILE_SPEC_FIXTURES_GENERATOR_UNION_X_SHA256 is the SHA256 hash of source file spec/fixtures/generator/union.x.
-pub const FILE_SPEC_FIXTURES_GENERATOR_UNION_X_SHA256: &str = "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41";
-/// FILES_SHA256 is the SHA256 hashes of the source files:
-///   spec/fixtures/generator/union.x
-pub const FILES_SHA256: &[&str] = [
-  FILE_SPEC_FIXTURES_GENERATOR_UNION_X_SHA256
-];
+//  spec/fixtures/generator/union.x
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
+
+/// `FILES_SHA256` is the SHA256 hashes of the source files:
+///   spec/fixtures/generator/union.x
+pub const FILES_SHA256: &[&str] = &[
+  /* spec/fixtures/generator/union.x */ "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41"
+];
 
 use core::{fmt, fmt::Debug, slice::Iter};
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -8,8 +8,6 @@ pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
   ("spec/fixtures/generator/union.x", "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41")
 ];
 
-#![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
-
 use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -3,9 +3,9 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-/// `XDR_FILES_SHA256` is the SHA256 hashes of the source files.
-pub const XDR_FILES_SHA256: &[&str] = &[
-  /* spec/fixtures/generator/union.x */ "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41"
+/// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
+pub const XDR_FILES_SHA256: &[(&str, &str)] = &[
+  ("spec/fixtures/generator/union.x", "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41")
 ];
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -1,5 +1,13 @@
 // Module  is generated from:
-//  spec/fixtures/generator/union.x
+//   spec/fixtures/generator/union.x
+
+/// FILE_SPEC_FIXTURES_GENERATOR_UNION_X_SHA256 is the SHA256 hash of source file spec/fixtures/generator/union.x.
+pub const FILE_SPEC_FIXTURES_GENERATOR_UNION_X_SHA256: &str = "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41";
+/// FILES_SHA256 is the SHA256 hashes of the source files:
+///   spec/fixtures/generator/union.x
+pub const FILES_SHA256: &[&str] = [
+  FILE_SPEC_FIXTURES_GENERATOR_UNION_X_SHA256
+];
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 


### PR DESCRIPTION
### What
Add input file SHA256 hash consts to Go/Rust generated code, injecting the following into the Stellar rs-stellar-xdr lib:

```rust
/// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
pub const XDR_FILES_SHA256: [(&str, &str); 6] = [
    (
        "xdr/curr/Stellar-SCP.x",
        "8f32b04d008f8bc33b8843d075e69837231a673691ee41d8b821ca229a6e802a",
    ),
    (
        "xdr/curr/Stellar-ledger-entries.x",
        "3aa135c309c2d67883f165961739b4940c90df59240d8aeef55deced8d7708b5",
    ),
    (
        "xdr/curr/Stellar-ledger.x",
        "ef746ead6bb8ef9541599796804d672f2994e2599a6dc595ece099e166b49f10",
    ),
    (
        "xdr/curr/Stellar-overlay.x",
        "8ecbc36d2a43103499a6416572c7cd7b4fd7638d1a2af515b81b463ce6909c51",
    ),
    (
        "xdr/curr/Stellar-transaction.x",
        "45fdeb428e68d6b07e3e3157b6404567e0efb712c9d4c90a61a1035854c32b90",
    ),
    (
        "xdr/curr/Stellar-types.x",
        "60b7588e573f5e5518766eb5e6b6ea42f0e53144663cbe557e485cceb6306c85",
    ),
];
```

### Why
@graydon pointed out that in applications or systems like stellar-core that import multiple XDR generated libraries it is really easy to accidentally import libraries that were generated from different sources. This mistake has occurred once and could have reasonably significant consequences, so building in meta information that applications like stellar-core can validate seems worthwhile.

Close #88

### Known Limitations
This change only adds them to the Go and Rust libs. 