### PR TITLE
Rust: Add VecM<>str conversions

### DIFF
--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -20,7 +20,7 @@ use noalloc::{boxed::Box, vec::Vec};
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{borrow::ToOwned, boxed::Box, string::String, vec::Vec};
 
 // TODO: Add support for read/write xdr fns when std not available.
 
@@ -36,6 +36,7 @@ pub enum Error {
     LengthExceedsMax,
     LengthMismatch,
     NonZeroPadding,
+    Utf8Error(core::str::Utf8Error),
     #[cfg(feature = "std")]
     IO(io::Error),
 }
@@ -58,9 +59,17 @@ impl fmt::Display for Error {
             Error::LengthExceedsMax => write!(f, "xdr value max length exceeded"),
             Error::LengthMismatch => write!(f, "xdr value length does not match"),
             Error::NonZeroPadding => write!(f, "xdr padding contains non-zero bytes"),
+            Error::Utf8Error(e) => write!(f, "{}", e),
             #[cfg(feature = "std")]
             Error::IO(e) => write!(f, "{}", e),
         }
+    }
+}
+
+impl From<core::str::Utf8Error> for Error {
+    #[must_use]
+    fn from(e: core::str::Utf8Error) -> Self {
+        Error::Utf8Error(e)
     }
 }
 
@@ -493,6 +502,65 @@ where
         } else {
             Err(Error::LengthExceedsMax)
         }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
+    type Error = Error;
+
+    fn try_from(v: String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(VecM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?.to_owned())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(VecM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(VecM(v.as_bytes()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
+    type Error = Error;
+
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 


### PR DESCRIPTION
### What
Add VecM<>str conversions to the Rust generated code.

### Why
VecM's are used for XDR strings.