### PR TITLE
Fix VecM fns and Deref for opaques and strings

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -446,8 +446,8 @@ module Xdrgen
       end
 
       def is_var_array_type(type)
-        (type == AST::Typespecs::Opaque && !type.fixed?) ||
-        (type == AST::Typespecs::String) ||
+        (AST::Typespecs::Opaque === type && !type.fixed?) ||
+        (AST::Typespecs::String === type) ||
         (type.sub_type == :var_array)
       end
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -770,37 +770,6 @@ impl Deref for Uint513 {
   }
 }
 
-impl Uint513 {
-    #[must_use]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    #[must_use]
-    pub fn to_vec(self) -> Vec<u8> {
-        self.into()
-    }
-
-    #[must_use]
-    pub fn as_vec(&self) -> &Vec<u8> {
-        self.as_ref()
-    }
-
-    #[must_use]
-    pub fn as_slice(&self) -> &[u8] {
-        self.as_ref()
-    }
-
-    pub fn iter(&self) -> Iter<'_, u8> {
-        self.0.iter()
-    }
-}
-
 impl From<Uint513> for Vec<u8> {
     #[must_use]
     fn from(x: Uint513) -> Self {
@@ -884,37 +853,6 @@ impl Deref for Uint514 {
   fn deref(&self) -> &Self::Target {
       &self.0
   }
-}
-
-impl Uint514 {
-    #[must_use]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    #[must_use]
-    pub fn to_vec(self) -> Vec<u8> {
-        self.into()
-    }
-
-    #[must_use]
-    pub fn as_vec(&self) -> &Vec<u8> {
-        self.as_ref()
-    }
-
-    #[must_use]
-    pub fn as_slice(&self) -> &[u8] {
-        self.as_ref()
-    }
-
-    pub fn iter(&self) -> Iter<'_, u8> {
-        self.0.iter()
-    }
 }
 
 impl From<Uint514> for Vec<u8> {

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -774,6 +774,78 @@ impl WriteXdr for Uint513 {
     }
 }
 
+impl Deref for Uint513 {
+  type Target = VecM::<u8, 64>;
+  fn deref(&self) -> &Self::Target {
+      &self.0
+  }
+}
+
+impl Uint513 {
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    #[must_use]
+    pub fn to_vec(self) -> Vec<u8> {
+        self.into()
+    }
+
+    #[must_use]
+    pub fn as_vec(&self) -> &Vec<u8> {
+        self.as_ref()
+    }
+
+    #[must_use]
+    pub fn as_slice(&self) -> &[u8] {
+        self.as_ref()
+    }
+
+    pub fn iter(&self) -> Iter<'_, u8> {
+        self.0.iter()
+    }
+}
+
+impl From<Uint513> for Vec<u8> {
+    #[must_use]
+    fn from(x: Uint513) -> Self {
+        x.0.0
+    }
+}
+
+impl TryFrom<Vec<u8>> for Uint513 {
+    type Error = Error;
+    fn try_from(x: Vec<u8>) -> Result<Self> {
+        Ok(Uint513(x.try_into()?))
+    }
+}
+
+impl AsRef<Vec<u8>> for Uint513 {
+    #[must_use]
+    fn as_ref(&self) -> &Vec<u8> {
+        &self.0.0
+    }
+}
+
+impl AsRef<[u8]> for Uint513 {
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        &self.0.0
+    }
+    #[cfg(not(feature = "alloc"))]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0.0
+    }
+}
+
 // Uint514 is an XDR Typedef defines as:
 //
 //   typedef opaque uint514<>;
@@ -815,6 +887,78 @@ impl WriteXdr for Uint514 {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
         self.0.write_xdr(w)
+    }
+}
+
+impl Deref for Uint514 {
+  type Target = VecM::<u8>;
+  fn deref(&self) -> &Self::Target {
+      &self.0
+  }
+}
+
+impl Uint514 {
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    #[must_use]
+    pub fn to_vec(self) -> Vec<u8> {
+        self.into()
+    }
+
+    #[must_use]
+    pub fn as_vec(&self) -> &Vec<u8> {
+        self.as_ref()
+    }
+
+    #[must_use]
+    pub fn as_slice(&self) -> &[u8] {
+        self.as_ref()
+    }
+
+    pub fn iter(&self) -> Iter<'_, u8> {
+        self.0.iter()
+    }
+}
+
+impl From<Uint514> for Vec<u8> {
+    #[must_use]
+    fn from(x: Uint514) -> Self {
+        x.0.0
+    }
+}
+
+impl TryFrom<Vec<u8>> for Uint514 {
+    type Error = Error;
+    fn try_from(x: Vec<u8>) -> Result<Self> {
+        Ok(Uint514(x.try_into()?))
+    }
+}
+
+impl AsRef<Vec<u8>> for Uint514 {
+    #[must_use]
+    fn as_ref(&self) -> &Vec<u8> {
+        &self.0.0
+    }
+}
+
+impl AsRef<[u8]> for Uint514 {
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        &self.0.0
+    }
+    #[cfg(not(feature = "alloc"))]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0.0
     }
 }
 


### PR DESCRIPTION
### What
Add VecM fns and Derefs to typedefs of opaques and strings.

### Why
The code was intended to add these fns and Derefs to opaques and strings, but I had the type comparison using the wrong operatore `==` instead of `===` and in reverse, so the condition didn't match.