### PR TITLE
Change Deref for VecM typedefs

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -354,7 +354,7 @@ module Xdrgen
             out.break
             out.puts <<-EOS.strip_heredoc
             impl Deref for #{name typedef} {
-              type Target = Vec<#{element_type_for_vec(typedef.type)}>;
+              type Target = #{reference(typedef, typedef.type)};
               fn deref(&self) -> &Self::Target {
                   &self.0
               }

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -963,7 +963,7 @@ impl WriteXdr for Hashes2 {
 }
 
 impl Deref for Hashes2 {
-  type Target = Vec<Hash>;
+  type Target = VecM::<Hash, 12>;
   fn deref(&self) -> &Self::Target {
       &self.0
   }
@@ -1079,7 +1079,7 @@ impl WriteXdr for Hashes3 {
 }
 
 impl Deref for Hashes3 {
-  type Target = Vec<Hash>;
+  type Target = VecM::<Hash>;
   fn deref(&self) -> &Self::Target {
       &self.0
   }


### PR DESCRIPTION
### What
Change Deref for VecM typedefs to be VecM instead of Vec.

### Why
I just added the Derefs, but I made the Deref target Vec for typedefs that wrap VecM. The internal type is VecM and so Deref should target that, and due to automatic chaining with Deref we'll get Vec anyway.