### PR TITLE
Rust: remove unnecessary lint ignore

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -183,7 +183,6 @@ module Xdrgen
         impl #{name enum} {
             #[must_use]
             pub fn name(&self) -> &str {
-                #[allow(clippy::match_same_arms)]
                 match self {
                     #{enum.members.map do |m|
                       "Self::#{name m} => \"#{name m}\","
@@ -279,7 +278,6 @@ module Xdrgen
         impl #{name union} {
             #[must_use]
             pub fn name(&self) -> &str {
-                #[allow(clippy::match_same_arms)]
                 match self {
                     #{union_cases(union) do |case_name, arm|
                       "Self::#{case_name}#{"(_)" unless arm.void?} => \"#{case_name}\","

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -905,7 +905,6 @@ pub enum AccountFlags {
 impl AccountFlags {
     #[must_use]
     pub fn name(&self) -> &str {
-        #[allow(clippy::match_same_arms)]
         match self {
             Self::AuthRequiredFlag => "AuthRequiredFlag",
         }

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -937,7 +937,6 @@ pub enum MessageType {
         impl MessageType {
             #[must_use]
             pub fn name(&self) -> &str {
-                #[allow(clippy::match_same_arms)]
                 match self {
                     Self::ErrorMsg => "ErrorMsg",
 Self::Hello => "Hello",
@@ -1033,7 +1032,6 @@ pub enum Color {
         impl Color {
             #[must_use]
             pub fn name(&self) -> &str {
-                #[allow(clippy::match_same_arms)]
                 match self {
                     Self::Red => "Red",
 Self::Green => "Green",
@@ -1107,7 +1105,6 @@ pub enum Color2 {
         impl Color2 {
             #[must_use]
             pub fn name(&self) -> &str {
-                #[allow(clippy::match_same_arms)]
                 match self {
                     Self::Red2 => "Red2",
 Self::Green2 => "Green2",

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -908,7 +908,6 @@ pub enum UnionKey {
         impl UnionKey {
             #[must_use]
             pub fn name(&self) -> &str {
-                #[allow(clippy::match_same_arms)]
                 match self {
                     Self::One => "One",
 Self::Two => "Two",
@@ -1058,7 +1057,6 @@ pub enum MyUnion {
         impl MyUnion {
             #[must_use]
             pub fn name(&self) -> &str {
-                #[allow(clippy::match_same_arms)]
                 match self {
                     Self::One(_) => "One",
 Self::Two(_) => "Two",

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -1615,7 +1615,6 @@ pub enum Color {
         impl Color {
             #[must_use]
             pub fn name(&self) -> &str {
-                #[allow(clippy::match_same_arms)]
                 match self {
                     Self::Red => "Red",
 Self::Blue => "Blue",
@@ -1699,7 +1698,6 @@ pub enum NesterNestedEnum {
         impl NesterNestedEnum {
             #[must_use]
             pub fn name(&self) -> &str {
-                #[allow(clippy::match_same_arms)]
                 match self {
                     Self::1 => "1",
 Self::2 => "2",
@@ -1797,7 +1795,6 @@ pub enum NesterNestedUnion {
 impl NesterNestedUnion {
     #[must_use]
     pub fn name(&self) -> &str {
-        #[allow(clippy::match_same_arms)]
         match self {
             Self::Red => "Red",
         }

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -918,7 +918,6 @@ pub enum UnionKey {
         impl UnionKey {
             #[must_use]
             pub fn name(&self) -> &str {
-                #[allow(clippy::match_same_arms)]
                 match self {
                     Self::Error => "Error",
 Self::Multi => "Multi",
@@ -992,7 +991,6 @@ pub enum MyUnion {
         impl MyUnion {
             #[must_use]
             pub fn name(&self) -> &str {
-                #[allow(clippy::match_same_arms)]
                 match self {
                     Self::Error(_) => "Error",
 Self::Multi(_) => "Multi",
@@ -1058,7 +1056,6 @@ pub enum IntUnion {
         impl IntUnion {
             #[must_use]
             pub fn name(&self) -> &str {
-                #[allow(clippy::match_same_arms)]
                 match self {
                     Self::V0(_) => "V0",
 Self::V1(_) => "V1",


### PR DESCRIPTION
### What
Remove unnecessary allow of arms matching the same result.

### Why
They are not required on these functions as it would never make sense for the enum values to map to the same values.