### PR TITLE
Rust: Make String<>VecM conversions from borrows/owned

### DIFF
--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -20,7 +20,14 @@ use noalloc::{boxed::Box, vec::Vec};
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
-use alloc::{borrow::ToOwned, boxed::Box, string::String, vec::Vec};
+use alloc::{
+    borrow::ToOwned,
+    boxed::Box,
+    string::{FromUtf8Error, String},
+    vec::Vec,
+};
+#[cfg(all(feature = "std"))]
+use std::string::FromUtf8Error;
 
 // TODO: Add support for read/write xdr fns when std not available.
 
@@ -70,6 +77,14 @@ impl From<core::str::Utf8Error> for Error {
     #[must_use]
     fn from(e: core::str::Utf8Error) -> Self {
         Error::Utf8Error(e)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<FromUtf8Error> for Error {
+    #[must_use]
+    fn from(e: FromUtf8Error) -> Self {
+        Error::Utf8Error(e.utf8_error())
     }
 }
 
@@ -506,13 +521,27 @@ where
 }
 
 #[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(VecM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
     fn try_from(v: String) -> Result<Self> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
-            Ok(VecM(v.as_bytes().to_vec()))
+            Ok(VecM(v.into()))
         } else {
             Err(Error::LengthExceedsMax)
         }
@@ -524,6 +553,15 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
     fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -535,7 +573,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     fn try_from(v: &str) -> Result<Self> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
-            Ok(VecM(v.as_bytes().to_vec()))
+            Ok(VecM(v.into()))
         } else {
             Err(Error::LengthExceedsMax)
         }

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -23,7 +23,14 @@ use noalloc::{boxed::Box, vec::Vec};
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
-use alloc::{borrow::ToOwned, boxed::Box, string::String, vec::Vec};
+use alloc::{
+    borrow::ToOwned,
+    boxed::Box,
+    string::{FromUtf8Error, String},
+    vec::Vec,
+};
+#[cfg(all(feature = "std"))]
+use std::string::FromUtf8Error;
 
 // TODO: Add support for read/write xdr fns when std not available.
 
@@ -73,6 +80,14 @@ impl From<core::str::Utf8Error> for Error {
     #[must_use]
     fn from(e: core::str::Utf8Error) -> Self {
         Error::Utf8Error(e)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<FromUtf8Error> for Error {
+    #[must_use]
+    fn from(e: FromUtf8Error) -> Self {
+        Error::Utf8Error(e.utf8_error())
     }
 }
 
@@ -509,13 +524,27 @@ where
 }
 
 #[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(VecM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
     fn try_from(v: String) -> Result<Self> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
-            Ok(VecM(v.as_bytes().to_vec()))
+            Ok(VecM(v.into()))
         } else {
             Err(Error::LengthExceedsMax)
         }
@@ -527,6 +556,15 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
     fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -538,7 +576,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     fn try_from(v: &str) -> Result<Self> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
-            Ok(VecM(v.as_bytes().to_vec()))
+            Ok(VecM(v.into()))
         } else {
             Err(Error::LengthExceedsMax)
         }

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -23,7 +23,14 @@ use noalloc::{boxed::Box, vec::Vec};
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
-use alloc::{borrow::ToOwned, boxed::Box, string::String, vec::Vec};
+use alloc::{
+    borrow::ToOwned,
+    boxed::Box,
+    string::{FromUtf8Error, String},
+    vec::Vec,
+};
+#[cfg(all(feature = "std"))]
+use std::string::FromUtf8Error;
 
 // TODO: Add support for read/write xdr fns when std not available.
 
@@ -73,6 +80,14 @@ impl From<core::str::Utf8Error> for Error {
     #[must_use]
     fn from(e: core::str::Utf8Error) -> Self {
         Error::Utf8Error(e)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<FromUtf8Error> for Error {
+    #[must_use]
+    fn from(e: FromUtf8Error) -> Self {
+        Error::Utf8Error(e.utf8_error())
     }
 }
 
@@ -509,13 +524,27 @@ where
 }
 
 #[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(VecM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
     fn try_from(v: String) -> Result<Self> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
-            Ok(VecM(v.as_bytes().to_vec()))
+            Ok(VecM(v.into()))
         } else {
             Err(Error::LengthExceedsMax)
         }
@@ -527,6 +556,15 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
     fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -538,7 +576,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     fn try_from(v: &str) -> Result<Self> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
