### PR TITLE
Rust: Impl Default on VecM

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -348,6 +348,7 @@ module Xdrgen
           out.puts "pub type #{name typedef} = #{reference(typedef, typedef.type)};"
         else
           out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]"
+          out.puts "#[derive(Default)]" if is_var_array_type(typedef.type)
           out.puts "pub struct #{name typedef}(pub #{reference(typedef, typedef.type)});"
           out.puts ""
           out.puts <<-EOS.strip_heredoc
@@ -395,12 +396,6 @@ module Xdrgen
               type Target = #{reference(typedef, typedef.type)};
               fn deref(&self) -> &Self::Target {
                   &self.0
-              }
-            }
-
-            impl Default for #{name typedef} {
-              fn default() -> Self {
-                  Self(#{reference_to_call(typedef, typedef.type)}::default())
               }
             }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -463,6 +463,12 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     }
 }
 
+impl<T, const MAX: u32> Default for VecM<T, MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -473,6 +473,12 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     }
 }
 
+impl<T, const MAX: u32> Default for VecM<T, MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -473,6 +473,12 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     }
 }
 
+impl<T, const MAX: u32> Default for VecM<T, MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -473,6 +473,12 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     }
 }
 
+impl<T, const MAX: u32> Default for VecM<T, MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -473,6 +473,12 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     }
 }
 
+impl<T, const MAX: u32> Default for VecM<T, MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -473,6 +473,12 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     }
 }
 
+impl<T, const MAX: u32> Default for VecM<T, MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -473,6 +473,12 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     }
 }
 
+impl<T, const MAX: u32> Default for VecM<T, MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -473,6 +473,12 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     }
 }
 
+impl<T, const MAX: u32> Default for VecM<T, MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -983,6 +989,12 @@ impl Deref for Uint513 {
   }
 }
 
+impl Default for Uint513 {
+  fn default() -> Self {
+      Self(VecM::<u8, 64>::default())
+  }
+}
+
 impl From<Uint513> for Vec<u8> {
     #[must_use]
     fn from(x: Uint513) -> Self {
@@ -1065,6 +1077,12 @@ impl Deref for Uint514 {
   type Target = VecM::<u8>;
   fn deref(&self) -> &Self::Target {
       &self.0
+  }
+}
+
+impl Default for Uint514 {
+  fn default() -> Self {
+      Self(VecM::<u8>::default())
   }
 }
 
@@ -1253,6 +1271,12 @@ impl Deref for Hashes2 {
   }
 }
 
+impl Default for Hashes2 {
+  fn default() -> Self {
+      Self(VecM::<Hash, 12>::default())
+  }
+}
+
 impl From<Hashes2> for Vec<Hash> {
     #[must_use]
     fn from(x: Hashes2) -> Self {
@@ -1335,6 +1359,12 @@ impl Deref for Hashes3 {
   type Target = VecM::<Hash>;
   fn deref(&self) -> &Self::Target {
       &self.0
+  }
+}
+
+impl Default for Hashes3 {
+  fn default() -> Self {
+      Self(VecM::<Hash>::default())
   }
 }
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -943,6 +943,7 @@ impl WriteXdr for Uint512 {
 //   typedef opaque uint513<64>;
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default)]
 pub struct Uint513(pub VecM::<u8, 64>);
 
 impl From<Uint513> for VecM::<u8, 64> {
@@ -989,12 +990,6 @@ impl Deref for Uint513 {
   }
 }
 
-impl Default for Uint513 {
-  fn default() -> Self {
-      Self(VecM::<u8, 64>::default())
-  }
-}
-
 impl From<Uint513> for Vec<u8> {
     #[must_use]
     fn from(x: Uint513) -> Self {
@@ -1034,6 +1029,7 @@ impl AsRef<[u8]> for Uint513 {
 //   typedef opaque uint514<>;
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default)]
 pub struct Uint514(pub VecM::<u8>);
 
 impl From<Uint514> for VecM::<u8> {
@@ -1077,12 +1073,6 @@ impl Deref for Uint514 {
   type Target = VecM::<u8>;
   fn deref(&self) -> &Self::Target {
       &self.0
-  }
-}
-
-impl Default for Uint514 {
-  fn default() -> Self {
-      Self(VecM::<u8>::default())
   }
 }
 
@@ -1225,6 +1215,7 @@ impl WriteXdr for Hashes1 {
 //   typedef Hash Hashes2<12>;
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default)]
 pub struct Hashes2(pub VecM::<Hash, 12>);
 
 impl From<Hashes2> for VecM::<Hash, 12> {
@@ -1271,12 +1262,6 @@ impl Deref for Hashes2 {
   }
 }
 
-impl Default for Hashes2 {
-  fn default() -> Self {
-      Self(VecM::<Hash, 12>::default())
-  }
-}
-
 impl From<Hashes2> for Vec<Hash> {
     #[must_use]
     fn from(x: Hashes2) -> Self {
@@ -1316,6 +1301,7 @@ impl AsRef<[Hash]> for Hashes2 {
 //   typedef Hash Hashes3<>;
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default)]
 pub struct Hashes3(pub VecM::<Hash>);
 
 impl From<Hashes3> for VecM::<Hash> {
@@ -1359,12 +1345,6 @@ impl Deref for Hashes3 {
   type Target = VecM::<Hash>;
   fn deref(&self) -> &Self::Target {
       &self.0
-  }
-}
-
-impl Default for Hashes3 {
-  fn default() -> Self {
-      Self(VecM::<Hash>::default())
   }
 }
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -473,6 +473,12 @@ impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     }
 }
 
+impl<T, const MAX: u32> Default for VecM<T, MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 


### PR DESCRIPTION
### What
Implement the `Default` trait on `VecM` and other var array types.

### Why
`VecM` doesn't make it easy to create an empty copy of itself, and using Default is the most reasonable way of providing that functionality.