### PR TITLE
Rust: Add to/from xdr bytes

### DIFF
--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -102,6 +102,13 @@ where
     }
 
     #[cfg(feature = "std")]
+    fn from_xdr<B: AsRef<[u8]>>(bytes: B) -> Result<Self> {
+        let mut cursor = Cursor::new(bytes.as_ref());
+        let t = Self::read_xdr(&mut cursor)?;
+        Ok(t)
+    }
+
+    #[cfg(feature = "std")]
     fn from_xdr_base64(b64: String) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
@@ -113,6 +120,14 @@ where
 pub trait WriteXdr {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()>;
+
+    #[cfg(feature = "std")]
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        let mut cursor = Cursor::new(vec![]);
+        self.write_xdr(&mut cursor)?;
+        let bytes = cursor.into_inner();
+        Ok(bytes)
+    }
 
     #[cfg(feature = "std")]
     fn to_xdr_base64(&self) -> Result<String> {

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -105,6 +105,13 @@ where
     }
 
     #[cfg(feature = "std")]
+    fn from_xdr<B: AsRef<[u8]>>(bytes: B) -> Result<Self> {
+        let mut cursor = Cursor::new(bytes.as_ref());
+        let t = Self::read_xdr(&mut cursor)?;
+        Ok(t)
+    }
+
+    #[cfg(feature = "std")]
     fn from_xdr_base64(b64: String) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
@@ -116,6 +123,14 @@ where
 pub trait WriteXdr {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()>;
+
+    #[cfg(feature = "std")]
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        let mut cursor = Cursor::new(vec![]);
+        self.write_xdr(&mut cursor)?;
+        let bytes = cursor.into_inner();
+        Ok(bytes)
+    }
 
     #[cfg(feature = "std")]
     fn to_xdr_base64(&self) -> Result<String> {

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -105,6 +105,13 @@ where
     }
 
     #[cfg(feature = "std")]
+    fn from_xdr<B: AsRef<[u8]>>(bytes: B) -> Result<Self> {
+        let mut cursor = Cursor::new(bytes.as_ref());
+        let t = Self::read_xdr(&mut cursor)?;
+        Ok(t)
+    }
+
+    #[cfg(feature = "std")]
     fn from_xdr_base64(b64: String) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
@@ -116,6 +123,14 @@ where
 pub trait WriteXdr {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()>;
+
+    #[cfg(feature = "std")]
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        let mut cursor = Cursor::new(vec![]);
+        self.write_xdr(&mut cursor)?;
+        let bytes = cursor.into_inner();
+        Ok(bytes)
+    }
 
     #[cfg(feature = "std")]
     fn to_xdr_base64(&self) -> Result<String> {

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -105,6 +105,13 @@ where
     }
 
     #[cfg(feature = "std")]
+    fn from_xdr<B: AsRef<[u8]>>(bytes: B) -> Result<Self> {
+        let mut cursor = Cursor::new(bytes.as_ref());
+        let t = Self::read_xdr(&mut cursor)?;
+        Ok(t)
+    }
+
+    #[cfg(feature = "std")]
     fn from_xdr_base64(b64: String) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
@@ -116,6 +123,14 @@ where
 pub trait WriteXdr {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()>;
+
+    #[cfg(feature = "std")]
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        let mut cursor = Cursor::new(vec![]);
+        self.write_xdr(&mut cursor)?;
+        let bytes = cursor.into_inner();
+        Ok(bytes)
+    }
 
     #[cfg(feature = "std")]
     fn to_xdr_base64(&self) -> Result<String> {

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -105,6 +105,13 @@ where
     }
 
     #[cfg(feature = "std")]
+    fn from_xdr<B: AsRef<[u8]>>(bytes: B) -> Result<Self> {
+        let mut cursor = Cursor::new(bytes.as_ref());
+        let t = Self::read_xdr(&mut cursor)?;
+        Ok(t)
+    }
+
+    #[cfg(feature = "std")]
     fn from_xdr_base64(b64: String) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
