### PR TITLE
Rust: Make name, discriminant const and trait fns

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -182,7 +182,7 @@ module Xdrgen
         out.puts <<-EOS.strip_heredoc
         impl #{name enum} {
             #[must_use]
-            pub const fn name(&self) -> &str {
+            pub const fn name(&self) -> &'static str {
                 match self {
                     #{enum.members.map do |m|
                       "Self::#{name m} => \"#{name m}\","
@@ -277,7 +277,7 @@ module Xdrgen
         out.puts <<-EOS.strip_heredoc
         impl #{name union} {
             #[must_use]
-            pub const fn name(&self) -> &str {
+            pub const fn name(&self) -> &'static str {
                 match self {
                     #{union_cases(union) do |case_name, arm|
                       "Self::#{case_name}#{"(_)" unless arm.void?} => \"#{case_name}\","

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -191,6 +191,13 @@ module Xdrgen
             }
         }
 
+        impl Enum for #{name enum} {
+            #[must_use]
+            fn name(&self) -> &'static str {
+                Self::name(self)
+            }
+        }
+
         impl fmt::Display for #{name enum} {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str(self.name())
@@ -297,6 +304,18 @@ module Xdrgen
                       },"
                     end.join("\n")}
                 }
+            }
+        }
+
+        impl Union<#{discriminant_type}> for #{name union} {
+            #[must_use]
+            fn name(&self) -> &'static str {
+                Self::name(self)
+            }
+
+            #[must_use]
+            fn discriminant(&self) -> #{discriminant_type} {
+                Self::discriminant(self)
             }
         }
 

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -182,7 +182,7 @@ module Xdrgen
         out.puts <<-EOS.strip_heredoc
         impl #{name enum} {
             #[must_use]
-            pub fn name(&self) -> &str {
+            pub const fn name(&self) -> &str {
                 match self {
                     #{enum.members.map do |m|
                       "Self::#{name m} => \"#{name m}\","
@@ -277,7 +277,7 @@ module Xdrgen
         out.puts <<-EOS.strip_heredoc
         impl #{name union} {
             #[must_use]
-            pub fn name(&self) -> &str {
+            pub const fn name(&self) -> &str {
                 match self {
                     #{union_cases(union) do |case_name, arm|
                       "Self::#{case_name}#{"(_)" unless arm.void?} => \"#{case_name}\","
@@ -286,7 +286,7 @@ module Xdrgen
             }
 
             #[must_use]
-            pub fn discriminant(&self) -> #{discriminant_type} {
+            pub const fn discriminant(&self) -> #{discriminant_type} {
                 #[allow(clippy::match_same_arms)]
                 match self {
                     #{union_cases(union) do |case_name, arm, value|

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -191,12 +191,14 @@ module Xdrgen
             }
         }
 
-        impl Enum for #{name enum} {
+        impl Name for #{name enum} {
             #[must_use]
             fn name(&self) -> &'static str {
                 Self::name(self)
             }
         }
+
+        impl Enum for #{name enum} {}
 
         impl fmt::Display for #{name enum} {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -307,17 +309,21 @@ module Xdrgen
             }
         }
 
-        impl Union<#{discriminant_type}> for #{name union} {
+        impl Name for #{name union} {
             #[must_use]
             fn name(&self) -> &'static str {
                 Self::name(self)
             }
+        }
 
+        impl Discriminant<#{discriminant_type}> for #{name union} {
             #[must_use]
             fn discriminant(&self) -> #{discriminant_type} {
                 Self::discriminant(self)
             }
         }
+
+        impl Union<#{discriminant_type}> for #{name union} {}
 
         impl ReadXdr for #{name union} {
             #[cfg(feature = "std")]

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -610,10 +610,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 }
 
 #[cfg(not(feature = "alloc"))]
-impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX>
-where
-    T: 'static,
-{
+impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
     fn try_from(v: &'static [T; N]) -> Result<Self> {

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -104,14 +104,25 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
-pub trait Enum {
+/// Name defines types that assign a static name to their value, such as the
+/// name given to an identifier in an XDR enum, or the name given to the case in
+/// a union.
+pub trait Name {
     fn name(&self) -> &'static str;
 }
 
-pub trait Union<D> {
-    fn name(&self) -> &'static str;
+/// Discriminant defines types that may contain a one-of value determined
+/// according to the discriminant, and exposes the value of the discriminant for
+/// that type, such as in an XDR union.
+pub trait Discriminant<D> {
     fn discriminant(&self) -> D;
 }
+
+// Enum defines a type that is represented as an XDR enumeration when encoded.
+pub trait Enum: Name {}
+
+// Union defines a type that is represented as an XDR union when encoded.
+pub trait Union<D>: Name + Discriminant<D> {}
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -104,6 +104,15 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
+pub trait Enum {
+    fn name(&self) -> &'static str;
+}
+
+pub trait Union<D> {
+    fn name(&self) -> &'static str;
+    fn discriminant(&self) -> D;
+}
+
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
     reader: BufReader<&'r mut R>,

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -907,7 +907,7 @@ pub enum AccountFlags {
 
 impl AccountFlags {
     #[must_use]
-    pub fn name(&self) -> &str {
+    pub const fn name(&self) -> &str {
         match self {
             Self::AuthRequiredFlag => "AuthRequiredFlag",
         }

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -114,6 +114,15 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
+pub trait Enum {
+    fn name(&self) -> &'static str;
+}
+
+pub trait Union<D> {
+    fn name(&self) -> &'static str;
+    fn discriminant(&self) -> D;
+}
+
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
     reader: BufReader<&'r mut R>,
@@ -911,6 +920,13 @@ impl AccountFlags {
         match self {
             Self::AuthRequiredFlag => "AuthRequiredFlag",
         }
+    }
+}
+
+impl Enum for AccountFlags {
+    #[must_use]
+    fn name(&self) -> &'static str {
+        Self::name(self)
     }
 }
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -907,7 +907,7 @@ pub enum AccountFlags {
 
 impl AccountFlags {
     #[must_use]
-    pub const fn name(&self) -> &str {
+    pub const fn name(&self) -> &'static str {
         match self {
             Self::AuthRequiredFlag => "AuthRequiredFlag",
         }

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -620,10 +620,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 }
 
 #[cfg(not(feature = "alloc"))]
-impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX>
-where
-    T: 'static,
-{
+impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
     fn try_from(v: &'static [T; N]) -> Result<Self> {

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -114,14 +114,25 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
-pub trait Enum {
+/// Name defines types that assign a static name to their value, such as the
+/// name given to an identifier in an XDR enum, or the name given to the case in
+/// a union.
+pub trait Name {
     fn name(&self) -> &'static str;
 }
 
-pub trait Union<D> {
-    fn name(&self) -> &'static str;
+/// Discriminant defines types that may contain a one-of value determined
+/// according to the discriminant, and exposes the value of the discriminant for
+/// that type, such as in an XDR union.
+pub trait Discriminant<D> {
     fn discriminant(&self) -> D;
 }
+
+// Enum defines a type that is represented as an XDR enumeration when encoded.
+pub trait Enum: Name {}
+
+// Union defines a type that is represented as an XDR union when encoded.
+pub trait Union<D>: Name + Discriminant<D> {}
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
@@ -923,12 +934,14 @@ impl AccountFlags {
     }
 }
 
-impl Enum for AccountFlags {
+impl Name for AccountFlags {
     #[must_use]
     fn name(&self) -> &'static str {
         Self::name(self)
     }
 }
+
+impl Enum for AccountFlags {}
 
 impl fmt::Display for AccountFlags {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -620,10 +620,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 }
 
 #[cfg(not(feature = "alloc"))]
-impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX>
-where
-    T: 'static,
-{
+impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
     fn try_from(v: &'static [T; N]) -> Result<Self> {

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -114,6 +114,15 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
+pub trait Enum {
+    fn name(&self) -> &'static str;
+}
+
+pub trait Union<D> {
+    fn name(&self) -> &'static str;
+    fn discriminant(&self) -> D;
+}
+
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
     reader: BufReader<&'r mut R>,

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -114,14 +114,25 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
-pub trait Enum {
+/// Name defines types that assign a static name to their value, such as the
+/// name given to an identifier in an XDR enum, or the name given to the case in
+/// a union.
+pub trait Name {
     fn name(&self) -> &'static str;
 }
 
-pub trait Union<D> {
-    fn name(&self) -> &'static str;
+/// Discriminant defines types that may contain a one-of value determined
+/// according to the discriminant, and exposes the value of the discriminant for
+/// that type, such as in an XDR union.
+pub trait Discriminant<D> {
     fn discriminant(&self) -> D;
 }
+
+// Enum defines a type that is represented as an XDR enumeration when encoded.
+pub trait Enum: Name {}
+
+// Union defines a type that is represented as an XDR union when encoded.
+pub trait Union<D>: Name + Discriminant<D> {}
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -114,6 +114,15 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
+pub trait Enum {
+    fn name(&self) -> &'static str;
+}
+
+pub trait Union<D> {
+    fn name(&self) -> &'static str;
+    fn discriminant(&self) -> D;
+}
+
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
     reader: BufReader<&'r mut R>,
@@ -959,6 +968,13 @@ Self::FbaMessage => "FbaMessage",
             }
         }
 
+        impl Enum for MessageType {
+            #[must_use]
+            fn name(&self) -> &'static str {
+                Self::name(self)
+            }
+        }
+
         impl fmt::Display for MessageType {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str(self.name())
@@ -1043,6 +1059,13 @@ Self::Blue => "Blue",
             }
         }
 
+        impl Enum for Color {
+            #[must_use]
+            fn name(&self) -> &'static str {
+                Self::name(self)
+            }
+        }
+
         impl fmt::Display for Color {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str(self.name())
@@ -1113,6 +1136,13 @@ pub enum Color2 {
 Self::Green2 => "Green2",
 Self::Blue2 => "Blue2",
                 }
+            }
+        }
+
+        impl Enum for Color2 {
+            #[must_use]
+            fn name(&self) -> &'static str {
+                Self::name(self)
             }
         }
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -114,14 +114,25 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
-pub trait Enum {
+/// Name defines types that assign a static name to their value, such as the
+/// name given to an identifier in an XDR enum, or the name given to the case in
+/// a union.
+pub trait Name {
     fn name(&self) -> &'static str;
 }
 
-pub trait Union<D> {
-    fn name(&self) -> &'static str;
+/// Discriminant defines types that may contain a one-of value determined
+/// according to the discriminant, and exposes the value of the discriminant for
+/// that type, such as in an XDR union.
+pub trait Discriminant<D> {
     fn discriminant(&self) -> D;
 }
+
+// Enum defines a type that is represented as an XDR enumeration when encoded.
+pub trait Enum: Name {}
+
+// Union defines a type that is represented as an XDR union when encoded.
+pub trait Union<D>: Name + Discriminant<D> {}
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
@@ -968,12 +979,14 @@ Self::FbaMessage => "FbaMessage",
             }
         }
 
-        impl Enum for MessageType {
+        impl Name for MessageType {
             #[must_use]
             fn name(&self) -> &'static str {
                 Self::name(self)
             }
         }
+
+        impl Enum for MessageType {}
 
         impl fmt::Display for MessageType {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1059,12 +1072,14 @@ Self::Blue => "Blue",
             }
         }
 
-        impl Enum for Color {
+        impl Name for Color {
             #[must_use]
             fn name(&self) -> &'static str {
                 Self::name(self)
             }
         }
+
+        impl Enum for Color {}
 
         impl fmt::Display for Color {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1139,12 +1154,14 @@ Self::Blue2 => "Blue2",
             }
         }
 
-        impl Enum for Color2 {
+        impl Name for Color2 {
             #[must_use]
             fn name(&self) -> &'static str {
                 Self::name(self)
             }
         }
+
+        impl Enum for Color2 {}
 
         impl fmt::Display for Color2 {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -939,7 +939,7 @@ pub enum MessageType {
 
         impl MessageType {
             #[must_use]
-            pub fn name(&self) -> &str {
+            pub const fn name(&self) -> &str {
                 match self {
                     Self::ErrorMsg => "ErrorMsg",
 Self::Hello => "Hello",
@@ -1034,7 +1034,7 @@ pub enum Color {
 
         impl Color {
             #[must_use]
-            pub fn name(&self) -> &str {
+            pub const fn name(&self) -> &str {
                 match self {
                     Self::Red => "Red",
 Self::Green => "Green",
@@ -1107,7 +1107,7 @@ pub enum Color2 {
 
         impl Color2 {
             #[must_use]
-            pub fn name(&self) -> &str {
+            pub const fn name(&self) -> &str {
                 match self {
                     Self::Red2 => "Red2",
 Self::Green2 => "Green2",

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -620,10 +620,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 }
 
 #[cfg(not(feature = "alloc"))]
-impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX>
-where
-    T: 'static,
-{
+impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
     fn try_from(v: &'static [T; N]) -> Result<Self> {

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -939,7 +939,7 @@ pub enum MessageType {
 
         impl MessageType {
             #[must_use]
-            pub const fn name(&self) -> &str {
+            pub const fn name(&self) -> &'static str {
                 match self {
                     Self::ErrorMsg => "ErrorMsg",
 Self::Hello => "Hello",
@@ -1034,7 +1034,7 @@ pub enum Color {
 
         impl Color {
             #[must_use]
-            pub const fn name(&self) -> &str {
+            pub const fn name(&self) -> &'static str {
                 match self {
                     Self::Red => "Red",
 Self::Green => "Green",
@@ -1107,7 +1107,7 @@ pub enum Color2 {
 
         impl Color2 {
             #[must_use]
-            pub const fn name(&self) -> &str {
+            pub const fn name(&self) -> &'static str {
                 match self {
                     Self::Red2 => "Red2",
 Self::Green2 => "Green2",

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -910,7 +910,7 @@ pub enum UnionKey {
 
         impl UnionKey {
             #[must_use]
-            pub fn name(&self) -> &str {
+            pub const fn name(&self) -> &str {
                 match self {
                     Self::One => "One",
 Self::Two => "Two",
@@ -1059,7 +1059,7 @@ pub enum MyUnion {
 
         impl MyUnion {
             #[must_use]
-            pub fn name(&self) -> &str {
+            pub const fn name(&self) -> &str {
                 match self {
                     Self::One(_) => "One",
 Self::Two(_) => "Two",
@@ -1068,7 +1068,7 @@ Self::Offer => "Offer",
             }
 
             #[must_use]
-            pub fn discriminant(&self) -> UnionKey {
+            pub const fn discriminant(&self) -> UnionKey {
                 #[allow(clippy::match_same_arms)]
                 match self {
                     Self::One(_) => UnionKey::One,

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -620,10 +620,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 }
 
 #[cfg(not(feature = "alloc"))]
-impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX>
-where
-    T: 'static,
-{
+impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
     fn try_from(v: &'static [T; N]) -> Result<Self> {

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -910,7 +910,7 @@ pub enum UnionKey {
 
         impl UnionKey {
             #[must_use]
-            pub const fn name(&self) -> &str {
+            pub const fn name(&self) -> &'static str {
                 match self {
                     Self::One => "One",
 Self::Two => "Two",
@@ -1059,7 +1059,7 @@ pub enum MyUnion {
 
         impl MyUnion {
             #[must_use]
-            pub const fn name(&self) -> &str {
+            pub const fn name(&self) -> &'static str {
                 match self {
                     Self::One(_) => "One",
 Self::Two(_) => "Two",

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -114,6 +114,15 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
+pub trait Enum {
+    fn name(&self) -> &'static str;
+}
+
+pub trait Union<D> {
+    fn name(&self) -> &'static str;
+    fn discriminant(&self) -> D;
+}
+
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
     reader: BufReader<&'r mut R>,
@@ -919,6 +928,13 @@ Self::Offer => "Offer",
             }
         }
 
+        impl Enum for UnionKey {
+            #[must_use]
+            fn name(&self) -> &'static str {
+                Self::name(self)
+            }
+        }
+
         impl fmt::Display for UnionKey {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str(self.name())
@@ -1075,6 +1091,18 @@ Self::Offer => "Offer",
 Self::Two(_) => UnionKey::Two,
 Self::Offer => UnionKey::Offer,
                 }
+            }
+        }
+
+        impl Union<UnionKey> for MyUnion {
+            #[must_use]
+            fn name(&self) -> &'static str {
+                Self::name(self)
+            }
+
+            #[must_use]
+            fn discriminant(&self) -> UnionKey {
+                Self::discriminant(self)
             }
         }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -620,10 +620,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 }
 
 #[cfg(not(feature = "alloc"))]
-impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX>
-where
-    T: 'static,
-{
+impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
     fn try_from(v: &'static [T; N]) -> Result<Self> {

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -114,6 +114,15 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
+pub trait Enum {
+    fn name(&self) -> &'static str;
+}
+
+pub trait Union<D> {
+    fn name(&self) -> &'static str;
+    fn discriminant(&self) -> D;
+}
+
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
     reader: BufReader<&'r mut R>,

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -114,14 +114,25 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
-pub trait Enum {
+/// Name defines types that assign a static name to their value, such as the
+/// name given to an identifier in an XDR enum, or the name given to the case in
+/// a union.
+pub trait Name {
     fn name(&self) -> &'static str;
 }
 
-pub trait Union<D> {
-    fn name(&self) -> &'static str;
+/// Discriminant defines types that may contain a one-of value determined
+/// according to the discriminant, and exposes the value of the discriminant for
+/// that type, such as in an XDR union.
+pub trait Discriminant<D> {
     fn discriminant(&self) -> D;
 }
+
+// Enum defines a type that is represented as an XDR enumeration when encoded.
+pub trait Enum: Name {}
+
+// Union defines a type that is represented as an XDR union when encoded.
+pub trait Union<D>: Name + Discriminant<D> {}
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -620,10 +620,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 }
 
 #[cfg(not(feature = "alloc"))]
-impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX>
-where
-    T: 'static,
-{
+impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
     fn try_from(v: &'static [T; N]) -> Result<Self> {

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -114,6 +114,15 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
+pub trait Enum {
+    fn name(&self) -> &'static str;
+}
+
+pub trait Union<D> {
+    fn name(&self) -> &'static str;
+    fn discriminant(&self) -> D;
+}
+
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
     reader: BufReader<&'r mut R>,

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -114,14 +114,25 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
-pub trait Enum {
+/// Name defines types that assign a static name to their value, such as the
+/// name given to an identifier in an XDR enum, or the name given to the case in
+/// a union.
+pub trait Name {
     fn name(&self) -> &'static str;
 }
 
-pub trait Union<D> {
-    fn name(&self) -> &'static str;
+/// Discriminant defines types that may contain a one-of value determined
+/// according to the discriminant, and exposes the value of the discriminant for
+/// that type, such as in an XDR union.
+pub trait Discriminant<D> {
     fn discriminant(&self) -> D;
 }
+
+// Enum defines a type that is represented as an XDR enumeration when encoded.
+pub trait Enum: Name {}
+
+// Union defines a type that is represented as an XDR union when encoded.
+pub trait Union<D>: Name + Discriminant<D> {}
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -620,10 +620,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 }
 
 #[cfg(not(feature = "alloc"))]
-impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX>
-where
-    T: 'static,
-{
+impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
     fn try_from(v: &'static [T; N]) -> Result<Self> {

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -114,14 +114,25 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
-pub trait Enum {
+/// Name defines types that assign a static name to their value, such as the
+/// name given to an identifier in an XDR enum, or the name given to the case in
+/// a union.
+pub trait Name {
     fn name(&self) -> &'static str;
 }
 
-pub trait Union<D> {
-    fn name(&self) -> &'static str;
+/// Discriminant defines types that may contain a one-of value determined
+/// according to the discriminant, and exposes the value of the discriminant for
+/// that type, such as in an XDR union.
+pub trait Discriminant<D> {
     fn discriminant(&self) -> D;
 }
+
+// Enum defines a type that is represented as an XDR enumeration when encoded.
+pub trait Enum: Name {}
+
+// Union defines a type that is represented as an XDR union when encoded.
+pub trait Union<D>: Name + Discriminant<D> {}
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
@@ -1639,12 +1650,14 @@ Self::Green => "Green",
             }
         }
 
-        impl Enum for Color {
+        impl Name for Color {
             #[must_use]
             fn name(&self) -> &'static str {
                 Self::name(self)
             }
         }
+
+        impl Enum for Color {}
 
         impl fmt::Display for Color {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1728,12 +1741,14 @@ Self::2 => "2",
             }
         }
 
-        impl Enum for NesterNestedEnum {
+        impl Name for NesterNestedEnum {
             #[must_use]
             fn name(&self) -> &'static str {
                 Self::name(self)
             }
         }
+
+        impl Enum for NesterNestedEnum {}
 
         impl fmt::Display for NesterNestedEnum {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1839,17 +1854,21 @@ impl NesterNestedUnion {
     }
 }
 
-impl Union<Color> for NesterNestedUnion {
+impl Name for NesterNestedUnion {
     #[must_use]
     fn name(&self) -> &'static str {
         Self::name(self)
     }
+}
 
+impl Discriminant<Color> for NesterNestedUnion {
     #[must_use]
     fn discriminant(&self) -> Color {
         Self::discriminant(self)
     }
 }
+
+impl Union<Color> for NesterNestedUnion {}
 
 impl ReadXdr for NesterNestedUnion {
     #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -114,6 +114,15 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
+pub trait Enum {
+    fn name(&self) -> &'static str;
+}
+
+pub trait Union<D> {
+    fn name(&self) -> &'static str;
+    fn discriminant(&self) -> D;
+}
+
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
     reader: BufReader<&'r mut R>,
@@ -1630,6 +1639,13 @@ Self::Green => "Green",
             }
         }
 
+        impl Enum for Color {
+            #[must_use]
+            fn name(&self) -> &'static str {
+                Self::name(self)
+            }
+        }
+
         impl fmt::Display for Color {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str(self.name())
@@ -1709,6 +1725,13 @@ pub enum NesterNestedEnum {
                     Self::1 => "1",
 Self::2 => "2",
                 }
+            }
+        }
+
+        impl Enum for NesterNestedEnum {
+            #[must_use]
+            fn name(&self) -> &'static str {
+                Self::name(self)
             }
         }
 
@@ -1813,6 +1836,18 @@ impl NesterNestedUnion {
         match self {
             Self::Red => Color::Red,
         }
+    }
+}
+
+impl Union<Color> for NesterNestedUnion {
+    #[must_use]
+    fn name(&self) -> &'static str {
+        Self::name(self)
+    }
+
+    #[must_use]
+    fn discriminant(&self) -> Color {
+        Self::discriminant(self)
     }
 }
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -1621,7 +1621,7 @@ pub enum Color {
 
         impl Color {
             #[must_use]
-            pub fn name(&self) -> &str {
+            pub const fn name(&self) -> &str {
                 match self {
                     Self::Red => "Red",
 Self::Blue => "Blue",
@@ -1704,7 +1704,7 @@ pub enum NesterNestedEnum {
 
         impl NesterNestedEnum {
             #[must_use]
-            pub fn name(&self) -> &str {
+            pub const fn name(&self) -> &str {
                 match self {
                     Self::1 => "1",
 Self::2 => "2",
@@ -1801,14 +1801,14 @@ pub enum NesterNestedUnion {
 
 impl NesterNestedUnion {
     #[must_use]
-    pub fn name(&self) -> &str {
+    pub const fn name(&self) -> &str {
         match self {
             Self::Red => "Red",
         }
     }
 
     #[must_use]
-    pub fn discriminant(&self) -> Color {
+    pub const fn discriminant(&self) -> Color {
         #[allow(clippy::match_same_arms)]
         match self {
             Self::Red => Color::Red,

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -1621,7 +1621,7 @@ pub enum Color {
 
         impl Color {
             #[must_use]
-            pub const fn name(&self) -> &str {
+            pub const fn name(&self) -> &'static str {
                 match self {
                     Self::Red => "Red",
 Self::Blue => "Blue",
@@ -1704,7 +1704,7 @@ pub enum NesterNestedEnum {
 
         impl NesterNestedEnum {
             #[must_use]
-            pub const fn name(&self) -> &str {
+            pub const fn name(&self) -> &'static str {
                 match self {
                     Self::1 => "1",
 Self::2 => "2",
@@ -1801,7 +1801,7 @@ pub enum NesterNestedUnion {
 
 impl NesterNestedUnion {
     #[must_use]
-    pub const fn name(&self) -> &str {
+    pub const fn name(&self) -> &'static str {
         match self {
             Self::Red => "Red",
         }

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -114,6 +114,15 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
+pub trait Enum {
+    fn name(&self) -> &'static str;
+}
+
+pub trait Union<D> {
+    fn name(&self) -> &'static str;
+    fn discriminant(&self) -> D;
+}
+
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
     reader: BufReader<&'r mut R>,
@@ -928,6 +937,13 @@ Self::Multi => "Multi",
             }
         }
 
+        impl Enum for UnionKey {
+            #[must_use]
+            fn name(&self) -> &'static str {
+                Self::name(self)
+            }
+        }
+
         impl fmt::Display for UnionKey {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str(self.name())
@@ -1010,6 +1026,18 @@ Self::Multi(_) => UnionKey::Multi,
             }
         }
 
+        impl Union<UnionKey> for MyUnion {
+            #[must_use]
+            fn name(&self) -> &'static str {
+                Self::name(self)
+            }
+
+            #[must_use]
+            fn discriminant(&self) -> UnionKey {
+                Self::discriminant(self)
+            }
+        }
+
         impl ReadXdr for MyUnion {
             #[cfg(feature = "std")]
             fn read_xdr(r: &mut impl Read) -> Result<Self> {
@@ -1072,6 +1100,18 @@ Self::V1(_) => "V1",
                     Self::V0(_) => 0,
 Self::V1(_) => 1,
                 }
+            }
+        }
+
+        impl Union<i32> for IntUnion {
+            #[must_use]
+            fn name(&self) -> &'static str {
+                Self::name(self)
+            }
+
+            #[must_use]
+            fn discriminant(&self) -> i32 {
+                Self::discriminant(self)
             }
         }
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -620,10 +620,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 }
 
 #[cfg(not(feature = "alloc"))]
-impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX>
-where
-    T: 'static,
-{
+impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
     fn try_from(v: &'static [T; N]) -> Result<Self> {

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -920,7 +920,7 @@ pub enum UnionKey {
 
         impl UnionKey {
             #[must_use]
-            pub const fn name(&self) -> &str {
+            pub const fn name(&self) -> &'static str {
                 match self {
                     Self::Error => "Error",
 Self::Multi => "Multi",
@@ -993,7 +993,7 @@ pub enum MyUnion {
 
         impl MyUnion {
             #[must_use]
-            pub const fn name(&self) -> &str {
+            pub const fn name(&self) -> &'static str {
                 match self {
                     Self::Error(_) => "Error",
 Self::Multi(_) => "Multi",
@@ -1058,7 +1058,7 @@ pub enum IntUnion {
 
         impl IntUnion {
             #[must_use]
-            pub const fn name(&self) -> &str {
+            pub const fn name(&self) -> &'static str {
                 match self {
                     Self::V0(_) => "V0",
 Self::V1(_) => "V1",

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -920,7 +920,7 @@ pub enum UnionKey {
 
         impl UnionKey {
             #[must_use]
-            pub fn name(&self) -> &str {
+            pub const fn name(&self) -> &str {
                 match self {
                     Self::Error => "Error",
 Self::Multi => "Multi",
@@ -993,7 +993,7 @@ pub enum MyUnion {
 
         impl MyUnion {
             #[must_use]
-            pub fn name(&self) -> &str {
+            pub const fn name(&self) -> &str {
                 match self {
                     Self::Error(_) => "Error",
 Self::Multi(_) => "Multi",
@@ -1001,7 +1001,7 @@ Self::Multi(_) => "Multi",
             }
 
             #[must_use]
-            pub fn discriminant(&self) -> UnionKey {
+            pub const fn discriminant(&self) -> UnionKey {
                 #[allow(clippy::match_same_arms)]
                 match self {
                     Self::Error(_) => UnionKey::Error,
@@ -1058,7 +1058,7 @@ pub enum IntUnion {
 
         impl IntUnion {
             #[must_use]
-            pub fn name(&self) -> &str {
+            pub const fn name(&self) -> &str {
                 match self {
                     Self::V0(_) => "V0",
 Self::V1(_) => "V1",
@@ -1066,7 +1066,7 @@ Self::V1(_) => "V1",
             }
 
             #[must_use]
-            pub fn discriminant(&self) -> i32 {
+            pub const fn discriminant(&self) -> i32 {
                 #[allow(clippy::match_same_arms)]
                 match self {
                     Self::V0(_) => 0,

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -114,14 +114,25 @@ impl From<Error> for () {
 #[allow(dead_code)]
 type Result<T> = core::result::Result<T, Error>;
 
-pub trait Enum {
+/// Name defines types that assign a static name to their value, such as the
+/// name given to an identifier in an XDR enum, or the name given to the case in
+/// a union.
+pub trait Name {
     fn name(&self) -> &'static str;
 }
 
-pub trait Union<D> {
-    fn name(&self) -> &'static str;
+/// Discriminant defines types that may contain a one-of value determined
+/// according to the discriminant, and exposes the value of the discriminant for
+/// that type, such as in an XDR union.
+pub trait Discriminant<D> {
     fn discriminant(&self) -> D;
 }
+
+// Enum defines a type that is represented as an XDR enumeration when encoded.
+pub trait Enum: Name {}
+
+// Union defines a type that is represented as an XDR union when encoded.
+pub trait Union<D>: Name + Discriminant<D> {}
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<'r, R: Read, S: ReadXdr> {
@@ -937,12 +948,14 @@ Self::Multi => "Multi",
             }
         }
 
-        impl Enum for UnionKey {
+        impl Name for UnionKey {
             #[must_use]
             fn name(&self) -> &'static str {
                 Self::name(self)
             }
         }
+
+        impl Enum for UnionKey {}
 
         impl fmt::Display for UnionKey {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1026,17 +1039,21 @@ Self::Multi(_) => UnionKey::Multi,
             }
         }
 
-        impl Union<UnionKey> for MyUnion {
+        impl Name for MyUnion {
             #[must_use]
             fn name(&self) -> &'static str {
                 Self::name(self)
             }
+        }
 
+        impl Discriminant<UnionKey> for MyUnion {
             #[must_use]
             fn discriminant(&self) -> UnionKey {
                 Self::discriminant(self)
             }
         }
+
+        impl Union<UnionKey> for MyUnion {}
 
         impl ReadXdr for MyUnion {
             #[cfg(feature = "std")]
@@ -1103,17 +1120,21 @@ Self::V1(_) => 1,
             }
         }
 
-        impl Union<i32> for IntUnion {
+        impl Name for IntUnion {
             #[must_use]
             fn name(&self) -> &'static str {
                 Self::name(self)
             }
+        }
 
+        impl Discriminant<i32> for IntUnion {
             #[must_use]
             fn discriminant(&self) -> i32 {
                 Self::discriminant(self)
             }
         }
+
+        impl Union<i32> for IntUnion {}
 
         impl ReadXdr for IntUnion {
             #[cfg(feature = "std")]


### PR DESCRIPTION
### What
In the Rust generator make the `name` and `discriminant` fns on enums and unions `const` and add `trait`s that group these fns. Also changed the `&str` return values so that they have a `'static` lifetime.

### Why
The fns can be const fns which increases the places we can use them, and their str values are easier to use if they have a static lifetime. @graydon asked for traits so it is easier to write code across all enum / union types.

Close #108 #107 #106 

### Additional Thoughts
Now that we're adding traits to the generated code it is becoming more interesting to have a use case where these traits could be usable across multiple sets of generated code which would mean moving out some of the code in `types.rs` into its own crate and repo. We may like to do this down the track.