### PR TITLE
Rust: Fix to_vec and add to_string

### DIFF
--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -416,13 +416,23 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 
     #[must_use]
-    pub fn to_vec(self) -> Vec<T> {
-        self.into()
-    }
-
-    #[must_use]
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
+    }
+}
+
+impl<T: Clone, const MAX: u32> VecM<T, MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<T> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> VecM<u8, MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
     }
 }
 
@@ -443,6 +453,14 @@ impl<T, const MAX: u32> From<VecM<T, MAX>> for Vec<T> {
     #[must_use]
     fn from(v: VecM<T, MAX>) -> Self {
         v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> From<&VecM<T, MAX>> for Vec<T> {
+    #[must_use]
+    fn from(v: &VecM<T, MAX>) -> Self {
+        v.0.clone()
     }
 }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -427,11 +427,21 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     pub fn to_vec(&self) -> Vec<T> {
         self.into()
     }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<T> {
+        self.into()
+    }
 }
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
     pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
         self.try_into()
     }
 }

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -419,13 +419,23 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 
     #[must_use]
-    pub fn to_vec(self) -> Vec<T> {
-        self.into()
-    }
-
-    #[must_use]
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
+    }
+}
+
+impl<T: Clone, const MAX: u32> VecM<T, MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<T> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> VecM<u8, MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
     }
 }
 
@@ -446,6 +456,14 @@ impl<T, const MAX: u32> From<VecM<T, MAX>> for Vec<T> {
     #[must_use]
     fn from(v: VecM<T, MAX>) -> Self {
         v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> From<&VecM<T, MAX>> for Vec<T> {
+    #[must_use]
+    fn from(v: &VecM<T, MAX>) -> Self {
+        v.0.clone()
     }
 }
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -430,11 +430,21 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     pub fn to_vec(&self) -> Vec<T> {
         self.into()
     }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<T> {
+        self.into()
+    }
 }
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
     pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
         self.try_into()
     }
 }

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -419,13 +419,23 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 
     #[must_use]
-    pub fn to_vec(self) -> Vec<T> {
-        self.into()
-    }
-
-    #[must_use]
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
+    }
+}
+
+impl<T: Clone, const MAX: u32> VecM<T, MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<T> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> VecM<u8, MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
     }
 }
 
@@ -446,6 +456,14 @@ impl<T, const MAX: u32> From<VecM<T, MAX>> for Vec<T> {
     #[must_use]
     fn from(v: VecM<T, MAX>) -> Self {
         v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> From<&VecM<T, MAX>> for Vec<T> {
+    #[must_use]
+    fn from(v: &VecM<T, MAX>) -> Self {
+        v.0.clone()
     }
 }
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -430,11 +430,21 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     pub fn to_vec(&self) -> Vec<T> {
         self.into()
     }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<T> {
+        self.into()
+    }
 }
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
     pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
         self.try_into()
     }
 }

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -419,13 +419,23 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 
     #[must_use]
-    pub fn to_vec(self) -> Vec<T> {
-        self.into()
-    }
-
-    #[must_use]
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
+    }
+}
+
+impl<T: Clone, const MAX: u32> VecM<T, MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<T> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> VecM<u8, MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
     }
 }
 
@@ -446,6 +456,14 @@ impl<T, const MAX: u32> From<VecM<T, MAX>> for Vec<T> {
     #[must_use]
     fn from(v: VecM<T, MAX>) -> Self {
         v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> From<&VecM<T, MAX>> for Vec<T> {
+    #[must_use]
+    fn from(v: &VecM<T, MAX>) -> Self {
+        v.0.clone()
     }
 }
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -430,11 +430,21 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     pub fn to_vec(&self) -> Vec<T> {
         self.into()
     }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<T> {
+        self.into()
+    }
 }
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
     pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
         self.try_into()
     }
 }

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -419,13 +419,23 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 
     #[must_use]
-    pub fn to_vec(self) -> Vec<T> {
-        self.into()
-    }
-
-    #[must_use]
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
+    }
+}
+
+impl<T: Clone, const MAX: u32> VecM<T, MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<T> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> VecM<u8, MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
     }
 }
 
