### PR TITLE
Rust: Add Deref<Target=Vec<_>> impls for VecMs

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -356,7 +356,7 @@ module Xdrgen
             impl Deref for #{name typedef} {
               type Target = Vec<#{element_type_for_vec(typedef.type)}>;
               fn deref(&self) -> &Self::Target {
-                  self.as_ref()
+                  &self.0
               }
             }
 

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -354,7 +354,7 @@ module Xdrgen
             out.break
             out.puts <<-EOS.strip_heredoc
             impl Deref for #{name typedef} {
-              type Target = [#{element_type_for_vec(typedef.type)}];
+              type Target = Vec<#{element_type_for_vec(typedef.type)}>;
               fn deref(&self) -> &Self::Target {
                   self.as_ref()
               }

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -351,8 +351,15 @@ module Xdrgen
           }
           EOS
           if is_var_array_type(typedef.type)
-            out.puts ""
+            out.break
             out.puts <<-EOS.strip_heredoc
+            impl Deref for #{name typedef} {
+              type Target = [#{element_type_for_vec(typedef.type)}];
+              fn deref(&self) -> &Self::Target {
+                  self.as_ref()
+              }
+            }
+
             impl #{name typedef} {
                 #[must_use]
                 pub fn len(&self) -> usize {

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-use core::{fmt, fmt::Debug, slice::Iter};
+use core::{fmt, fmt::Debug, ops::Deref, slice::Iter};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -358,6 +358,14 @@ pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
+
+impl<T, const MAX: u32> Deref for VecM<T, MAX> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
 
 impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -360,7 +360,7 @@ where
     T: 'static;
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
-    type Target = [T];
+    type Target = Vec<T>;
 
     fn deref(&self) -> &Self::Target {
         self.as_ref()

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -363,7 +363,7 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;
 
     fn deref(&self) -> &Self::Target {
-        self.as_ref()
+        &self.0
     }
 }
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-use core::{fmt, fmt::Debug, slice::Iter};
+use core::{fmt, fmt::Debug, ops::Deref, slice::Iter};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -361,6 +361,14 @@ pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
+
+impl<T, const MAX: u32> Deref for VecM<T, MAX> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
 
 impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -363,7 +363,7 @@ where
     T: 'static;
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
-    type Target = [T];
+    type Target = Vec<T>;
 
     fn deref(&self) -> &Self::Target {
         self.as_ref()

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -366,7 +366,7 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;
 
     fn deref(&self) -> &Self::Target {
-        self.as_ref()
+        &self.0
     }
 }
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-use core::{fmt, fmt::Debug, slice::Iter};
+use core::{fmt, fmt::Debug, ops::Deref, slice::Iter};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -361,6 +361,14 @@ pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
+
+impl<T, const MAX: u32> Deref for VecM<T, MAX> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
 
 impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -363,7 +363,7 @@ where
     T: 'static;
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
-    type Target = [T];
+    type Target = Vec<T>;
 
     fn deref(&self) -> &Self::Target {
         self.as_ref()

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -366,7 +366,7 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;
 
     fn deref(&self) -> &Self::Target {
-        self.as_ref()
+        &self.0
     }
 }
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-use core::{fmt, fmt::Debug, slice::Iter};
+use core::{fmt, fmt::Debug, ops::Deref, slice::Iter};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -361,6 +361,14 @@ pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
+
+impl<T, const MAX: u32> Deref for VecM<T, MAX> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
 
 impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -363,7 +363,7 @@ where
     T: 'static;
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
-    type Target = [T];
+    type Target = Vec<T>;
 
     fn deref(&self) -> &Self::Target {
         self.as_ref()

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -366,7 +366,7 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;
 
     fn deref(&self) -> &Self::Target {
-        self.as_ref()
+        &self.0
     }
 }
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-use core::{fmt, fmt::Debug, slice::Iter};
+use core::{fmt, fmt::Debug, ops::Deref, slice::Iter};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -361,6 +361,14 @@ pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
+
+impl<T, const MAX: u32> Deref for VecM<T, MAX> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
 
 impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -363,7 +363,7 @@ where
     T: 'static;
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
-    type Target = [T];
+    type Target = Vec<T>;
 
     fn deref(&self) -> &Self::Target {
         self.as_ref()

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -366,7 +366,7 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;
 
     fn deref(&self) -> &Self::Target {
-        self.as_ref()
+        &self.0
     }
 }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-use core::{fmt, fmt::Debug, slice::Iter};
+use core::{fmt, fmt::Debug, ops::Deref, slice::Iter};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -361,6 +361,14 @@ pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
+
+impl<T, const MAX: u32> Deref for VecM<T, MAX> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
 
 impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -363,7 +363,7 @@ where
     T: 'static;
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
-    type Target = [T];
+    type Target = Vec<T>;
 
     fn deref(&self) -> &Self::Target {
         self.as_ref()

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -366,7 +366,7 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;
 
     fn deref(&self) -> &Self::Target {
-        self.as_ref()
+        &self.0
     }
 }
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-use core::{fmt, fmt::Debug, slice::Iter};
+use core::{fmt, fmt::Debug, ops::Deref, slice::Iter};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -361,6 +361,14 @@ pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
+
+impl<T, const MAX: u32> Deref for VecM<T, MAX> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
 
 impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -363,7 +363,7 @@ where
     T: 'static;
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
-    type Target = [T];
+    type Target = Vec<T>;
 
     fn deref(&self) -> &Self::Target {
         self.as_ref()

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -366,7 +366,7 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;
 
     fn deref(&self) -> &Self::Target {
-        self.as_ref()
+        &self.0
     }
 }
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -363,7 +363,7 @@ where
     T: 'static;
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
-    type Target = [T];
+    type Target = Vec<T>;
 
     fn deref(&self) -> &Self::Target {
         self.as_ref()
@@ -963,7 +963,7 @@ impl WriteXdr for Hashes2 {
 }
 
 impl Deref for Hashes2 {
-  type Target = [Hash];
+  type Target = Vec<Hash>;
   fn deref(&self) -> &Self::Target {
       self.as_ref()
   }
@@ -1079,7 +1079,7 @@ impl WriteXdr for Hashes3 {
 }
 
 impl Deref for Hashes3 {
-  type Target = [Hash];
+  type Target = Vec<Hash>;
   fn deref(&self) -> &Self::Target {
       self.as_ref()
   }

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-use core::{fmt, fmt::Debug, slice::Iter};
+use core::{fmt, fmt::Debug, ops::Deref, slice::Iter};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -361,6 +361,14 @@ pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
+
+impl<T, const MAX: u32> Deref for VecM<T, MAX> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
 
 impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]
@@ -954,6 +962,13 @@ impl WriteXdr for Hashes2 {
     }
 }
 
+impl Deref for Hashes2 {
+  type Target = [Hash];
+  fn deref(&self) -> &Self::Target {
+      self.as_ref()
+  }
+}
+
 impl Hashes2 {
     #[must_use]
     pub fn len(&self) -> usize {
@@ -1061,6 +1076,13 @@ impl WriteXdr for Hashes3 {
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
         self.0.write_xdr(w)
     }
+}
+
+impl Deref for Hashes3 {
+  type Target = [Hash];
+  fn deref(&self) -> &Self::Target {
+      self.as_ref()
+  }
 }
 
 impl Hashes3 {

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -366,7 +366,7 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;
 
     fn deref(&self) -> &Self::Target {
-        self.as_ref()
+        &self.0
     }
 }
 
@@ -965,7 +965,7 @@ impl WriteXdr for Hashes2 {
 impl Deref for Hashes2 {
   type Target = Vec<Hash>;
   fn deref(&self) -> &Self::Target {
-      self.as_ref()
+      &self.0
   }
 }
 
@@ -1081,7 +1081,7 @@ impl WriteXdr for Hashes3 {
 impl Deref for Hashes3 {
   type Target = Vec<Hash>;
   fn deref(&self) -> &Self::Target {
-      self.as_ref()
+      &self.0
   }
 }
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-use core::{fmt, fmt::Debug, slice::Iter};
+use core::{fmt, fmt::Debug, ops::Deref, slice::Iter};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -361,6 +361,14 @@ pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
+
+impl<T, const MAX: u32> Deref for VecM<T, MAX> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
 
 impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -363,7 +363,7 @@ where
     T: 'static;
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
-    type Target = [T];
+    type Target = Vec<T>;
 
     fn deref(&self) -> &Self::Target {
         self.as_ref()

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -366,7 +366,7 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;
 
     fn deref(&self) -> &Self::Target {
-        self.as_ref()
+        &self.0
     }
 }
 


### PR DESCRIPTION
### What
Add to the Rust generated code `Deref<Target=Vec<_>>` implementations for `VecM` and all types that are typedefs to `VecM`.

### Why
`Vec` in the stdlib has `[T]` as its Deref which is convenient, and `VecM` could do the same also for convenience. It derefs to `Vec<T>` since `[T]` comes automatically since they're automatically chained.