### PR TITLE
Rust: Add serde json support

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -134,7 +134,7 @@ module Xdrgen
 
       def render_struct(out, struct)
         out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]"
-        out.puts "#[cfg_attr(all(feature = \"serde\", feature = \"alloc\"), derive(Serialize, Deserialize), serde(rename_all = \"camelCase\"))]"
+        out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]}
         out.puts "pub struct #{name struct} {"
         out.indent do
           struct.members.each do |m|
@@ -171,7 +171,7 @@ module Xdrgen
       def render_enum(out, enum)
         out.puts "// enum"
         out.puts "#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]"
-        out.puts "#[cfg_attr(feature = \"serde\", derive(Serialize, Deserialize), serde(rename_all = \"camelCase\"))]"
+        out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]}
         out.puts "#[repr(i32)]"
         out.puts "pub enum #{name enum} {"
         out.indent do
@@ -277,7 +277,7 @@ module Xdrgen
         discriminant_type_builtin = is_builtin_type(union.discriminant.type) || (is_builtin_type(union.discriminant.type.resolved_type.type) if union.discriminant.type.respond_to?(:resolved_type) && AST::Definitions::Typedef === union.discriminant.type.resolved_type)
         out.puts "// union with discriminant #{discriminant_type}"
         out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]"
-        out.puts "#[cfg_attr(feature = \"serde\", derive(Serialize, Deserialize), serde(rename_all = \"camelCase\"))]"
+        out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]}
         out.puts "#[allow(clippy::large_enum_variant)]"
         out.puts "pub enum #{name union} {"
         out.indent do
@@ -376,7 +376,7 @@ module Xdrgen
         else
           out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]"
           out.puts "#[derive(Default)]" if is_var_array_type(typedef.type)
-          out.puts "#[cfg_attr(feature = \"serde\", derive(Serialize, Deserialize), serde(rename_all = \"camelCase\"))]"
+          out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]}
           out.puts "pub struct #{name typedef}(pub #{reference(typedef, typedef.type)});"
           out.puts ""
           out.puts <<-EOS.strip_heredoc

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -133,8 +133,8 @@ module Xdrgen
       end
 
       def render_struct(out, struct)
-        out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]"
-        out.puts "#[serde(rename_all = \"camelCase\")]"
+        out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]"
+        out.puts "#[cfg_attr(feature = \"serde\", derive(Serialize, Deserialize), serde(rename_all = \"camelCase\"))]"
         out.puts "pub struct #{name struct} {"
         out.indent do
           struct.members.each do |m|
@@ -170,8 +170,8 @@ module Xdrgen
 
       def render_enum(out, enum)
         out.puts "// enum"
-        out.puts "#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]"
-        out.puts "#[serde(rename_all = \"camelCase\")]"
+        out.puts "#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]"
+        out.puts "#[cfg_attr(feature = \"serde\", derive(Serialize, Deserialize), serde(rename_all = \"camelCase\"))]"
         out.puts "#[repr(i32)]"
         out.puts "pub enum #{name enum} {"
         out.indent do
@@ -276,8 +276,8 @@ module Xdrgen
         discriminant_type = reference(nil, union.discriminant.type)
         discriminant_type_builtin = is_builtin_type(union.discriminant.type) || (is_builtin_type(union.discriminant.type.resolved_type.type) if union.discriminant.type.respond_to?(:resolved_type) && AST::Definitions::Typedef === union.discriminant.type.resolved_type)
         out.puts "// union with discriminant #{discriminant_type}"
-        out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]"
-        out.puts "#[serde(rename_all = \"camelCase\")]"
+        out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]"
+        out.puts "#[cfg_attr(feature = \"serde\", derive(Serialize, Deserialize), serde(rename_all = \"camelCase\"))]"
         out.puts "#[allow(clippy::large_enum_variant)]"
         out.puts "pub enum #{name union} {"
         out.indent do
@@ -374,9 +374,9 @@ module Xdrgen
         if is_builtin_type(typedef.type)
           out.puts "pub type #{name typedef} = #{reference(typedef, typedef.type)};"
         else
-          out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]"
+          out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]"
           out.puts "#[derive(Default)]" if is_var_array_type(typedef.type)
-          out.puts "#[serde(rename_all = \"camelCase\")]"
+          out.puts "#[cfg_attr(feature = \"serde\", derive(Serialize, Deserialize), serde(rename_all = \"camelCase\"))]"
           out.puts "pub struct #{name typedef}(pub #{reference(typedef, typedef.type)});"
           out.puts ""
           out.puts <<-EOS.strip_heredoc

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -133,7 +133,8 @@ module Xdrgen
       end
 
       def render_struct(out, struct)