@@ -446,6 +456,14 @@ impl<T, const MAX: u32> From<VecM<T, MAX>> for Vec<T> {
     #[must_use]
     fn from(v: VecM<T, MAX>) -> Self {
         v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> From<&VecM<T, MAX>> for Vec<T> {
+    #[must_use]
+    fn from(v: &VecM<T, MAX>) -> Self {
+        v.0.clone()
     }
 }
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -430,11 +430,21 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     pub fn to_vec(&self) -> Vec<T> {
         self.into()
     }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<T> {
+        self.into()
+    }
 }
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
     pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
         self.try_into()
     }
 }

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -419,13 +419,23 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 
     #[must_use]
-    pub fn to_vec(self) -> Vec<T> {
-        self.into()
-    }
-
-    #[must_use]
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
+    }
+}
+
+impl<T: Clone, const MAX: u32> VecM<T, MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<T> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> VecM<u8, MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
     }
 }
 
@@ -446,6 +456,14 @@ impl<T, const MAX: u32> From<VecM<T, MAX>> for Vec<T> {
     #[must_use]
     fn from(v: VecM<T, MAX>) -> Self {
         v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> From<&VecM<T, MAX>> for Vec<T> {
+    #[must_use]
+    fn from(v: &VecM<T, MAX>) -> Self {
+        v.0.clone()
     }
 }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -430,11 +430,21 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     pub fn to_vec(&self) -> Vec<T> {
         self.into()
     }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<T> {
+        self.into()
+    }
 }
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
     pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
         self.try_into()
     }
 }

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -419,13 +419,23 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 
     #[must_use]
-    pub fn to_vec(self) -> Vec<T> {
-        self.into()
-    }
-
-    #[must_use]
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
+    }
+}
+
+impl<T: Clone, const MAX: u32> VecM<T, MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<T> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> VecM<u8, MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
     }
 }
 
@@ -446,6 +456,14 @@ impl<T, const MAX: u32> From<VecM<T, MAX>> for Vec<T> {
     #[must_use]
     fn from(v: VecM<T, MAX>) -> Self {
         v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> From<&VecM<T, MAX>> for Vec<T> {
+    #[must_use]
+    fn from(v: &VecM<T, MAX>) -> Self {
+        v.0.clone()
     }
 }
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -430,11 +430,21 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     pub fn to_vec(&self) -> Vec<T> {
         self.into()
     }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<T> {
+        self.into()
+    }
 }
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
     pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
         self.try_into()
     }
 }

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -419,13 +419,23 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 
     #[must_use]
-    pub fn to_vec(self) -> Vec<T> {
-        self.into()
-    }
-
-    #[must_use]
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
+    }
+}
+
+impl<T: Clone, const MAX: u32> VecM<T, MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<T> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> VecM<u8, MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
     }
 }
 
@@ -446,6 +456,14 @@ impl<T, const MAX: u32> From<VecM<T, MAX>> for Vec<T> {
     #[must_use]
     fn from(v: VecM<T, MAX>) -> Self {
         v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> From<&VecM<T, MAX>> for Vec<T> {
+    #[must_use]
+    fn from(v: &VecM<T, MAX>) -> Self {
+        v.0.clone()
     }
 }
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -430,11 +430,21 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     pub fn to_vec(&self) -> Vec<T> {
         self.into()
     }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<T> {
+        self.into()
+    }
 }
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
     pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
         self.try_into()
     }
 }

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -419,13 +419,23 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 
     #[must_use]
-    pub fn to_vec(self) -> Vec<T> {
-        self.into()
-    }
-
-    #[must_use]
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
+    }
+}
+
+impl<T: Clone, const MAX: u32> VecM<T, MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<T> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> VecM<u8, MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
     }
 }
 
@@ -446,6 +456,14 @@ impl<T, const MAX: u32> From<VecM<T, MAX>> for Vec<T> {
     #[must_use]
     fn from(v: VecM<T, MAX>) -> Self {
         v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> From<&VecM<T, MAX>> for Vec<T> {
+    #[must_use]
+    fn from(v: &VecM<T, MAX>) -> Self {
+        v.0.clone()
     }
 }
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -430,11 +430,21 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     pub fn to_vec(&self) -> Vec<T> {
         self.into()
     }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<T> {
+        self.into()
+    }
 }
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
     pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
         self.try_into()
     }
 }


### PR DESCRIPTION
### What
Make to_vec not consume the vec and create a new vec. Add to_string to do same as vec but for a string.

### Why
to_ functions should not consume an owned type unless they are Copy. The to_string function is helpful because we use VecM's for strings, and it is not always convenient to try_into a string.