### PR TITLE
Rust: Add as_slice to fixed length arrays

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -415,6 +415,13 @@ module Xdrgen
           if is_fixed_array_type(typedef.type)
             out.break
             out.puts <<-EOS.strip_heredoc
+            impl #{name typedef} {
+                #[must_use]
+                pub fn as_slice(&self) -> &[#{element_type_for_vec(typedef.type)}] {
+                    &self.0
+                }
+            }
+
             #[cfg(feature = "alloc")]
             impl TryFrom<Vec<#{element_type_for_vec(typedef.type)}>> for #{name typedef} {
                 type Error = Error;

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -970,6 +970,13 @@ impl WriteXdr for Uint512 {
     }
 }
 
+impl Uint512 {
+    #[must_use]
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+}
+
 #[cfg(feature = "alloc")]
 impl TryFrom<Vec<u8>> for Uint512 {
     type Error = Error;
@@ -1244,6 +1251,13 @@ impl WriteXdr for Hash {
     }
 }
 
+impl Hash {
+    #[must_use]
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+}
+
 #[cfg(feature = "alloc")]
 impl TryFrom<Vec<u8>> for Hash {
     type Error = Error;
@@ -1315,6 +1329,13 @@ impl WriteXdr for Hashes1 {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
         self.0.write_xdr(w)
+    }
+}
+
+impl Hashes1 {
+    #[must_use]
+    pub fn as_slice(&self) -> &[Hash] {
+        &self.0
     }
 }
 


### PR DESCRIPTION
### What
Add as_slice to fixed length arrays.

### Why
Convenience and consistency with other types.