### PR TITLE
Rust: Add additional conversion fns for array types

### DIFF
--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1,4 +1,4 @@
-use core::{fmt, fmt::Debug, ops::Deref};
+use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
 
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
@@ -71,6 +71,12 @@ impl fmt::Display for Error {
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{}", e),
         }
+    }
+}
+
+impl From<TryFromSliceError> for Error {
+    fn from(_: TryFromSliceError) -> Error {
+        Error::LengthMismatch
     }
 }
 
@@ -561,6 +567,15 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
     #[must_use]
     fn as_ref(&self) -> &Vec<T> {
         &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<T>) -> Result<Self> {
+        v.as_slice().try_into()
     }
 }
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -8,7 +8,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
   ("spec/fixtures/generator/block_comments.x", "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30")
 ];
 
-use core::{fmt, fmt::Debug, ops::Deref};
+use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
 
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
@@ -81,6 +81,12 @@ impl fmt::Display for Error {
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{}", e),
         }
+    }
+}
+
+impl From<TryFromSliceError> for Error {
+    fn from(_: TryFromSliceError) -> Error {
+        Error::LengthMismatch
     }
 }
 
@@ -571,6 +577,15 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
     #[must_use]
     fn as_ref(&self) -> &Vec<T> {
         &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<T>) -> Result<Self> {
+        v.as_slice().try_into()
     }
 }
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -8,7 +8,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
   ("spec/fixtures/generator/const.x", "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37")
 ];
 
-use core::{fmt, fmt::Debug, ops::Deref};
+use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
 
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
@@ -81,6 +81,12 @@ impl fmt::Display for Error {
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{}", e),
         }
+    }
+}
+
+impl From<TryFromSliceError> for Error {
+    fn from(_: TryFromSliceError) -> Error {
+        Error::LengthMismatch
     }
 }
 
@@ -571,6 +577,15 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
     #[must_use]
     fn as_ref(&self) -> &Vec<T> {
         &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<T>) -> Result<Self> {
+        v.as_slice().try_into()
     }
 }
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -8,7 +8,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
   ("spec/fixtures/generator/enum.x", "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f")
 ];
 
-use core::{fmt, fmt::Debug, ops::Deref};
+use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
 
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
@@ -81,6 +81,12 @@ impl fmt::Display for Error {
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{}", e),
         }
+    }
+}
+
+impl From<TryFromSliceError> for Error {
+    fn from(_: TryFromSliceError) -> Error {
+        Error::LengthMismatch
     }
 }
 
@@ -571,6 +577,15 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
     #[must_use]
     fn as_ref(&self) -> &Vec<T> {
         &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<T>) -> Result<Self> {
+        v.as_slice().try_into()
     }
 }
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -8,7 +8,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
   ("spec/fixtures/generator/nesting.x", "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a")
 ];
 
-use core::{fmt, fmt::Debug, ops::Deref};
+use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
 
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
@@ -81,6 +81,12 @@ impl fmt::Display for Error {
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{}", e),
         }
+    }
+}
+
+impl From<TryFromSliceError> for Error {
+    fn from(_: TryFromSliceError) -> Error {
+        Error::LengthMismatch
     }
 }
 
@@ -571,6 +577,15 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
     #[must_use]
     fn as_ref(&self) -> &Vec<T> {
         &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<T>) -> Result<Self> {
+        v.as_slice().try_into()
     }
 }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -8,7 +8,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
   ("spec/fixtures/generator/optional.x", "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7")
 ];
 
-use core::{fmt, fmt::Debug, ops::Deref};
+use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
 
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
@@ -81,6 +81,12 @@ impl fmt::Display for Error {
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{}", e),
         }
+    }
+}
+
+impl From<TryFromSliceError> for Error {
+    fn from(_: TryFromSliceError) -> Error {
+        Error::LengthMismatch
     }
 }
 
@@ -571,6 +577,15 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
     #[must_use]
     fn as_ref(&self) -> &Vec<T> {
         &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<T>) -> Result<Self> {
+        v.as_slice().try_into()
     }
 }
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -8,7 +8,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
   ("spec/fixtures/generator/struct.x", "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a")
 ];
 
-use core::{fmt, fmt::Debug, ops::Deref};
+use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
 
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
@@ -81,6 +81,12 @@ impl fmt::Display for Error {
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{}", e),
         }
+    }
+}
+
+impl From<TryFromSliceError> for Error {
+    fn from(_: TryFromSliceError) -> Error {
+        Error::LengthMismatch
     }
 }
 
@@ -571,6 +577,15 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
     #[must_use]
     fn as_ref(&self) -> &Vec<T> {
         &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<T>) -> Result<Self> {
+        v.as_slice().try_into()
     }
 }
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -8,7 +8,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
   ("spec/fixtures/generator/test.x", "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41")
 ];
 
-use core::{fmt, fmt::Debug, ops::Deref};
+use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
 
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
@@ -81,6 +81,12 @@ impl fmt::Display for Error {
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{}", e),
         }
+    }
+}
+
+impl From<TryFromSliceError> for Error {
+    fn from(_: TryFromSliceError) -> Error {
+        Error::LengthMismatch
     }
 }
 
@@ -575,6 +581,15 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 }
 
 #[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<T>) -> Result<Self> {
+        v.as_slice().try_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
@@ -955,6 +970,36 @@ impl WriteXdr for Uint512 {
     }
 }
 