-        out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]"
+        out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]"
+        out.puts "#[serde(rename_all = \"camelCase\")]"
         out.puts "pub struct #{name struct} {"
         out.indent do
           struct.members.each do |m|
@@ -169,7 +170,8 @@ module Xdrgen
 
       def render_enum(out, enum)
         out.puts "// enum"
-        out.puts "#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]"
+        out.puts "#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]"
+        out.puts "#[serde(rename_all = \"camelCase\")]"
         out.puts "#[repr(i32)]"
         out.puts "pub enum #{name enum} {"
         out.indent do
@@ -274,7 +276,8 @@ module Xdrgen
         discriminant_type = reference(nil, union.discriminant.type)
         discriminant_type_builtin = is_builtin_type(union.discriminant.type) || (is_builtin_type(union.discriminant.type.resolved_type.type) if union.discriminant.type.respond_to?(:resolved_type) && AST::Definitions::Typedef === union.discriminant.type.resolved_type)
         out.puts "// union with discriminant #{discriminant_type}"
-        out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]"
+        out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]"
+        out.puts "#[serde(rename_all = \"camelCase\")]"
         out.puts "#[allow(clippy::large_enum_variant)]"
         out.puts "pub enum #{name union} {"
         out.indent do
@@ -371,8 +374,9 @@ module Xdrgen
         if is_builtin_type(typedef.type)
           out.puts "pub type #{name typedef} = #{reference(typedef, typedef.type)};"
         else
-          out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]"
+          out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]"
           out.puts "#[derive(Default)]" if is_var_array_type(typedef.type)
+          out.puts "#[serde(rename_all = \"camelCase\")]"
           out.puts "pub struct #{name typedef}(pub #{reference(typedef, typedef.type)});"
           out.puts ""
           out.puts <<-EOS.strip_heredoc

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -134,7 +134,7 @@ module Xdrgen
 
       def render_struct(out, struct)
         out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]"
