### PR TITLE
Rust: add read_xdr_iter

### DIFF
--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -124,7 +124,7 @@ impl<'r, R: Read, S: ReadXdr> ReadXdrIter<'r, R, S> {
 impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
     type Item = Result<S>;
 
-    // Next reads the internal reader and XDR decoded it into the Self type. If
+    // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
     // EOF is reached after reading some bytes a truncated entry is assumed an
     // an `Error::Io` containing an `UnexpectedEof`. If any other IO error

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -125,7 +125,7 @@ impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
         match S::read_xdr(&mut self.r) {
             Ok(s) => Some(Ok(s)),
             // TODO: Distinguish between EOF and EOF-with-a-partial-fill. An EOF
-            // that occurs at teh end of an item indicates the end of a stream
+            // that occurs at the end of an item indicates the end of a stream
             // and should end iteration. An EOF that occurs whilst reading an
             // item indicates a corrupt stream and should cause an error. The
             // xdr types use the `std::io::Read::read_exact` method that

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -35,7 +35,7 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "std")]
 use std::{
     error, io,
-    io::{Cursor, Read, Write},
+    io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
 #[derive(Debug)]
@@ -106,14 +106,17 @@ type Result<T> = core::result::Result<T, Error>;
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
-    r: &'r mut R,
+    reader: BufReader<&'r mut R>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<'r, R: Read, S: ReadXdr> ReadXdrIter<'r, R, S> {
     fn new(r: &'r mut R) -> Self {
-        Self { r, _s: PhantomData }
+        Self {
+            reader: BufReader::new(r),
+            _s: PhantomData,
+        }
     }
 }
 