+#[cfg(feature = "alloc")]
+impl TryFrom<Vec<u8>> for Uint512 {
+    type Error = Error;
+    fn try_from(x: Vec<u8>) -> Result<Self> {
+        x.as_slice().try_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl TryFrom<&Vec<u8>> for Uint512 {
+    type Error = Error;
+    fn try_from(x: &Vec<u8>) -> Result<Self> {
+        x.as_slice().try_into()
+    }
+}
+
+impl TryFrom<&[u8]> for Uint512 {
+    type Error = Error;
+    fn try_from(x: &[u8]) -> Result<Self> {
+        Ok(Uint512(x.try_into()?))
+    }
+}
+
+impl AsRef<[u8]> for Uint512 {
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
 // Uint513 is an XDR Typedef defines as:
 //
 //   typedef opaque uint513<64>;
@@ -1017,6 +1062,14 @@ impl From<Uint513> for Vec<u8> {
 impl TryFrom<Vec<u8>> for Uint513 {
     type Error = Error;
     fn try_from(x: Vec<u8>) -> Result<Self> {
+        Ok(Uint513(x.try_into()?))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl TryFrom<&Vec<u8>> for Uint513 {
+    type Error = Error;
+    fn try_from(x: &Vec<u8>) -> Result<Self> {
         Ok(Uint513(x.try_into()?))
     }
 }
@@ -1107,6 +1160,14 @@ impl TryFrom<Vec<u8>> for Uint514 {
     }
 }
 
+#[cfg(feature = "alloc")]
+impl TryFrom<&Vec<u8>> for Uint514 {
+    type Error = Error;
+    fn try_from(x: &Vec<u8>) -> Result<Self> {
+        Ok(Uint514(x.try_into()?))
+    }
+}
+
 impl AsRef<Vec<u8>> for Uint514 {
     #[must_use]
     fn as_ref(&self) -> &Vec<u8> {
@@ -1183,6 +1244,36 @@ impl WriteXdr for Hash {
     }
 }
 
+#[cfg(feature = "alloc")]
+impl TryFrom<Vec<u8>> for Hash {
+    type Error = Error;
+    fn try_from(x: Vec<u8>) -> Result<Self> {
+        x.as_slice().try_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl TryFrom<&Vec<u8>> for Hash {
+    type Error = Error;
+    fn try_from(x: &Vec<u8>) -> Result<Self> {
+        x.as_slice().try_into()
+    }
+}
+
+impl TryFrom<&[u8]> for Hash {
+    type Error = Error;
+    fn try_from(x: &[u8]) -> Result<Self> {
+        Ok(Hash(x.try_into()?))
+    }
+}
+
+impl AsRef<[u8]> for Hash {
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
 // Hashes1 is an XDR Typedef defines as:
 //
 //   typedef Hash Hashes1[12];
@@ -1224,6 +1315,36 @@ impl WriteXdr for Hashes1 {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
         self.0.write_xdr(w)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl TryFrom<Vec<Hash>> for Hashes1 {
+    type Error = Error;
+    fn try_from(x: Vec<Hash>) -> Result<Self> {
+        x.as_slice().try_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl TryFrom<&Vec<Hash>> for Hashes1 {
+    type Error = Error;
+    fn try_from(x: &Vec<Hash>) -> Result<Self> {
+        x.as_slice().try_into()
+    }
+}
+
+impl TryFrom<&[Hash]> for Hashes1 {
+    type Error = Error;
+    fn try_from(x: &[Hash]) -> Result<Self> {
+        Ok(Hashes1(x.try_into()?))
+    }
+}
+
+impl AsRef<[Hash]> for Hashes1 {
+    #[must_use]
+    fn as_ref(&self) -> &[Hash] {
+        &self.0
     }
 }
 
@@ -1289,6 +1410,14 @@ impl From<Hashes2> for Vec<Hash> {
 impl TryFrom<Vec<Hash>> for Hashes2 {
     type Error = Error;
     fn try_from(x: Vec<Hash>) -> Result<Self> {
+        Ok(Hashes2(x.try_into()?))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl TryFrom<&Vec<Hash>> for Hashes2 {
+    type Error = Error;
+    fn try_from(x: &Vec<Hash>) -> Result<Self> {
         Ok(Hashes2(x.try_into()?))
     }
 }
@@ -1375,6 +1504,14 @@ impl From<Hashes3> for Vec<Hash> {
 impl TryFrom<Vec<Hash>> for Hashes3 {
     type Error = Error;
     fn try_from(x: Vec<Hash>) -> Result<Self> {
+        Ok(Hashes3(x.try_into()?))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl TryFrom<&Vec<Hash>> for Hashes3 {
+    type Error = Error;
+    fn try_from(x: &Vec<Hash>) -> Result<Self> {
         Ok(Hashes3(x.try_into()?))
     }
 }

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -8,7 +8,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
   ("spec/fixtures/generator/union.x", "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41")
 ];
 
-use core::{fmt, fmt::Debug, ops::Deref};
+use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
 
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
@@ -81,6 +81,12 @@ impl fmt::Display for Error {
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{}", e),
         }
+    }
+}
+
+impl From<TryFromSliceError> for Error {
+    fn from(_: TryFromSliceError) -> Error {
+        Error::LengthMismatch
     }
 }
 
@@ -571,6 +577,15 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
     #[must_use]
     fn as_ref(&self) -> &Vec<T> {
         &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<T>) -> Result<Self> {
+        v.as_slice().try_into()
     }
 }
 


### PR DESCRIPTION
### What
Add additional conversion fns for array types to the Rust generated code.

### Why
To make it simpler to convert from slices to fixed length XDR arrays.