@@ -116,6 +123,14 @@ where
 pub trait WriteXdr {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()>;
+
+    #[cfg(feature = "std")]
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        let mut cursor = Cursor::new(vec![]);
+        self.write_xdr(&mut cursor)?;
+        let bytes = cursor.into_inner();
+        Ok(bytes)
+    }
 
     #[cfg(feature = "std")]
     fn to_xdr_base64(&self) -> Result<String> {

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -105,6 +105,13 @@ where
     }
 
     #[cfg(feature = "std")]
+    fn from_xdr<B: AsRef<[u8]>>(bytes: B) -> Result<Self> {
+        let mut cursor = Cursor::new(bytes.as_ref());
+        let t = Self::read_xdr(&mut cursor)?;
+        Ok(t)
+    }
+
+    #[cfg(feature = "std")]
     fn from_xdr_base64(b64: String) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
@@ -116,6 +123,14 @@ where
 pub trait WriteXdr {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()>;
+
+    #[cfg(feature = "std")]
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        let mut cursor = Cursor::new(vec![]);
+        self.write_xdr(&mut cursor)?;
+        let bytes = cursor.into_inner();
+        Ok(bytes)
+    }
 
     #[cfg(feature = "std")]
     fn to_xdr_base64(&self) -> Result<String> {

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -105,6 +105,13 @@ where
     }
 
     #[cfg(feature = "std")]
+    fn from_xdr<B: AsRef<[u8]>>(bytes: B) -> Result<Self> {
+        let mut cursor = Cursor::new(bytes.as_ref());
+        let t = Self::read_xdr(&mut cursor)?;
+        Ok(t)
+    }
+
+    #[cfg(feature = "std")]
     fn from_xdr_base64(b64: String) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
@@ -116,6 +123,14 @@ where
 pub trait WriteXdr {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()>;
+
+    #[cfg(feature = "std")]
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        let mut cursor = Cursor::new(vec![]);
+        self.write_xdr(&mut cursor)?;
+        let bytes = cursor.into_inner();
+        Ok(bytes)
+    }
 
     #[cfg(feature = "std")]
     fn to_xdr_base64(&self) -> Result<String> {

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -105,6 +105,13 @@ where
     }
 
     #[cfg(feature = "std")]
+    fn from_xdr<B: AsRef<[u8]>>(bytes: B) -> Result<Self> {
+        let mut cursor = Cursor::new(bytes.as_ref());
+        let t = Self::read_xdr(&mut cursor)?;
+        Ok(t)
+    }
+
+    #[cfg(feature = "std")]
     fn from_xdr_base64(b64: String) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
@@ -116,6 +123,14 @@ where
 pub trait WriteXdr {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()>;
+
+    #[cfg(feature = "std")]
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        let mut cursor = Cursor::new(vec![]);
+        self.write_xdr(&mut cursor)?;
+        let bytes = cursor.into_inner();
+        Ok(bytes)
+    }
 
     #[cfg(feature = "std")]
     fn to_xdr_base64(&self) -> Result<String> {

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -105,6 +105,13 @@ where
     }
 
     #[cfg(feature = "std")]
+    fn from_xdr<B: AsRef<[u8]>>(bytes: B) -> Result<Self> {
+        let mut cursor = Cursor::new(bytes.as_ref());
+        let t = Self::read_xdr(&mut cursor)?;
+        Ok(t)
+    }
+
+    #[cfg(feature = "std")]
     fn from_xdr_base64(b64: String) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
@@ -116,6 +123,14 @@ where
 pub trait WriteXdr {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()>;
+
+    #[cfg(feature = "std")]
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        let mut cursor = Cursor::new(vec![]);
+        self.write_xdr(&mut cursor)?;
+        let bytes = cursor.into_inner();
+        Ok(bytes)
+    }
 
     #[cfg(feature = "std")]
     fn to_xdr_base64(&self) -> Result<String> {


### PR DESCRIPTION
### What
Add to/from xdr bytes to the Rust xdr types.

### Why
The xdr types provide convenience functions for serialization to and from base64 strings, and general readers/writers, but not byte slices/vecs. It would be convenient if it did so.