-            Ok(VecM(v.as_bytes().to_vec()))
+            Ok(VecM(v.into()))
         } else {
             Err(Error::LengthExceedsMax)
         }

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -23,7 +23,14 @@ use noalloc::{boxed::Box, vec::Vec};
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
-use alloc::{borrow::ToOwned, boxed::Box, string::String, vec::Vec};
+use alloc::{
+    borrow::ToOwned,
+    boxed::Box,
+    string::{FromUtf8Error, String},
+    vec::Vec,
+};
+#[cfg(all(feature = "std"))]
+use std::string::FromUtf8Error;
 
 // TODO: Add support for read/write xdr fns when std not available.
 
@@ -73,6 +80,14 @@ impl From<core::str::Utf8Error> for Error {
     #[must_use]
     fn from(e: core::str::Utf8Error) -> Self {
         Error::Utf8Error(e)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<FromUtf8Error> for Error {
+    #[must_use]
+    fn from(e: FromUtf8Error) -> Self {
+        Error::Utf8Error(e.utf8_error())
     }
 }
 
@@ -509,13 +524,27 @@ where
 }
 
 #[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(VecM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
     fn try_from(v: String) -> Result<Self> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
-            Ok(VecM(v.as_bytes().to_vec()))
+            Ok(VecM(v.into()))
         } else {
             Err(Error::LengthExceedsMax)
         }
@@ -527,6 +556,15 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
     fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -538,7 +576,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     fn try_from(v: &str) -> Result<Self> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
-            Ok(VecM(v.as_bytes().to_vec()))
+            Ok(VecM(v.into()))
         } else {
             Err(Error::LengthExceedsMax)
         }

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -23,7 +23,14 @@ use noalloc::{boxed::Box, vec::Vec};
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
-use alloc::{borrow::ToOwned, boxed::Box, string::String, vec::Vec};
+use alloc::{
+    borrow::ToOwned,
+    boxed::Box,
+    string::{FromUtf8Error, String},
+    vec::Vec,
+};
+#[cfg(all(feature = "std"))]
+use std::string::FromUtf8Error;
 
 // TODO: Add support for read/write xdr fns when std not available.
 
@@ -73,6 +80,14 @@ impl From<core::str::Utf8Error> for Error {
     #[must_use]
     fn from(e: core::str::Utf8Error) -> Self {
         Error::Utf8Error(e)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<FromUtf8Error> for Error {
+    #[must_use]
+    fn from(e: FromUtf8Error) -> Self {
+        Error::Utf8Error(e.utf8_error())
     }
 }
 
@@ -509,13 +524,27 @@ where
 }
 
 #[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(VecM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
     fn try_from(v: String) -> Result<Self> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
-            Ok(VecM(v.as_bytes().to_vec()))
+            Ok(VecM(v.into()))
         } else {
             Err(Error::LengthExceedsMax)
         }
@@ -527,6 +556,15 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
     fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -538,7 +576,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     fn try_from(v: &str) -> Result<Self> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
-            Ok(VecM(v.as_bytes().to_vec()))
+            Ok(VecM(v.into()))
         } else {
             Err(Error::LengthExceedsMax)
         }

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -23,7 +23,14 @@ use noalloc::{boxed::Box, vec::Vec};
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
-use alloc::{borrow::ToOwned, boxed::Box, string::String, vec::Vec};
+use alloc::{
+    borrow::ToOwned,
+    boxed::Box,
+    string::{FromUtf8Error, String},
+    vec::Vec,
+};
+#[cfg(all(feature = "std"))]
+use std::string::FromUtf8Error;
 
 // TODO: Add support for read/write xdr fns when std not available.
 
@@ -73,6 +80,14 @@ impl From<core::str::Utf8Error> for Error {
     #[must_use]
     fn from(e: core::str::Utf8Error) -> Self {
         Error::Utf8Error(e)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<FromUtf8Error> for Error {
+    #[must_use]
+    fn from(e: FromUtf8Error) -> Self {
+        Error::Utf8Error(e.utf8_error())
     }
 }
 
@@ -509,13 +524,27 @@ where
 }
 
 #[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(VecM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
     fn try_from(v: String) -> Result<Self> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
-            Ok(VecM(v.as_bytes().to_vec()))
+            Ok(VecM(v.into()))
         } else {
             Err(Error::LengthExceedsMax)
         }
@@ -527,6 +556,15 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
     fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -538,7 +576,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     fn try_from(v: &str) -> Result<Self> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
