### PR TITLE
Rust: allow large enum variants

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -275,6 +275,7 @@ module Xdrgen
         discriminant_type_builtin = is_builtin_type(union.discriminant.type) || (is_builtin_type(union.discriminant.type.resolved_type.type) if union.discriminant.type.respond_to?(:resolved_type) && AST::Definitions::Typedef === union.discriminant.type.resolved_type)
         out.puts "// union with discriminant #{discriminant_type}"
         out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]"
+        out.puts "#[allow(clippy::large_enum_variant)]"
         out.puts "pub enum #{name union} {"
         out.indent do
           union_cases(union) do |case_name, arm|

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -1095,6 +1095,7 @@ self.foo.write_xdr(w)?;
 //
 // union with discriminant UnionKey
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
   One(MyUnionOne),
   Two(MyUnionTwo),

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -1991,6 +1991,7 @@ impl WriteXdr for NesterNestedStruct {
 //
 // union with discriminant Color
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(clippy::large_enum_variant)]
 pub enum NesterNestedUnion {
   Red,
 }

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -1030,6 +1030,7 @@ Self::Multi => "Multi",
 //
 // union with discriminant UnionKey
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
   Error(i32),
   Multi(VecM::<i32>),
@@ -1111,6 +1112,7 @@ Self::Multi(v) => v.write_xdr(w)?,
 //
 // union with discriminant i32
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(clippy::large_enum_variant)]
 pub enum IntUnion {
   V0(i32),
   V1(VecM::<i32>),


### PR DESCRIPTION
### What
Allow Rust enum variants generated for unions to have large discrepencies in size.

### Why
In some cases it may be beneficial to box the large variants, but it is difficult to distinguish them in xdrgen so we'd probably need labeling via comments in the XDR if we wanted to selectively box enum variants. We could also just box all variants, but that reduces ergonomics and isn't necessarily better. The only case we have where this is required, that is part of CAP-56's new TransactionMetaV3, isn't a problem since the largest variant will be the most common variant.

Close #115