### PR TITLE
Rust: make conversions into vec backed types more convenient

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -521,9 +521,10 @@ module Xdrgen
             }
 
             #[cfg(feature = "alloc")]
-            impl<T> TryFrom<&Vec<T>> for #{name typedef} {
+            impl<T> TryFrom<&Vec<T>> for #{name typedef}
             where
                 for<'a> &'a T: Into<#{element_type_for_vec(typedef.type)}>,
+            {
                 type Error = Error;
                 fn try_from(v: &Vec<T>) -> Result<Self> {
                     v.iter()

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -528,7 +528,7 @@ module Xdrgen
                 type Error = Error;
                 fn try_from(v: &Vec<T>) -> Result<Self> {
                     v.iter()
-                        .map(|t| <_ as Into<#{element_type_for_vec(typedef.type)}>>::into(t))
+                        .map(<_ as Into<#{element_type_for_vec(typedef.type)}>>::into)
                         .collect::<Vec<_>>()
                         .try_into()
                 }

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -521,10 +521,15 @@ module Xdrgen
             }
 
             #[cfg(feature = "alloc")]
-            impl TryFrom<&Vec<#{element_type_for_vec(typedef.type)}>> for #{name typedef} {
+            impl<T> TryFrom<&Vec<T>> for #{name typedef} {
+            where
+                for<'a> &'a T: Into<#{element_type_for_vec(typedef.type)}>,
                 type Error = Error;
-                fn try_from(x: &Vec<#{element_type_for_vec(typedef.type)}>) -> Result<Self> {
-                    Ok(#{name typedef}(x.try_into()?))
+                fn try_from(v: &Vec<T>) -> Result<Self> {
+                    v.iter()
+                        .map(|t| <_ as Into<#{element_type_for_vec(typedef.type)}>>::into(t))
+                        .collect::<Vec<_>>()
+                        .try_into()
                 }
             }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -590,7 +590,7 @@ where
     type Error = Error;
     fn try_from(v: &Vec<I>) -> Result<Self> {
         v.iter()
-            .map(|i| <_ as Into<T>>::into(i))
+            .map(<_ as Into<T>>::into)
             .collect::<Vec<_>>()
             .try_into()
     }

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -583,11 +583,15 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 }
 
 #[cfg(feature = "alloc")]
-impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
+impl<I, T> TryFrom<&Vec<I>> for VecM<T, MAX> {
+where
+    for<'a> &'a I: Into<T>,
     type Error = Error;
-
-    fn try_from(v: &Vec<T>) -> Result<Self> {
-        v.as_slice().try_into()
+    fn try_from(v: &Vec<I>) -> Result<Self> {
+        v.iter()
+            .map(|i| <_ as Into<T>>::into(i))
+            .collect::<Vec<_>>()
+            .try_into()
     }
 }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -584,7 +584,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 
 #[cfg(feature = "alloc")]
 impl<I, T> TryFrom<&Vec<I>> for VecM<T, MAX>
-whe
+where
     for<'a> &'a I: Into<T>,
 {
     type Error = Error;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -583,7 +583,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 }
 
 #[cfg(feature = "alloc")]
-impl<I, T> TryFrom<&Vec<I>> for VecM<T, MAX>
+impl<I, T, const MAX: u32> TryFrom<&Vec<I>> for VecM<T, MAX>
 where
     for<'a> &'a I: Into<T>,
 {

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -583,9 +583,10 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 }
 
 #[cfg(feature = "alloc")]
-impl<I, T> TryFrom<&Vec<I>> for VecM<T, MAX> {
-where
+impl<I, T> TryFrom<&Vec<I>> for VecM<T, MAX>
+whe
     for<'a> &'a I: Into<T>,
+{
     type Error = Error;
     fn try_from(v: &Vec<I>) -> Result<Self> {
         v.iter()

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -593,11 +593,15 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 }
 
 #[cfg(feature = "alloc")]
-impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
+impl<I, T> TryFrom<&Vec<I>> for VecM<T, MAX> {
+where
+    for<'a> &'a I: Into<T>,
     type Error = Error;
-
-    fn try_from(v: &Vec<T>) -> Result<Self> {
-        v.as_slice().try_into()
+    fn try_from(v: &Vec<I>) -> Result<Self> {
+        v.iter()
+            .map(|i| <_ as Into<T>>::into(i))
+            .collect::<Vec<_>>()
+            .try_into()
     }
 }
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -593,11 +593,15 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 }
 
 #[cfg(feature = "alloc")]
-impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
+impl<I, T> TryFrom<&Vec<I>> for VecM<T, MAX> {
+where
+    for<'a> &'a I: Into<T>,
     type Error = Error;
-
-    fn try_from(v: &Vec<T>) -> Result<Self> {
-        v.as_slice().try_into()
+    fn try_from(v: &Vec<I>) -> Result<Self> {
+        v.iter()
+            .map(|i| <_ as Into<T>>::into(i))
+            .collect::<Vec<_>>()
+            .try_into()
     }
 }
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -593,11 +593,15 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 }
 
 #[cfg(feature = "alloc")]
-impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
+impl<I, T> TryFrom<&Vec<I>> for VecM<T, MAX> {
+where
+    for<'a> &'a I: Into<T>,
     type Error = Error;
-
-    fn try_from(v: &Vec<T>) -> Result<Self> {
-        v.as_slice().try_into()
+    fn try_from(v: &Vec<I>) -> Result<Self> {
+        v.iter()
+            .map(|i| <_ as Into<T>>::into(i))
+            .collect::<Vec<_>>()
+            .try_into()
     }
 }
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -593,11 +593,15 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 }
 
 #[cfg(feature = "alloc")]
-impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
+impl<I, T> TryFrom<&Vec<I>> for VecM<T, MAX> {
+where
+    for<'a> &'a I: Into<T>,
     type Error = Error;
-
-    fn try_from(v: &Vec<T>) -> Result<Self> {
-        v.as_slice().try_into()
+    fn try_from(v: &Vec<I>) -> Result<Self> {
+        v.iter()
+            .map(|i| <_ as Into<T>>::into(i))
+            .collect::<Vec<_>>()
+            .try_into()
     }
 }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -593,11 +593,15 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 }
 
 #[cfg(feature = "alloc")]
-impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
+impl<I, T> TryFrom<&Vec<I>> for VecM<T, MAX> {
+where
+    for<'a> &'a I: Into<T>,
     type Error = Error;
-
-    fn try_from(v: &Vec<T>) -> Result<Self> {
-        v.as_slice().try_into()
+    fn try_from(v: &Vec<I>) -> Result<Self> {
+        v.iter()
+            .map(|i| <_ as Into<T>>::into(i))
+            .collect::<Vec<_>>()
+            .try_into()
     }
 }
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -593,11 +593,15 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 }
 
 #[cfg(feature = "alloc")]
-impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
+impl<I, T> TryFrom<&Vec<I>> for VecM<T, MAX> {
+where
+    for<'a> &'a I: Into<T>,
     type Error = Error;
-
-    fn try_from(v: &Vec<T>) -> Result<Self> {
-        v.as_slice().try_into()
+    fn try_from(v: &Vec<I>) -> Result<Self> {
+        v.iter()
+            .map(|i| <_ as Into<T>>::into(i))
+            .collect::<Vec<_>>()
+            .try_into()
     }
 }
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -593,11 +593,15 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 }
 
 #[cfg(feature = "alloc")]
-impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
+impl<I, T> TryFrom<&Vec<I>> for VecM<T, MAX> {
+where
+    for<'a> &'a I: Into<T>,
     type Error = Error;
-
-    fn try_from(v: &Vec<T>) -> Result<Self> {
-        v.as_slice().try_into()
+    fn try_from(v: &Vec<I>) -> Result<Self> {
+        v.iter()
+            .map(|i| <_ as Into<T>>::into(i))
+            .collect::<Vec<_>>()
+            .try_into()
     }
 }
 
@@ -1088,10 +1092,15 @@ impl TryFrom<Vec<u8>> for Uint513 {
 }
 
 #[cfg(feature = "alloc")]
-impl TryFrom<&Vec<u8>> for Uint513 {
+impl<T> TryFrom<&Vec<T>> for Uint513 {
+where
+    for<'a> &'a T: Into<u8>,
     type Error = Error;
-    fn try_from(x: &Vec<u8>) -> Result<Self> {
-        Ok(Uint513(x.try_into()?))
+    fn try_from(v: &Vec<T>) -> Result<Self> {
+        v.iter()
+            .map(|t| <_ as Into<u8>>::into(t))
+            .collect::<Vec<_>>()
+            .try_into()
     }
 }
 
@@ -1183,10 +1192,15 @@ impl TryFrom<Vec<u8>> for Uint514 {
 }
 
 #[cfg(feature = "alloc")]
-impl TryFrom<&Vec<u8>> for Uint514 {
+impl<T> TryFrom<&Vec<T>> for Uint514 {
+where
+    for<'a> &'a T: Into<u8>,
     type Error = Error;
-    fn try_from(x: &Vec<u8>) -> Result<Self> {
-        Ok(Uint514(x.try_into()?))
+    fn try_from(v: &Vec<T>) -> Result<Self> {
+        v.iter()
+            .map(|t| <_ as Into<u8>>::into(t))
+            .collect::<Vec<_>>()
+            .try_into()
     }
 }
 
@@ -1454,10 +1468,15 @@ impl TryFrom<Vec<Hash>> for Hashes2 {
 }
 
 #[cfg(feature = "alloc")]
-impl TryFrom<&Vec<Hash>> for Hashes2 {
+impl<T> TryFrom<&Vec<T>> for Hashes2 {
+where
+    for<'a> &'a T: Into<Hash>,
     type Error = Error;
-    fn try_from(x: &Vec<Hash>) -> Result<Self> {
-        Ok(Hashes2(x.try_into()?))
+    fn try_from(v: &Vec<T>) -> Result<Self> {
+        v.iter()
+            .map(|t| <_ as Into<Hash>>::into(t))
+            .collect::<Vec<_>>()
+            .try_into()
     }
 }
 
@@ -1549,10 +1568,15 @@ impl TryFrom<Vec<Hash>> for Hashes3 {
 }
 
 #[cfg(feature = "alloc")]
-impl TryFrom<&Vec<Hash>> for Hashes3 {
+impl<T> TryFrom<&Vec<T>> for Hashes3 {
+where
+    for<'a> &'a T: Into<Hash>,
     type Error = Error;
-    fn try_from(x: &Vec<Hash>) -> Result<Self> {
-        Ok(Hashes3(x.try_into()?))
+    fn try_from(v: &Vec<T>) -> Result<Self> {
+        v.iter()
+            .map(|t| <_ as Into<Hash>>::into(t))
+            .collect::<Vec<_>>()
+            .try_into()
     }
 }
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -593,11 +593,15 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 }
 
 #[cfg(feature = "alloc")]
-impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
+impl<I, T> TryFrom<&Vec<I>> for VecM<T, MAX> {
+where
+    for<'a> &'a I: Into<T>,
     type Error = Error;
-
-    fn try_from(v: &Vec<T>) -> Result<Self> {
-        v.as_slice().try_into()
+    fn try_from(v: &Vec<I>) -> Result<Self> {
+        v.iter()
+            .map(|i| <_ as Into<T>>::into(i))
+            .collect::<Vec<_>>()
+            .try_into()
     }
 }
 


### PR DESCRIPTION
### What
Allow conversions from Vecs into Vec backed types where the type of the Vec isn't the destination type but can be converted into it. These conversions are added for references of Vecs only.
### Why
This makes conversions into Vec backed types more convenient, since in the XDR we often have the values in a different type destined for a type that is equivalent either exactly but disjoint in name only, or via conversion, in the XDR.

Only conversions from `&Vec` are supported because this convenience conversion ultimately requires allocating a new `Vec` in memory. Since we need to allocate a new Vec in memory for conversions from `&Vec` anyway this introduces little cost. If we were to do the same thing on conversions from `Vec` it would require a new copy even when unnecessary.