-        out.puts "#[cfg_attr(feature = \"serde\", derive(Serialize, Deserialize), serde(rename_all = \"camelCase\"))]"
+        out.puts "#[cfg_attr(all(feature = \"serde\", feature = \"alloc\"), derive(Serialize, Deserialize), serde(rename_all = \"camelCase\"))]"
         out.puts "pub struct #{name struct} {"
         out.indent do
           struct.members.each do |m|

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1,8 +1,5 @@
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
@@ -476,7 +473,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1,4 +1,6 @@
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
+
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
@@ -8,18 +10,7 @@ use core::marker::PhantomData;
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
     pub mod boxed {
-        use serde::{Deserialize, Deserializer, Serialize};
-        #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-        pub struct Box<T: 'static>(&'static T);
-
-        impl<'de, T> Deserialize<'de> for Box<T> {
-            fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
-            where
-                D: Deserializer<'de>,
-            {
-                todo!();
-            }
-        }
+        pub type Box<T> = &'static T;
     }
     pub mod vec {
         pub type Vec<T> = &'static [T];
@@ -484,26 +475,15 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 }
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
-
-#[cfg(not(feature = "alloc"))]
-use serde::Deserializer;
-#[cfg(not(feature = "alloc"))]
-impl<'de, T, const MAX: u32> Deserialize<'de> for VecM<T, MAX> {
-    fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        todo!();
-    }
-}
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1,4 +1,5 @@
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
@@ -7,7 +8,18 @@ use core::marker::PhantomData;
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
     pub mod boxed {
-        pub type Box<T> = &'static T;
+        use serde::{Deserialize, Deserializer, Serialize};
+        #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+        pub struct Box<T: 'static>(&'static T);
+
+        impl<'de, T> Deserialize<'de> for Box<T> {
+            fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                todo!();
+            }
+        }
     }
     pub mod vec {
         pub type Vec<T> = &'static [T];
@@ -472,14 +484,26 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 }
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
+
+#[cfg(not(feature = "alloc"))]
+use serde::Deserializer;
+#[cfg(not(feature = "alloc"))]
+impl<'de, T, const MAX: u32> Deserialize<'de> for VecM<T, MAX> {
+    fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        todo!();
+    }
+}
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -9,6 +9,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
@@ -17,7 +18,18 @@ use core::marker::PhantomData;
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
     pub mod boxed {
-        pub type Box<T> = &'static T;
+        use serde::{Deserialize, Deserializer, Serialize};
+        #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+        pub struct Box<T: 'static>(&'static T);
+
+        impl<'de, T> Deserialize<'de> for Box<T> {
+            fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                todo!();
+            }
+        }
     }
     pub mod vec {
         pub type Vec<T> = &'static [T];
@@ -482,14 +494,26 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 }
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
+
+#[cfg(not(feature = "alloc"))]
+use serde::Deserializer;
+#[cfg(not(feature = "alloc"))]
+impl<'de, T, const MAX: u32> Deserialize<'de> for VecM<T, MAX> {
+    fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        todo!();
+    }
+}
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;
@@ -934,7 +958,8 @@ mod tests {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[repr(i32)]
 pub enum AccountFlags {
   AuthRequiredFlag = 1,

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -9,6 +9,8 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
+
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
@@ -18,18 +20,7 @@ use core::marker::PhantomData;
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
     pub mod boxed {
-        use serde::{Deserialize, Deserializer, Serialize};
-        #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-        pub struct Box<T: 'static>(&'static T);
-
-        impl<'de, T> Deserialize<'de> for Box<T> {
-            fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
-            where
-                D: Deserializer<'de>,
-            {
-                todo!();
-            }
-        }
+        pub type Box<T> = &'static T;
     }
     pub mod vec {
         pub type Vec<T> = &'static [T];
@@ -494,26 +485,15 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 }
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
-
-#[cfg(not(feature = "alloc"))]
-use serde::Deserializer;
-#[cfg(not(feature = "alloc"))]
-impl<'de, T, const MAX: u32> Deserialize<'de> for VecM<T, MAX> {
-    fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        todo!();
-    }
-}
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;
@@ -958,8 +938,8 @@ mod tests {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 #[repr(i32)]
 pub enum AccountFlags {
   AuthRequiredFlag = 1,

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -10,9 +10,6 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
@@ -486,7 +483,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
@@ -939,7 +936,7 @@ mod tests {
 //
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 #[repr(i32)]
 pub enum AccountFlags {
   AuthRequiredFlag = 1,

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -9,6 +9,8 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
+
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
@@ -18,18 +20,7 @@ use core::marker::PhantomData;
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
     pub mod boxed {
-        use serde::{Deserialize, Deserializer, Serialize};
-        #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-        pub struct Box<T: 'static>(&'static T);
-
-        impl<'de, T> Deserialize<'de> for Box<T> {
-            fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
-            where
-                D: Deserializer<'de>,
-            {
-                todo!();
-            }
-        }
+        pub type Box<T> = &'static T;
     }
     pub mod vec {
         pub type Vec<T> = &'static [T];
@@ -494,26 +485,15 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 }
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
-
-#[cfg(not(feature = "alloc"))]
-use serde::Deserializer;
-#[cfg(not(feature = "alloc"))]
-impl<'de, T, const MAX: u32> Deserialize<'de> for VecM<T, MAX> {
-    fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        todo!();
-    }
-}
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -9,6 +9,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
@@ -17,7 +18,18 @@ use core::marker::PhantomData;
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
     pub mod boxed {
-        pub type Box<T> = &'static T;
+        use serde::{Deserialize, Deserializer, Serialize};
+        #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+        pub struct Box<T: 'static>(&'static T);
+
+        impl<'de, T> Deserialize<'de> for Box<T> {
+            fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                todo!();
+            }
+        }
     }
     pub mod vec {
         pub type Vec<T> = &'static [T];
@@ -482,14 +494,26 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 }
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
+
+#[cfg(not(feature = "alloc"))]
+use serde::Deserializer;
+#[cfg(not(feature = "alloc"))]
+impl<'de, T, const MAX: u32> Deserialize<'de> for VecM<T, MAX> {
+    fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        todo!();
+    }
+}
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -10,9 +10,6 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
@@ -486,7 +483,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -10,9 +10,6 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
@@ -486,7 +483,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
@@ -958,7 +955,7 @@ mod tests {
 //
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 #[repr(i32)]
 pub enum MessageType {
   ErrorMsg = 0,
@@ -1074,7 +1071,7 @@ Self::FbaMessage => "FbaMessage",
 //
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 #[repr(i32)]
 pub enum Color {
   Red = 0,
@@ -1157,7 +1154,7 @@ Self::Blue => "Blue",
 //
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 #[repr(i32)]
 pub enum Color2 {
   Red2 = 0,

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -9,6 +9,8 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
+
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
@@ -18,18 +20,7 @@ use core::marker::PhantomData;
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
     pub mod boxed {
-        use serde::{Deserialize, Deserializer, Serialize};
-        #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-        pub struct Box<T: 'static>(&'static T);
-
-        impl<'de, T> Deserialize<'de> for Box<T> {
-            fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
-            where
-                D: Deserializer<'de>,
-            {
-                todo!();
-            }
-        }
+        pub type Box<T> = &'static T;
     }
     pub mod vec {
         pub type Vec<T> = &'static [T];
@@ -494,26 +485,15 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 }
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
-
-#[cfg(not(feature = "alloc"))]
-use serde::Deserializer;
-#[cfg(not(feature = "alloc"))]
-impl<'de, T, const MAX: u32> Deserialize<'de> for VecM<T, MAX> {
-    fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        todo!();
-    }
-}
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;
@@ -977,8 +957,8 @@ mod tests {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 #[repr(i32)]
 pub enum MessageType {
   ErrorMsg = 0,
@@ -1093,8 +1073,8 @@ Self::FbaMessage => "FbaMessage",
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 #[repr(i32)]
 pub enum Color {
   Red = 0,
@@ -1176,8 +1156,8 @@ Self::Blue => "Blue",
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 #[repr(i32)]
 pub enum Color2 {
   Red2 = 0,

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -10,9 +10,6 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
@@ -486,7 +483,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
@@ -940,7 +937,7 @@ mod tests {
 //
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 #[repr(i32)]
 pub enum UnionKey {
   One = 1,
@@ -1026,7 +1023,7 @@ pub type Foo = i32;
 //            }
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 pub struct MyUnionOne {
   pub some_int: i32,
 }
@@ -1056,7 +1053,7 @@ impl WriteXdr for MyUnionOne {
 //            }
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 pub struct MyUnionTwo {
   pub some_int: i32,
   pub foo: i32,
@@ -1102,7 +1099,7 @@ self.foo.write_xdr(w)?;
 //
 // union with discriminant UnionKey
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 #[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
   One(MyUnionOne),

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -9,6 +9,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
@@ -17,7 +18,18 @@ use core::marker::PhantomData;
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
     pub mod boxed {
-        pub type Box<T> = &'static T;
+        use serde::{Deserialize, Deserializer, Serialize};
+        #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+        pub struct Box<T: 'static>(&'static T);
+
+        impl<'de, T> Deserialize<'de> for Box<T> {
+            fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                todo!();
+            }
+        }
     }
     pub mod vec {
         pub type Vec<T> = &'static [T];
@@ -482,14 +494,26 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 }
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
+
+#[cfg(not(feature = "alloc"))]
+use serde::Deserializer;
+#[cfg(not(feature = "alloc"))]
+impl<'de, T, const MAX: u32> Deserialize<'de> for VecM<T, MAX> {
+    fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        todo!();
+    }
+}
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;
@@ -935,7 +959,8 @@ mod tests {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[repr(i32)]
 pub enum UnionKey {
   One = 1,
@@ -1020,7 +1045,8 @@ pub type Foo = i32;
 //                int someInt;
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct MyUnionOne {
   pub some_int: i32,
 }
@@ -1049,7 +1075,8 @@ impl WriteXdr for MyUnionOne {
 //                Foo foo;
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct MyUnionTwo {
   pub some_int: i32,
   pub foo: i32,
@@ -1094,7 +1121,8 @@ self.foo.write_xdr(w)?;
 //    };
 //
 // union with discriminant UnionKey
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
   One(MyUnionOne),

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -9,6 +9,8 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
+
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
@@ -18,18 +20,7 @@ use core::marker::PhantomData;
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
     pub mod boxed {
-        use serde::{Deserialize, Deserializer, Serialize};
-        #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-        pub struct Box<T: 'static>(&'static T);
-
-        impl<'de, T> Deserialize<'de> for Box<T> {
-            fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
-            where
-                D: Deserializer<'de>,
-            {
-                todo!();
-            }
-        }
+        pub type Box<T> = &'static T;
     }
     pub mod vec {
         pub type Vec<T> = &'static [T];
@@ -494,26 +485,15 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 }
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
-
-#[cfg(not(feature = "alloc"))]
-use serde::Deserializer;
-#[cfg(not(feature = "alloc"))]
-impl<'de, T, const MAX: u32> Deserialize<'de> for VecM<T, MAX> {
-    fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        todo!();
-    }
-}
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;
@@ -959,8 +939,8 @@ mod tests {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 #[repr(i32)]
 pub enum UnionKey {
   One = 1,
@@ -1045,8 +1025,8 @@ pub type Foo = i32;
 //                int someInt;
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct MyUnionOne {
   pub some_int: i32,
 }
@@ -1075,8 +1055,8 @@ impl WriteXdr for MyUnionOne {
 //                Foo foo;
 //            }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct MyUnionTwo {
   pub some_int: i32,
   pub foo: i32,
@@ -1121,8 +1101,8 @@ self.foo.write_xdr(w)?;
 //    };
 //
 // union with discriminant UnionKey
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 #[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
   One(MyUnionOne),

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -9,6 +9,8 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
+
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
@@ -18,18 +20,7 @@ use core::marker::PhantomData;
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
     pub mod boxed {
-        use serde::{Deserialize, Deserializer, Serialize};
-        #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-        pub struct Box<T: 'static>(&'static T);
-
-        impl<'de, T> Deserialize<'de> for Box<T> {
-            fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
-            where
-                D: Deserializer<'de>,
-            {
-                todo!();
-            }
-        }
+        pub type Box<T> = &'static T;
     }
     pub mod vec {
         pub type Vec<T> = &'static [T];
@@ -494,26 +485,15 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 }
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
-
-#[cfg(not(feature = "alloc"))]
-use serde::Deserializer;
-#[cfg(not(feature = "alloc"))]
-impl<'de, T, const MAX: u32> Deserialize<'de> for VecM<T, MAX> {
-    fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        todo!();
-    }
-}
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;
@@ -965,8 +945,8 @@ pub type Arr = [i32; 2];
 //      Arr *thirdOption;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct HasOptions {
   pub first_option: Option<i32>,
   pub second_option: Option<i32>,

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -10,9 +10,6 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
@@ -486,7 +483,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
@@ -946,7 +943,7 @@ pub type Arr = [i32; 2];
 //    };
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 pub struct HasOptions {
   pub first_option: Option<i32>,
   pub second_option: Option<i32>,

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -9,6 +9,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
@@ -17,7 +18,18 @@ use core::marker::PhantomData;
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
     pub mod boxed {
-        pub type Box<T> = &'static T;
+        use serde::{Deserialize, Deserializer, Serialize};
+        #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+        pub struct Box<T: 'static>(&'static T);
+
+        impl<'de, T> Deserialize<'de> for Box<T> {
+            fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                todo!();
+            }
+        }
     }
     pub mod vec {
         pub type Vec<T> = &'static [T];
@@ -482,14 +494,26 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 }
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
+
+#[cfg(not(feature = "alloc"))]
+use serde::Deserializer;
+#[cfg(not(feature = "alloc"))]
+impl<'de, T, const MAX: u32> Deserialize<'de> for VecM<T, MAX> {
+    fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        todo!();
+    }
+}
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;
@@ -941,7 +965,8 @@ pub type Arr = [i32; 2];
 //      Arr *thirdOption;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct HasOptions {
   pub first_option: Option<i32>,
   pub second_option: Option<i32>,

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -9,6 +9,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
@@ -17,7 +18,18 @@ use core::marker::PhantomData;
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
     pub mod boxed {
-        pub type Box<T> = &'static T;
+        use serde::{Deserialize, Deserializer, Serialize};
+        #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+        pub struct Box<T: 'static>(&'static T);
+
+        impl<'de, T> Deserialize<'de> for Box<T> {
+            fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                todo!();
+            }
+        }
     }
     pub mod vec {
         pub type Vec<T> = &'static [T];
@@ -482,14 +494,26 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 }
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
+
+#[cfg(not(feature = "alloc"))]
+use serde::Deserializer;
+#[cfg(not(feature = "alloc"))]
+impl<'de, T, const MAX: u32> Deserialize<'de> for VecM<T, MAX> {
+    fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        todo!();
+    }
+}
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;
@@ -943,7 +967,8 @@ pub type Int64 = i64;
 //        string maxString<100>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct MyStruct {
   pub some_int: i32,
   pub a_big_int: i64,

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -10,9 +10,6 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
@@ -486,7 +483,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
@@ -948,7 +945,7 @@ pub type Int64 = i64;
 //    };
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 pub struct MyStruct {
   pub some_int: i32,
   pub a_big_int: i64,

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -9,6 +9,8 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
+
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
@@ -18,18 +20,7 @@ use core::marker::PhantomData;
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
     pub mod boxed {
-        use serde::{Deserialize, Deserializer, Serialize};
-        #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-        pub struct Box<T: 'static>(&'static T);
-
-        impl<'de, T> Deserialize<'de> for Box<T> {
-            fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
-            where
-                D: Deserializer<'de>,
-            {
-                todo!();
-            }
-        }
+        pub type Box<T> = &'static T;
     }
     pub mod vec {
         pub type Vec<T> = &'static [T];
@@ -494,26 +485,15 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 }
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
-
-#[cfg(not(feature = "alloc"))]
-use serde::Deserializer;
-#[cfg(not(feature = "alloc"))]
-impl<'de, T, const MAX: u32> Deserialize<'de> for VecM<T, MAX> {
-    fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        todo!();
-    }
-}
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;
@@ -967,8 +947,8 @@ pub type Int64 = i64;
 //        string maxString<100>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct MyStruct {
   pub some_int: i32,
   pub a_big_int: i64,

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -10,9 +10,6 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
@@ -486,7 +483,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
@@ -935,7 +932,7 @@ mod tests {
 //   typedef opaque uint512[64];
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 pub struct Uint512(pub [u8; 64]);
 
 impl From<Uint512> for [u8; 64] {
@@ -1018,7 +1015,7 @@ impl AsRef<[u8]> for Uint512 {
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[derive(Default)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 pub struct Uint513(pub VecM::<u8, 64>);
 
 impl From<Uint513> for VecM::<u8, 64> {
@@ -1113,7 +1110,7 @@ impl AsRef<[u8]> for Uint513 {
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[derive(Default)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 pub struct Uint514(pub VecM::<u8>);
 
 impl From<Uint514> for VecM::<u8> {
@@ -1219,7 +1216,7 @@ pub type Str2 = VecM::<u8>;
 //   typedef opaque Hash[32];
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 pub struct Hash(pub [u8; 32]);
 
 impl From<Hash> for [u8; 32] {
@@ -1301,7 +1298,7 @@ impl AsRef<[u8]> for Hash {
 //   typedef Hash Hashes1[12];
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 pub struct Hashes1(pub [Hash; 12]);
 
 impl From<Hashes1> for [Hash; 12] {
@@ -1384,7 +1381,7 @@ impl AsRef<[Hash]> for Hashes1 {
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[derive(Default)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 pub struct Hashes2(pub VecM::<Hash, 12>);
 
 impl From<Hashes2> for VecM::<Hash, 12> {
@@ -1479,7 +1476,7 @@ impl AsRef<[Hash]> for Hashes2 {
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[derive(Default)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 pub struct Hashes3(pub VecM::<Hash>);
 
 impl From<Hashes3> for VecM::<Hash> {
@@ -1573,7 +1570,7 @@ impl AsRef<[Hash]> for Hashes3 {
 //   typedef Hash *optHash1;
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 pub struct OptHash1(pub Option<Hash>);
 
 impl From<OptHash1> for Option<Hash> {
@@ -1618,7 +1615,7 @@ impl WriteXdr for OptHash1 {
 //   typedef Hash* optHash2;
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 pub struct OptHash2(pub Option<Hash>);
 
 impl From<OptHash2> for Option<Hash> {
@@ -1696,7 +1693,7 @@ pub type Int4 = u64;
 //    };
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 pub struct MyStruct {
   pub field1: Uint512,
   pub field2: OptHash1,
@@ -1744,7 +1741,7 @@ self.field7.write_xdr(w)?;
 //    };
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 pub struct LotsOfMyStructs {
   pub members: VecM::<MyStruct>,
 }
@@ -1774,7 +1771,7 @@ impl WriteXdr for LotsOfMyStructs {
 //    };
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 pub struct HasStuff {
   pub data: LotsOfMyStructs,
 }
@@ -1806,7 +1803,7 @@ impl WriteXdr for HasStuff {
 //
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 #[repr(i32)]
 pub enum Color {
   Red = 0,
@@ -1900,7 +1897,7 @@ pub const BAR: u64 = FOO;
 //
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 #[repr(i32)]
 pub enum NesterNestedEnum {
   1 = 0,
@@ -1977,7 +1974,7 @@ Self::2 => "2",
 //      }
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 pub struct NesterNestedStruct {
   pub blah: i32,
 }
@@ -2010,7 +2007,7 @@ impl WriteXdr for NesterNestedStruct {
 //
 // union with discriminant Color
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 #[allow(clippy::large_enum_variant)]
 pub enum NesterNestedUnion {
   Red,
@@ -2099,7 +2096,7 @@ impl WriteXdr for NesterNestedUnion {
 //    };
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 pub struct Nester {
   pub nested_enum: NesterNestedEnum,
   pub nested_struct: NesterNestedStruct,

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -9,6 +9,8 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
+
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
@@ -18,18 +20,7 @@ use core::marker::PhantomData;
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
     pub mod boxed {
-        use serde::{Deserialize, Deserializer, Serialize};
-        #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-        pub struct Box<T: 'static>(&'static T);
-
-        impl<'de, T> Deserialize<'de> for Box<T> {
-            fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
-            where
-                D: Deserializer<'de>,
-            {
-                todo!();
-            }
-        }
+        pub type Box<T> = &'static T;
     }
     pub mod vec {
         pub type Vec<T> = &'static [T];
@@ -494,26 +485,15 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 }
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
-
-#[cfg(not(feature = "alloc"))]
-use serde::Deserializer;
-#[cfg(not(feature = "alloc"))]
-impl<'de, T, const MAX: u32> Deserialize<'de> for VecM<T, MAX> {
-    fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        todo!();
-    }
-}
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;
@@ -954,8 +934,8 @@ mod tests {
 //
 //   typedef opaque uint512[64];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct Uint512(pub [u8; 64]);
 
 impl From<Uint512> for [u8; 64] {
@@ -1036,9 +1016,9 @@ impl AsRef<[u8]> for Uint512 {
 //
 //   typedef opaque uint513<64>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[derive(Default)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct Uint513(pub VecM::<u8, 64>);
 
 impl From<Uint513> for VecM::<u8, 64> {
@@ -1131,9 +1111,9 @@ impl AsRef<[u8]> for Uint513 {
 //
 //   typedef opaque uint514<>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[derive(Default)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct Uint514(pub VecM::<u8>);
 
 impl From<Uint514> for VecM::<u8> {
@@ -1238,8 +1218,8 @@ pub type Str2 = VecM::<u8>;
 //
 //   typedef opaque Hash[32];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct Hash(pub [u8; 32]);
 
 impl From<Hash> for [u8; 32] {
@@ -1320,8 +1300,8 @@ impl AsRef<[u8]> for Hash {
 //
 //   typedef Hash Hashes1[12];
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct Hashes1(pub [Hash; 12]);
 
 impl From<Hashes1> for [Hash; 12] {
@@ -1402,9 +1382,9 @@ impl AsRef<[Hash]> for Hashes1 {
 //
 //   typedef Hash Hashes2<12>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[derive(Default)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct Hashes2(pub VecM::<Hash, 12>);
 
 impl From<Hashes2> for VecM::<Hash, 12> {
@@ -1497,9 +1477,9 @@ impl AsRef<[Hash]> for Hashes2 {
 //
 //   typedef Hash Hashes3<>;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[derive(Default)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct Hashes3(pub VecM::<Hash>);
 
 impl From<Hashes3> for VecM::<Hash> {
@@ -1592,8 +1572,8 @@ impl AsRef<[Hash]> for Hashes3 {
 //
 //   typedef Hash *optHash1;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct OptHash1(pub Option<Hash>);
 
 impl From<OptHash1> for Option<Hash> {
@@ -1637,8 +1617,8 @@ impl WriteXdr for OptHash1 {
 //
 //   typedef Hash* optHash2;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct OptHash2(pub Option<Hash>);
 
 impl From<OptHash2> for Option<Hash> {
@@ -1715,8 +1695,8 @@ pub type Int4 = u64;
 //        bool field7;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct MyStruct {
   pub field1: Uint512,
   pub field2: OptHash1,
@@ -1763,8 +1743,8 @@ self.field7.write_xdr(w)?;
 //        MyStruct members<>;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct LotsOfMyStructs {
   pub members: VecM::<MyStruct>,
 }
@@ -1793,8 +1773,8 @@ impl WriteXdr for LotsOfMyStructs {
 //      LotsOfMyStructs data;
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct HasStuff {
   pub data: LotsOfMyStructs,
 }
@@ -1825,8 +1805,8 @@ impl WriteXdr for HasStuff {
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 #[repr(i32)]
 pub enum Color {
   Red = 0,
@@ -1919,8 +1899,8 @@ pub const BAR: u64 = FOO;
 //      }
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 #[repr(i32)]
 pub enum NesterNestedEnum {
   1 = 0,
@@ -1996,8 +1976,8 @@ Self::2 => "2",
 //        int blah;
 //      }
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct NesterNestedStruct {
   pub blah: i32,
 }
@@ -2029,8 +2009,8 @@ impl WriteXdr for NesterNestedStruct {
 //      }
 //
 // union with discriminant Color
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 #[allow(clippy::large_enum_variant)]
 pub enum NesterNestedUnion {
   Red,
@@ -2118,8 +2098,8 @@ impl WriteXdr for NesterNestedUnion {
 //    
 //    };
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct Nester {
   pub nested_enum: NesterNestedEnum,
   pub nested_struct: NesterNestedStruct,

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -10,9 +10,6 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
@@ -486,7 +483,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
@@ -951,7 +948,7 @@ pub type Multi = i32;
 //
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 #[repr(i32)]
 pub enum UnionKey {
   Error = 0,
@@ -1035,7 +1032,7 @@ Self::Multi => "Multi",
 //
 // union with discriminant UnionKey
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 #[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
   Error(i32),
@@ -1118,7 +1115,7 @@ Self::Multi(v) => v.write_xdr(w)?,
 //
 // union with discriminant i32
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 #[allow(clippy::large_enum_variant)]
 pub enum IntUnion {
   V0(i32),
@@ -1193,7 +1190,7 @@ Self::V1(v) => v.write_xdr(w)?,
 //   typedef IntUnion IntUnion2;
 //
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]
 pub struct IntUnion2(pub IntUnion);
 
 impl From<IntUnion2> for IntUnion {

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -9,6 +9,8 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
+
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
@@ -18,18 +20,7 @@ use core::marker::PhantomData;
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
     pub mod boxed {
-        use serde::{Deserialize, Deserializer, Serialize};
-        #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-        pub struct Box<T: 'static>(&'static T);
-
-        impl<'de, T> Deserialize<'de> for Box<T> {
-            fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
-            where
-                D: Deserializer<'de>,
-            {
-                todo!();
-            }
-        }
+        pub type Box<T> = &'static T;
     }
     pub mod vec {
         pub type Vec<T> = &'static [T];
@@ -494,26 +485,15 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 }
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
-
-#[cfg(not(feature = "alloc"))]
-use serde::Deserializer;
-#[cfg(not(feature = "alloc"))]
-impl<'de, T, const MAX: u32> Deserialize<'de> for VecM<T, MAX> {
-    fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        todo!();
-    }
-}
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;
@@ -970,8 +950,8 @@ pub type Multi = i32;
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 #[repr(i32)]
 pub enum UnionKey {
   Error = 0,
@@ -1054,8 +1034,8 @@ Self::Multi => "Multi",
 //    };
 //
 // union with discriminant UnionKey
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 #[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
   Error(i32),
@@ -1137,8 +1117,8 @@ Self::Multi(v) => v.write_xdr(w)?,
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 #[allow(clippy::large_enum_variant)]
 pub enum IntUnion {
   V0(i32),
@@ -1212,8 +1192,8 @@ Self::V1(v) => v.write_xdr(w)?,
 //
 //   typedef IntUnion IntUnion2;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct IntUnion2(pub IntUnion);
 
 impl From<IntUnion2> for IntUnion {

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -9,6 +9,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, ops::Deref};
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
@@ -17,7 +18,18 @@ use core::marker::PhantomData;
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
     pub mod boxed {
-        pub type Box<T> = &'static T;
+        use serde::{Deserialize, Deserializer, Serialize};
+        #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+        pub struct Box<T: 'static>(&'static T);
+
+        impl<'de, T> Deserialize<'de> for Box<T> {
+            fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                todo!();
+            }
+        }
     }
     pub mod vec {
         pub type Vec<T> = &'static [T];
@@ -482,14 +494,26 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 }
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>)
 where
     T: 'static;
+
+#[cfg(not(feature = "alloc"))]
+use serde::Deserializer;
+#[cfg(not(feature = "alloc"))]
+impl<'de, T, const MAX: u32> Deserialize<'de> for VecM<T, MAX> {
+    fn deserialize<D>(_deserializer: D) -> core::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        todo!();
+    }
+}
 
 impl<T, const MAX: u32> Deref for VecM<T, MAX> {
     type Target = Vec<T>;
@@ -946,7 +970,8 @@ pub type Multi = i32;
 //    };
 //
 // enum
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[repr(i32)]
 pub enum UnionKey {
   Error = 0,
@@ -1029,7 +1054,8 @@ Self::Multi => "Multi",
 //    };
 //
 // union with discriminant UnionKey
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
   Error(i32),
@@ -1111,7 +1137,8 @@ Self::Multi(v) => v.write_xdr(w)?,
 //    };
 //
 // union with discriminant i32
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[allow(clippy::large_enum_variant)]
 pub enum IntUnion {
   V0(i32),
@@ -1185,7 +1212,8 @@ Self::V1(v) => v.write_xdr(w)?,
 //
 //   typedef IntUnion IntUnion2;
 //
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct IntUnion2(pub IntUnion);
 
 impl From<IntUnion2> for IntUnion {


### PR DESCRIPTION
Initial implementation of #112.

Deserialization of `Box` and `VecM` is not implemented yet without `alloc`. Should be fixed as part of https://github.com/stellar/rs-stellar-xdr/issues/47.