@@ -121,17 +124,32 @@ impl<'r, R: Read, S: ReadXdr> ReadXdrIter<'r, R, S> {
 impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
     type Item = Result<S>;
 
+    // Next reads the internal reader and XDR decoded it into the Self type. If
+    // the EOF is reached without reading any new bytes `None` is returned. If
+    // EOF is reached after reading some bytes a truncated entry is assumed an
+    // an `Error::Io` containing an `UnexpectedEof`. If any other IO error
+    // occurs it is returned. Iteration of this iterator stops naturally when
+    // `None` is returned, but not when a `Some(Err(...))` is returned. The
+    // caller is responsible for checking each Result.
     fn next(&mut self) -> Option<Self::Item> {
-        match S::read_xdr(&mut self.r) {
+        // Try to fill the buffer to see if the EOF has been reached or not.
+        // This happens to effectively peek to see if the stream has finished
+        // and there are no more items.  It is necessary to do this because the
+        // xdr types in this crate heavily use the `std::io::Read::read_exact`
+        // method that doesn't distinguish between an EOF at the beginning of a
+        // read and an EOF after a partial fill of a read_exact.
+        match self.reader.fill_buf() {
+            // If the reader has no more data and is unable to fill any new data
+            // into its internal buf, then the EOF has been reached.
+            Ok([]) => return None,
+            // If an error occurs filling the buffer, treat that as an error and stop.
+            Err(e) => return Some(Err(Error::Io(e))),
+            // If there is data in the buf available for reading, continue.
+            Ok([..]) => (),
+        };
+        // Read the buf into the type.
+        match S::read_xdr(&mut self.reader) {
             Ok(s) => Some(Ok(s)),
-            // TODO: Distinguish between EOF and EOF-with-a-partial-fill. An EOF
-            // that occurs at the end of an item indicates the end of a stream
-            // and should end iteration. An EOF that occurs whilst reading an
-            // item indicates a corrupt stream and should cause an error. The
-            // xdr types use the `std::io::Read::read_exact` method that
-            // unfortunately doesn't distinguish between these two extremely
-            // different events.
-            Err(Error::Io(e)) if e.kind() == io::ErrorKind::UnexpectedEof => None,
             Err(e) => Some(Err(e)),
         }
     }

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -135,7 +135,7 @@ impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
         match S::read_xdr(&mut self.r) {
             Ok(s) => Some(Ok(s)),
             // TODO: Distinguish between EOF and EOF-with-a-partial-fill. An EOF
-            // that occurs at teh end of an item indicates the end of a stream
+            // that occurs at the end of an item indicates the end of a stream
             // and should end iteration. An EOF that occurs whilst reading an
             // item indicates a corrupt stream and should cause an error. The
             // xdr types use the `std::io::Read::read_exact` method that

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -134,7 +134,7 @@ impl<'r, R: Read, S: ReadXdr> ReadXdrIter<'r, R, S> {
 impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
     type Item = Result<S>;
 
-    // Next reads the internal reader and XDR decoded it into the Self type. If
+    // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
     // EOF is reached after reading some bytes a truncated entry is assumed an
     // an `Error::Io` containing an `UnexpectedEof`. If any other IO error

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -10,6 +10,9 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 
 use core::{fmt, fmt::Debug, ops::Deref};
 
+#[cfg(feature = "std")]
+use core::marker::PhantomData;
+
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
@@ -111,6 +114,39 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
+#[cfg(feature = "std")]
+pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
+    r: &'r mut R,
+    _s: PhantomData<S>,
+}
+
+#[cfg(feature = "std")]
+impl<'r, R: Read, S: ReadXdr> ReadXdrIter<'r, R, S> {
+    fn new(r: &'r mut R) -> Self {
+        Self { r, _s: PhantomData }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
+    type Item = Result<S>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match S::read_xdr(&mut self.r) {
+            Ok(s) => Some(Ok(s)),
+            // TODO: Distinguish between EOF and EOF-with-a-partial-fill. An EOF
+            // that occurs at teh end of an item indicates the end of a stream
+            // and should end iteration. An EOF that occurs whilst reading an
+            // item indicates a corrupt stream and should cause an error. The
+            // xdr types use the `std::io::Read::read_exact` method that
+            // unfortunately doesn't distinguish between these two extremely
+            // different events.
+            Err(Error::Io(e)) if e.kind() == io::ErrorKind::UnexpectedEof => None,
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
 pub trait ReadXdr
 where
     Self: Sized,
@@ -122,6 +158,11 @@ where
     fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    fn read_xdr_iter<R: Read>(r: &mut R) -> ReadXdrIter<R, Self> {
+        ReadXdrIter::new(r)
     }
 
     #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -135,7 +135,7 @@ impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
         match S::read_xdr(&mut self.r) {
             Ok(s) => Some(Ok(s)),
             // TODO: Distinguish between EOF and EOF-with-a-partial-fill. An EOF
-            // that occurs at teh end of an item indicates the end of a stream
+            // that occurs at the end of an item indicates the end of a stream
             // and should end iteration. An EOF that occurs whilst reading an
             // item indicates a corrupt stream and should cause an error. The
             // xdr types use the `std::io::Read::read_exact` method that

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -134,7 +134,7 @@ impl<'r, R: Read, S: ReadXdr> ReadXdrIter<'r, R, S> {
 impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
     type Item = Result<S>;
 
-    // Next reads the internal reader and XDR decoded it into the Self type. If
+    // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
     // EOF is reached after reading some bytes a truncated entry is assumed an
     // an `Error::Io` containing an `UnexpectedEof`. If any other IO error

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -10,6 +10,9 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 
 use core::{fmt, fmt::Debug, ops::Deref};
 
+#[cfg(feature = "std")]
+use core::marker::PhantomData;
+
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
@@ -111,6 +114,39 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
+#[cfg(feature = "std")]
+pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
+    r: &'r mut R,
+    _s: PhantomData<S>,
+}
+
+#[cfg(feature = "std")]
+impl<'r, R: Read, S: ReadXdr> ReadXdrIter<'r, R, S> {
+    fn new(r: &'r mut R) -> Self {
+        Self { r, _s: PhantomData }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
+    type Item = Result<S>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match S::read_xdr(&mut self.r) {
+            Ok(s) => Some(Ok(s)),
+            // TODO: Distinguish between EOF and EOF-with-a-partial-fill. An EOF
+            // that occurs at teh end of an item indicates the end of a stream
+            // and should end iteration. An EOF that occurs whilst reading an
+            // item indicates a corrupt stream and should cause an error. The
+            // xdr types use the `std::io::Read::read_exact` method that
+            // unfortunately doesn't distinguish between these two extremely
+            // different events.
+            Err(Error::Io(e)) if e.kind() == io::ErrorKind::UnexpectedEof => None,
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
 pub trait ReadXdr
 where
     Self: Sized,
@@ -122,6 +158,11 @@ where
     fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    fn read_xdr_iter<R: Read>(r: &mut R) -> ReadXdrIter<R, Self> {
+        ReadXdrIter::new(r)
     }
 
     #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -135,7 +135,7 @@ impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
         match S::read_xdr(&mut self.r) {
             Ok(s) => Some(Ok(s)),
             // TODO: Distinguish between EOF and EOF-with-a-partial-fill. An EOF
-            // that occurs at teh end of an item indicates the end of a stream
+            // that occurs at the end of an item indicates the end of a stream
             // and should end iteration. An EOF that occurs whilst reading an
             // item indicates a corrupt stream and should cause an error. The
             // xdr types use the `std::io::Read::read_exact` method that

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -134,7 +134,7 @@ impl<'r, R: Read, S: ReadXdr> ReadXdrIter<'r, R, S> {
 impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
     type Item = Result<S>;
 
-    // Next reads the internal reader and XDR decoded it into the Self type. If
+    // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
     // EOF is reached after reading some bytes a truncated entry is assumed an
     // an `Error::Io` containing an `UnexpectedEof`. If any other IO error

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -10,6 +10,9 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 
 use core::{fmt, fmt::Debug, ops::Deref};
 
+#[cfg(feature = "std")]
+use core::marker::PhantomData;
+
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
@@ -111,6 +114,39 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
+#[cfg(feature = "std")]
+pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
+    r: &'r mut R,
+    _s: PhantomData<S>,
+}
+
+#[cfg(feature = "std")]
+impl<'r, R: Read, S: ReadXdr> ReadXdrIter<'r, R, S> {
+    fn new(r: &'r mut R) -> Self {
+        Self { r, _s: PhantomData }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
+    type Item = Result<S>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match S::read_xdr(&mut self.r) {
+            Ok(s) => Some(Ok(s)),
+            // TODO: Distinguish between EOF and EOF-with-a-partial-fill. An EOF
+            // that occurs at teh end of an item indicates the end of a stream
+            // and should end iteration. An EOF that occurs whilst reading an
+            // item indicates a corrupt stream and should cause an error. The
+            // xdr types use the `std::io::Read::read_exact` method that
+            // unfortunately doesn't distinguish between these two extremely
+            // different events.
+            Err(Error::Io(e)) if e.kind() == io::ErrorKind::UnexpectedEof => None,
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
 pub trait ReadXdr
 where
     Self: Sized,
@@ -122,6 +158,11 @@ where
     fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    fn read_xdr_iter<R: Read>(r: &mut R) -> ReadXdrIter<R, Self> {
+        ReadXdrIter::new(r)
     }
 
     #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -135,7 +135,7 @@ impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
         match S::read_xdr(&mut self.r) {
             Ok(s) => Some(Ok(s)),
             // TODO: Distinguish between EOF and EOF-with-a-partial-fill. An EOF
-            // that occurs at teh end of an item indicates the end of a stream
+            // that occurs at the end of an item indicates the end of a stream
             // and should end iteration. An EOF that occurs whilst reading an
             // item indicates a corrupt stream and should cause an error. The
             // xdr types use the `std::io::Read::read_exact` method that

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -134,7 +134,7 @@ impl<'r, R: Read, S: ReadXdr> ReadXdrIter<'r, R, S> {
 impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
     type Item = Result<S>;
 
-    // Next reads the internal reader and XDR decoded it into the Self type. If
+    // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
     // EOF is reached after reading some bytes a truncated entry is assumed an
     // an `Error::Io` containing an `UnexpectedEof`. If any other IO error

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -10,6 +10,9 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 
 use core::{fmt, fmt::Debug, ops::Deref};
 
+#[cfg(feature = "std")]
+use core::marker::PhantomData;
+
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
@@ -111,6 +114,39 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
+#[cfg(feature = "std")]
+pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
+    r: &'r mut R,
+    _s: PhantomData<S>,
+}
+
+#[cfg(feature = "std")]
+impl<'r, R: Read, S: ReadXdr> ReadXdrIter<'r, R, S> {
+    fn new(r: &'r mut R) -> Self {
+        Self { r, _s: PhantomData }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
+    type Item = Result<S>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match S::read_xdr(&mut self.r) {
+            Ok(s) => Some(Ok(s)),
+            // TODO: Distinguish between EOF and EOF-with-a-partial-fill. An EOF
+            // that occurs at teh end of an item indicates the end of a stream
+            // and should end iteration. An EOF that occurs whilst reading an
+            // item indicates a corrupt stream and should cause an error. The
+            // xdr types use the `std::io::Read::read_exact` method that
+            // unfortunately doesn't distinguish between these two extremely
+            // different events.
+            Err(Error::Io(e)) if e.kind() == io::ErrorKind::UnexpectedEof => None,
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
 pub trait ReadXdr
 where
     Self: Sized,
@@ -122,6 +158,11 @@ where
     fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    fn read_xdr_iter<R: Read>(r: &mut R) -> ReadXdrIter<R, Self> {
+        ReadXdrIter::new(r)
     }
 
     #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -135,7 +135,7 @@ impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
         match S::read_xdr(&mut self.r) {
             Ok(s) => Some(Ok(s)),
             // TODO: Distinguish between EOF and EOF-with-a-partial-fill. An EOF
-            // that occurs at teh end of an item indicates the end of a stream
+            // that occurs at the end of an item indicates the end of a stream
             // and should end iteration. An EOF that occurs whilst reading an
             // item indicates a corrupt stream and should cause an error. The
             // xdr types use the `std::io::Read::read_exact` method that

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -134,7 +134,7 @@ impl<'r, R: Read, S: ReadXdr> ReadXdrIter<'r, R, S> {
 impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
     type Item = Result<S>;
 
-    // Next reads the internal reader and XDR decoded it into the Self type. If
+    // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
     // EOF is reached after reading some bytes a truncated entry is assumed an
     // an `Error::Io` containing an `UnexpectedEof`. If any other IO error

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -10,6 +10,9 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 
 use core::{fmt, fmt::Debug, ops::Deref};
 
+#[cfg(feature = "std")]
+use core::marker::PhantomData;
+
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
@@ -111,6 +114,39 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
+#[cfg(feature = "std")]
+pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
+    r: &'r mut R,
+    _s: PhantomData<S>,
+}
+
+#[cfg(feature = "std")]
+impl<'r, R: Read, S: ReadXdr> ReadXdrIter<'r, R, S> {
+    fn new(r: &'r mut R) -> Self {
+        Self { r, _s: PhantomData }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
+    type Item = Result<S>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match S::read_xdr(&mut self.r) {
+            Ok(s) => Some(Ok(s)),
+            // TODO: Distinguish between EOF and EOF-with-a-partial-fill. An EOF
+            // that occurs at teh end of an item indicates the end of a stream
+            // and should end iteration. An EOF that occurs whilst reading an
+            // item indicates a corrupt stream and should cause an error. The
+            // xdr types use the `std::io::Read::read_exact` method that
+            // unfortunately doesn't distinguish between these two extremely
+            // different events.
+            Err(Error::Io(e)) if e.kind() == io::ErrorKind::UnexpectedEof => None,
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
 pub trait ReadXdr
 where
     Self: Sized,
@@ -122,6 +158,11 @@ where
     fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    fn read_xdr_iter<R: Read>(r: &mut R) -> ReadXdrIter<R, Self> {
+        ReadXdrIter::new(r)
     }
 
     #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -135,7 +135,7 @@ impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
         match S::read_xdr(&mut self.r) {
             Ok(s) => Some(Ok(s)),
             // TODO: Distinguish between EOF and EOF-with-a-partial-fill. An EOF
-            // that occurs at teh end of an item indicates the end of a stream
+            // that occurs at the end of an item indicates the end of a stream
             // and should end iteration. An EOF that occurs whilst reading an
             // item indicates a corrupt stream and should cause an error. The
             // xdr types use the `std::io::Read::read_exact` method that

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -134,7 +134,7 @@ impl<'r, R: Read, S: ReadXdr> ReadXdrIter<'r, R, S> {
 impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
     type Item = Result<S>;
 
-    // Next reads the internal reader and XDR decoded it into the Self type. If
+    // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
     // EOF is reached after reading some bytes a truncated entry is assumed an
     // an `Error::Io` containing an `UnexpectedEof`. If any other IO error

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -10,6 +10,9 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 
 use core::{fmt, fmt::Debug, ops::Deref};
 
+#[cfg(feature = "std")]
+use core::marker::PhantomData;
+
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
@@ -111,6 +114,39 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
+#[cfg(feature = "std")]
+pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
+    r: &'r mut R,
+    _s: PhantomData<S>,
+}
+
+#[cfg(feature = "std")]
+impl<'r, R: Read, S: ReadXdr> ReadXdrIter<'r, R, S> {
+    fn new(r: &'r mut R) -> Self {
+        Self { r, _s: PhantomData }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
+    type Item = Result<S>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match S::read_xdr(&mut self.r) {
+            Ok(s) => Some(Ok(s)),
+            // TODO: Distinguish between EOF and EOF-with-a-partial-fill. An EOF
+            // that occurs at teh end of an item indicates the end of a stream
+            // and should end iteration. An EOF that occurs whilst reading an
+            // item indicates a corrupt stream and should cause an error. The
+            // xdr types use the `std::io::Read::read_exact` method that
+            // unfortunately doesn't distinguish between these two extremely
+            // different events.
+            Err(Error::Io(e)) if e.kind() == io::ErrorKind::UnexpectedEof => None,
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
 pub trait ReadXdr
 where
     Self: Sized,
@@ -122,6 +158,11 @@ where
     fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    fn read_xdr_iter<R: Read>(r: &mut R) -> ReadXdrIter<R, Self> {
+        ReadXdrIter::new(r)
     }
 
     #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -135,7 +135,7 @@ impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
         match S::read_xdr(&mut self.r) {
             Ok(s) => Some(Ok(s)),
             // TODO: Distinguish between EOF and EOF-with-a-partial-fill. An EOF
-            // that occurs at teh end of an item indicates the end of a stream
+            // that occurs at the end of an item indicates the end of a stream
             // and should end iteration. An EOF that occurs whilst reading an
             // item indicates a corrupt stream and should cause an error. The
             // xdr types use the `std::io::Read::read_exact` method that

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -134,7 +134,7 @@ impl<'r, R: Read, S: ReadXdr> ReadXdrIter<'r, R, S> {
 impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
     type Item = Result<S>;
 
-    // Next reads the internal reader and XDR decoded it into the Self type. If
+    // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
     // EOF is reached after reading some bytes a truncated entry is assumed an
     // an `Error::Io` containing an `UnexpectedEof`. If any other IO error

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -10,6 +10,9 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 
 use core::{fmt, fmt::Debug, ops::Deref};
 
+#[cfg(feature = "std")]
+use core::marker::PhantomData;
+
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
@@ -111,6 +114,39 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
+#[cfg(feature = "std")]
+pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
+    r: &'r mut R,
+    _s: PhantomData<S>,
+}
+
+#[cfg(feature = "std")]
+impl<'r, R: Read, S: ReadXdr> ReadXdrIter<'r, R, S> {
+    fn new(r: &'r mut R) -> Self {
+        Self { r, _s: PhantomData }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
+    type Item = Result<S>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match S::read_xdr(&mut self.r) {
+            Ok(s) => Some(Ok(s)),
+            // TODO: Distinguish between EOF and EOF-with-a-partial-fill. An EOF
+            // that occurs at teh end of an item indicates the end of a stream
+            // and should end iteration. An EOF that occurs whilst reading an
+            // item indicates a corrupt stream and should cause an error. The
+            // xdr types use the `std::io::Read::read_exact` method that
+            // unfortunately doesn't distinguish between these two extremely
+            // different events.
+            Err(Error::Io(e)) if e.kind() == io::ErrorKind::UnexpectedEof => None,
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
 pub trait ReadXdr
 where
     Self: Sized,
@@ -122,6 +158,11 @@ where
     fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    fn read_xdr_iter<R: Read>(r: &mut R) -> ReadXdrIter<R, Self> {
+        ReadXdrIter::new(r)
     }
 
     #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -135,7 +135,7 @@ impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
         match S::read_xdr(&mut self.r) {
             Ok(s) => Some(Ok(s)),
             // TODO: Distinguish between EOF and EOF-with-a-partial-fill. An EOF
-            // that occurs at teh end of an item indicates the end of a stream
+            // that occurs at the end of an item indicates the end of a stream
             // and should end iteration. An EOF that occurs whilst reading an
             // item indicates a corrupt stream and should cause an error. The
             // xdr types use the `std::io::Read::read_exact` method that

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -134,7 +134,7 @@ impl<'r, R: Read, S: ReadXdr> ReadXdrIter<'r, R, S> {
 impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
     type Item = Result<S>;
 
-    // Next reads the internal reader and XDR decoded it into the Self type. If
+    // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
     // EOF is reached after reading some bytes a truncated entry is assumed an
     // an `Error::Io` containing an `UnexpectedEof`. If any other IO error

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -10,6 +10,9 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 
 use core::{fmt, fmt::Debug, ops::Deref};
 
+#[cfg(feature = "std")]
+use core::marker::PhantomData;
+
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
@@ -111,6 +114,39 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
+#[cfg(feature = "std")]
+pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
+    r: &'r mut R,
+    _s: PhantomData<S>,
+}
+
+#[cfg(feature = "std")]
+impl<'r, R: Read, S: ReadXdr> ReadXdrIter<'r, R, S> {
+    fn new(r: &'r mut R) -> Self {
+        Self { r, _s: PhantomData }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'r, R: Read, S: ReadXdr> Iterator for ReadXdrIter<'r, R, S> {
+    type Item = Result<S>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match S::read_xdr(&mut self.r) {
+            Ok(s) => Some(Ok(s)),
+            // TODO: Distinguish between EOF and EOF-with-a-partial-fill. An EOF
+            // that occurs at teh end of an item indicates the end of a stream
+            // and should end iteration. An EOF that occurs whilst reading an
+            // item indicates a corrupt stream and should cause an error. The
+            // xdr types use the `std::io::Read::read_exact` method that
+            // unfortunately doesn't distinguish between these two extremely
+            // different events.
+            Err(Error::Io(e)) if e.kind() == io::ErrorKind::UnexpectedEof => None,
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
 pub trait ReadXdr
 where
     Self: Sized,
@@ -122,6 +158,11 @@ where
     fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    fn read_xdr_iter<R: Read>(r: &mut R) -> ReadXdrIter<R, Self> {
+        ReadXdrIter::new(r)
     }
 
     #[cfg(feature = "std")]


### PR DESCRIPTION
### What
Add a read_xdr_iter to all ReadXdr impls that returns an iterator for reading a stream of values from a Read impl.

### Why
In a couple places we need to read a stream of XDR values which is pretty inconvenient to impl in practice. Wrapping it into an iterator should make it much simpler.

### Also
This highlights a problem with existing read_xdr impls that they use read_exact which unfortunately obscures partial fill EOFs which could be a security concern in our uses. A TODO has been added to address this later.