-            Ok(VecM(v.as_bytes().to_vec()))
+            Ok(VecM(v.into()))
         } else {
             Err(Error::LengthExceedsMax)
         }

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -23,7 +23,14 @@ use noalloc::{boxed::Box, vec::Vec};
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
-use alloc::{borrow::ToOwned, boxed::Box, string::String, vec::Vec};
+use alloc::{
+    borrow::ToOwned,
+    boxed::Box,
+    string::{FromUtf8Error, String},
+    vec::Vec,
+};
+#[cfg(all(feature = "std"))]
+use std::string::FromUtf8Error;
 
 // TODO: Add support for read/write xdr fns when std not available.
 
@@ -73,6 +80,14 @@ impl From<core::str::Utf8Error> for Error {
     #[must_use]
     fn from(e: core::str::Utf8Error) -> Self {
         Error::Utf8Error(e)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<FromUtf8Error> for Error {
+    #[must_use]
+    fn from(e: FromUtf8Error) -> Self {
+        Error::Utf8Error(e.utf8_error())
     }
 }
 
@@ -509,13 +524,27 @@ where
 }
 
 #[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(VecM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
     fn try_from(v: String) -> Result<Self> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
-            Ok(VecM(v.as_bytes().to_vec()))
+            Ok(VecM(v.into()))
         } else {
             Err(Error::LengthExceedsMax)
         }
@@ -527,6 +556,15 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
     fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -538,7 +576,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     fn try_from(v: &str) -> Result<Self> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
-            Ok(VecM(v.as_bytes().to_vec()))
+            Ok(VecM(v.into()))
         } else {
             Err(Error::LengthExceedsMax)
         }

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -23,7 +23,14 @@ use noalloc::{boxed::Box, vec::Vec};
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
-use alloc::{borrow::ToOwned, boxed::Box, string::String, vec::Vec};
+use alloc::{
+    borrow::ToOwned,
+    boxed::Box,
+    string::{FromUtf8Error, String},
+    vec::Vec,
+};
+#[cfg(all(feature = "std"))]
+use std::string::FromUtf8Error;
 
 // TODO: Add support for read/write xdr fns when std not available.
 
@@ -73,6 +80,14 @@ impl From<core::str::Utf8Error> for Error {
     #[must_use]
     fn from(e: core::str::Utf8Error) -> Self {
         Error::Utf8Error(e)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<FromUtf8Error> for Error {
+    #[must_use]
+    fn from(e: FromUtf8Error) -> Self {
+        Error::Utf8Error(e.utf8_error())
     }
 }
 
@@ -509,13 +524,27 @@ where
 }
 
 #[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(VecM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
     fn try_from(v: String) -> Result<Self> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
-            Ok(VecM(v.as_bytes().to_vec()))
+            Ok(VecM(v.into()))
         } else {
             Err(Error::LengthExceedsMax)
         }
@@ -527,6 +556,15 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
     fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -538,7 +576,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     fn try_from(v: &str) -> Result<Self> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
-            Ok(VecM(v.as_bytes().to_vec()))
+            Ok(VecM(v.into()))
         } else {
             Err(Error::LengthExceedsMax)
         }

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -23,7 +23,14 @@ use noalloc::{boxed::Box, vec::Vec};
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
-use alloc::{borrow::ToOwned, boxed::Box, string::String, vec::Vec};
+use alloc::{
+    borrow::ToOwned,
+    boxed::Box,
+    string::{FromUtf8Error, String},
+    vec::Vec,
+};
+#[cfg(all(feature = "std"))]
+use std::string::FromUtf8Error;
 
 // TODO: Add support for read/write xdr fns when std not available.
 
@@ -73,6 +80,14 @@ impl From<core::str::Utf8Error> for Error {
     #[must_use]
     fn from(e: core::str::Utf8Error) -> Self {
         Error::Utf8Error(e)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<FromUtf8Error> for Error {
+    #[must_use]
+    fn from(e: FromUtf8Error) -> Self {
+        Error::Utf8Error(e.utf8_error())
     }
 }
 
@@ -509,13 +524,27 @@ where
 }
 
 #[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(VecM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
     fn try_from(v: String) -> Result<Self> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
-            Ok(VecM(v.as_bytes().to_vec()))
+            Ok(VecM(v.into()))
         } else {
             Err(Error::LengthExceedsMax)
         }
@@ -527,6 +556,15 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
     fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -538,7 +576,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     fn try_from(v: &str) -> Result<Self> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
-            Ok(VecM(v.as_bytes().to_vec()))
+            Ok(VecM(v.into()))
         } else {
             Err(Error::LengthExceedsMax)
         }


### PR DESCRIPTION
### What
Clean up the String<>VecM conversions so that there are owned and non-owned conversions, and owned conversions do not allocate.

### Why
The existing conversions took owned values and then allocated unnecessarily.