### PR TITLE
Rust: Add name fn to enums, unions

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -180,6 +180,18 @@ module Xdrgen
         out.puts '}'
         out.puts ""
         out.puts <<-EOS.strip_heredoc
+        impl #{name enum} {
+            #[must_use]
+            pub fn name(&self) -> &str {
+                #[allow(clippy::match_same_arms)]
+                match self {
+                    #{enum.members.map do |m|
+                      "Self::#{name m} => \"#{name m}\","
+                    end.join("\n")}
+                }
+            }
+        }
+
         impl TryFrom<i32> for #{name enum} {
             type Error = Error;
 
@@ -259,6 +271,16 @@ module Xdrgen
         out.puts ""
         out.puts <<-EOS.strip_heredoc
         impl #{name union} {
+            #[must_use]
+            pub fn name(&self) -> &str {
+                #[allow(clippy::match_same_arms)]
+                match self {
+                    #{union_cases(union) do |case_name, arm|
+                      "Self::#{case_name}#{"(_)" unless arm.void?} => \"#{case_name}\","
+                    end.join("\n")}
+                }
+            }
+
             #[must_use]
             pub fn discriminant(&self) -> #{discriminant_type} {
                 #[allow(clippy::match_same_arms)]

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -843,6 +843,16 @@ pub enum AccountFlags {
   AuthRequiredFlag = 1,
 }
 
+impl AccountFlags {
+    #[must_use]
+    pub fn name(&self) -> &str {
+        #[allow(clippy::match_same_arms)]
+        match self {
+            Self::AuthRequiredFlag => "AuthRequiredFlag",
+        }
+    }
+}
+
 impl TryFrom<i32> for AccountFlags {
     type Error = Error;
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -875,6 +875,29 @@ pub enum MessageType {
   FbaMessage = 13,
 }
 
+        impl MessageType {
+            #[must_use]
+            pub fn name(&self) -> &str {
+                #[allow(clippy::match_same_arms)]
+                match self {
+                    Self::ErrorMsg => "ErrorMsg",
+Self::Hello => "Hello",
+Self::DontHave => "DontHave",
+Self::GetPeers => "GetPeers",
+Self::Peers => "Peers",
+Self::GetTxSet => "GetTxSet",
+Self::TxSet => "TxSet",
+Self::GetValidations => "GetValidations",
+Self::Validations => "Validations",
+Self::Transaction => "Transaction",
+Self::JsonTransaction => "JsonTransaction",
+Self::GetFbaQuorumset => "GetFbaQuorumset",
+Self::FbaQuorumset => "FbaQuorumset",
+Self::FbaMessage => "FbaMessage",
+                }
+            }
+        }
+
         impl TryFrom<i32> for MessageType {
             type Error = Error;
 
@@ -942,6 +965,18 @@ pub enum Color {
   Blue = 2,
 }
 
+        impl Color {
+            #[must_use]
+            pub fn name(&self) -> &str {
+                #[allow(clippy::match_same_arms)]
+                match self {
+                    Self::Red => "Red",
+Self::Green => "Green",
+Self::Blue => "Blue",
+                }
+            }
+        }
+
         impl TryFrom<i32> for Color {
             type Error = Error;
 
@@ -997,6 +1032,18 @@ pub enum Color2 {
   Green2 = 1,
   Blue2 = 2,
 }
+
+        impl Color2 {
+            #[must_use]
+            pub fn name(&self) -> &str {
+                #[allow(clippy::match_same_arms)]
+                match self {
+                    Self::Red2 => "Red2",
+Self::Green2 => "Green2",
+Self::Blue2 => "Blue2",
+                }
+            }
+        }
 
         impl TryFrom<i32> for Color2 {
             type Error = Error;

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -846,6 +846,18 @@ pub enum UnionKey {
   Offer = 3,
 }
 
+        impl UnionKey {
+            #[must_use]
+            pub fn name(&self) -> &str {
+                #[allow(clippy::match_same_arms)]
+                match self {
+                    Self::One => "One",
+Self::Two => "Two",
+Self::Offer => "Offer",
+                }
+            }
+        }
+
         impl TryFrom<i32> for UnionKey {
             type Error = Error;
 
@@ -979,6 +991,16 @@ pub enum MyUnion {
 }
 
         impl MyUnion {
+            #[must_use]
+            pub fn name(&self) -> &str {
+                #[allow(clippy::match_same_arms)]
+                match self {
+                    Self::One(_) => "One",
+Self::Two(_) => "Two",
+Self::Offer => "Offer",
+                }
+            }
+
             #[must_use]
             pub fn discriminant(&self) -> UnionKey {
                 #[allow(clippy::match_same_arms)]

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -1553,6 +1553,18 @@ pub enum Color {
   Green = 6,
 }
 
+        impl Color {
+            #[must_use]
+            pub fn name(&self) -> &str {
+                #[allow(clippy::match_same_arms)]
+                match self {
+                    Self::Red => "Red",
+Self::Blue => "Blue",
+Self::Green => "Green",
+                }
+            }
+        }
+
         impl TryFrom<i32> for Color {
             type Error = Error;
 
@@ -1618,6 +1630,17 @@ pub enum NesterNestedEnum {
   1 = 0,
   2 = 1,
 }
+
+        impl NesterNestedEnum {
+            #[must_use]
+            pub fn name(&self) -> &str {
+                #[allow(clippy::match_same_arms)]
+                match self {
+                    Self::1 => "1",
+Self::2 => "2",
+                }
+            }
+        }
 
         impl TryFrom<i32> for NesterNestedEnum {
             type Error = Error;
@@ -1701,6 +1724,14 @@ pub enum NesterNestedUnion {
 }
 
 impl NesterNestedUnion {
+    #[must_use]
+    pub fn name(&self) -> &str {
+        #[allow(clippy::match_same_arms)]
+        match self {
+            Self::Red => "Red",
+        }
+    }
+
     #[must_use]
     pub fn discriminant(&self) -> Color {
         #[allow(clippy::match_same_arms)]

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -856,6 +856,17 @@ pub enum UnionKey {
   Multi = 1,
 }
 
+        impl UnionKey {
+            #[must_use]
+            pub fn name(&self) -> &str {
+                #[allow(clippy::match_same_arms)]
+                match self {
+                    Self::Error => "Error",
+Self::Multi => "Multi",
+                }
+            }
+        }
+
         impl TryFrom<i32> for UnionKey {
             type Error = Error;
 
@@ -915,6 +926,15 @@ pub enum MyUnion {
 
         impl MyUnion {
             #[must_use]
+            pub fn name(&self) -> &str {
+                #[allow(clippy::match_same_arms)]
+                match self {
+                    Self::Error(_) => "Error",
+Self::Multi(_) => "Multi",
+                }
+            }
+
+            #[must_use]
             pub fn discriminant(&self) -> UnionKey {
                 #[allow(clippy::match_same_arms)]
                 match self {
@@ -971,6 +991,15 @@ pub enum IntUnion {
 }
 
         impl IntUnion {
+            #[must_use]
+            pub fn name(&self) -> &str {
+                #[allow(clippy::match_same_arms)]
+                match self {
+                    Self::V0(_) => "V0",
+Self::V1(_) => "V1",
+                }
+            }
+
             #[must_use]
             pub fn discriminant(&self) -> i32 {
                 #[allow(clippy::match_same_arms)]


### PR DESCRIPTION
### What
Add name fn to enums and unions that returns a string representation of the case.

### Why
@graydon mentioned that it is needed in the host.