### PR TITLE
Remove unnecessary fns on VecM

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -360,37 +360,6 @@ module Xdrgen
               }
             }
 
-            impl #{name typedef} {
-                #[must_use]
-                pub fn len(&self) -> usize {
-                    self.0.len()
-                }
-
-                #[must_use]
-                pub fn is_empty(&self) -> bool {
-                    self.0.is_empty()
-                }
-
-                #[must_use]
-                pub fn to_vec(self) -> Vec<#{element_type_for_vec(typedef.type)}> {
-                    self.into()
-                }
-
-                #[must_use]
-                pub fn as_vec(&self) -> &Vec<#{element_type_for_vec(typedef.type)}> {
-                    self.as_ref()
-                }
-
-                #[must_use]
-                pub fn as_slice(&self) -> &[#{element_type_for_vec(typedef.type)}] {
-                    self.as_ref()
-                }
-
-                pub fn iter(&self) -> Iter<'_, #{element_type_for_vec(typedef.type)}> {
-                    self.0.iter()
-                }
-            }
-
             impl From<#{name typedef}> for Vec<#{element_type_for_vec(typedef.type)}> {
                 #[must_use]
                 fn from(x: #{name typedef}) -> Self {

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-use core::{fmt, fmt::Debug, ops::Deref, slice::Iter};
+use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -369,16 +369,6 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
 
 impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    #[must_use]
     pub fn to_vec(self) -> Vec<T> {
         self.into()
     }
@@ -386,15 +376,6 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
-    }
-
-    #[must_use]
-    pub fn as_slice(&self) -> &[T] {
-        self.as_ref()
-    }
-
-    pub fn iter(&self) -> Iter<'_, T> {
-        self.0.iter()
     }
 }
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-use core::{fmt, fmt::Debug, ops::Deref, slice::Iter};
+use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -372,16 +372,6 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
 
 impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    #[must_use]
     pub fn to_vec(self) -> Vec<T> {
         self.into()
     }
@@ -389,15 +379,6 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
-    }
-
-    #[must_use]
-    pub fn as_slice(&self) -> &[T] {
-        self.as_ref()
-    }
-
-    pub fn iter(&self) -> Iter<'_, T> {
-        self.0.iter()
     }
 }
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-use core::{fmt, fmt::Debug, ops::Deref, slice::Iter};
+use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -372,16 +372,6 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
 
 impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    #[must_use]
     pub fn to_vec(self) -> Vec<T> {
         self.into()
     }
@@ -389,15 +379,6 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
-    }
-
-    #[must_use]
-    pub fn as_slice(&self) -> &[T] {
-        self.as_ref()
-    }
-
-    pub fn iter(&self) -> Iter<'_, T> {
-        self.0.iter()
     }
 }
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-use core::{fmt, fmt::Debug, ops::Deref, slice::Iter};
+use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -372,16 +372,6 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
 
 impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    #[must_use]
     pub fn to_vec(self) -> Vec<T> {
         self.into()
     }
@@ -389,15 +379,6 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
-    }
-
-    #[must_use]
-    pub fn as_slice(&self) -> &[T] {
-        self.as_ref()
-    }
-
-    pub fn iter(&self) -> Iter<'_, T> {
-        self.0.iter()
     }
 }
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-use core::{fmt, fmt::Debug, ops::Deref, slice::Iter};
+use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -372,16 +372,6 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
 
 impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    #[must_use]
     pub fn to_vec(self) -> Vec<T> {
         self.into()
     }
@@ -389,15 +379,6 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
-    }
-
-    #[must_use]
-    pub fn as_slice(&self) -> &[T] {
-        self.as_ref()
-    }
-
-    pub fn iter(&self) -> Iter<'_, T> {
-        self.0.iter()
     }
 }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-use core::{fmt, fmt::Debug, ops::Deref, slice::Iter};
+use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -372,16 +372,6 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
 
 impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    #[must_use]
     pub fn to_vec(self) -> Vec<T> {
         self.into()
     }
@@ -389,15 +379,6 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
-    }
-
-    #[must_use]
-    pub fn as_slice(&self) -> &[T] {
-        self.as_ref()
-    }
-
-    pub fn iter(&self) -> Iter<'_, T> {
-        self.0.iter()
     }
 }
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-use core::{fmt, fmt::Debug, ops::Deref, slice::Iter};
+use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -372,16 +372,6 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
 
 impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    #[must_use]
     pub fn to_vec(self) -> Vec<T> {
         self.into()
     }
@@ -389,15 +379,6 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
-    }
-
-    #[must_use]
-    pub fn as_slice(&self) -> &[T] {
-        self.as_ref()
-    }
-
-    pub fn iter(&self) -> Iter<'_, T> {
-        self.0.iter()
     }
 }
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-use core::{fmt, fmt::Debug, ops::Deref, slice::Iter};
+use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -372,16 +372,6 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
 
 impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    #[must_use]
     pub fn to_vec(self) -> Vec<T> {
         self.into()
     }
@@ -389,15 +379,6 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
-    }
-
-    #[must_use]
-    pub fn as_slice(&self) -> &[T] {
-        self.as_ref()
-    }
-
-    pub fn iter(&self) -> Iter<'_, T> {
-        self.0.iter()
     }
 }
 
@@ -969,37 +950,6 @@ impl Deref for Hashes2 {
   }
 }
 
-impl Hashes2 {
-    #[must_use]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    #[must_use]
-    pub fn to_vec(self) -> Vec<Hash> {
-        self.into()
-    }
-
-    #[must_use]
-    pub fn as_vec(&self) -> &Vec<Hash> {
-        self.as_ref()
-    }
-
-    #[must_use]
-    pub fn as_slice(&self) -> &[Hash] {
-        self.as_ref()
-    }
-
-    pub fn iter(&self) -> Iter<'_, Hash> {
-        self.0.iter()
-    }
-}
-
 impl From<Hashes2> for Vec<Hash> {
     #[must_use]
     fn from(x: Hashes2) -> Self {
@@ -1083,37 +1033,6 @@ impl Deref for Hashes3 {
   fn deref(&self) -> &Self::Target {
       &self.0
   }
-}
-
-impl Hashes3 {
-    #[must_use]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    #[must_use]
-    pub fn to_vec(self) -> Vec<Hash> {
-        self.into()
-    }
-
-    #[must_use]
-    pub fn as_vec(&self) -> &Vec<Hash> {
-        self.as_ref()
-    }
-
-    #[must_use]
-    pub fn as_slice(&self) -> &[Hash] {
-        self.as_ref()
-    }
-
-    pub fn iter(&self) -> Iter<'_, Hash> {
-        self.0.iter()
-    }
 }
 
 impl From<Hashes3> for Vec<Hash> {

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::missing_errors_doc, clippy::unreadable_literal)]
 
-use core::{fmt, fmt::Debug, ops::Deref, slice::Iter};
+use core::{fmt, fmt::Debug, ops::Deref};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -372,16 +372,6 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
 
 impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    #[must_use]
     pub fn to_vec(self) -> Vec<T> {
         self.into()
     }
@@ -389,15 +379,6 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
-    }
-
-    #[must_use]
-    pub fn as_slice(&self) -> &[T] {
-        self.as_ref()
-    }
-
-    pub fn iter(&self) -> Iter<'_, T> {
-        self.0.iter()
     }
 }
 


### PR DESCRIPTION
### What
Remove unnecessary fns on VecM that are already provided via the Deref impl to Vec.

### Why
Since the Deref impl to Vec provides the fns there is no need to reimplement them in VecM.