### PR TITLE
Rust: add base64 feature

### DIFF
--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -217,7 +217,7 @@ where
         Ok(t)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: String) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
@@ -238,7 +238,7 @@ pub trait WriteXdr {
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "base64")]
     fn to_xdr_base64(&self) -> Result<String> {
         let mut enc = base64::write::EncoderStringWriter::new(base64::STANDARD);
         self.write_xdr(&mut enc)?;

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -227,7 +227,7 @@ where
         Ok(t)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: String) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
@@ -248,7 +248,7 @@ pub trait WriteXdr {
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "base64")]
     fn to_xdr_base64(&self) -> Result<String> {
         let mut enc = base64::write::EncoderStringWriter::new(base64::STANDARD);
         self.write_xdr(&mut enc)?;

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -227,7 +227,7 @@ where
         Ok(t)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: String) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
@@ -248,7 +248,7 @@ pub trait WriteXdr {
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "base64")]
     fn to_xdr_base64(&self) -> Result<String> {
         let mut enc = base64::write::EncoderStringWriter::new(base64::STANDARD);
         self.write_xdr(&mut enc)?;

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -227,7 +227,7 @@ where
         Ok(t)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: String) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
@@ -248,7 +248,7 @@ pub trait WriteXdr {
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "base64")]
     fn to_xdr_base64(&self) -> Result<String> {
         let mut enc = base64::write::EncoderStringWriter::new(base64::STANDARD);
         self.write_xdr(&mut enc)?;

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -227,7 +227,7 @@ where
         Ok(t)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: String) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
@@ -248,7 +248,7 @@ pub trait WriteXdr {
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "base64")]
     fn to_xdr_base64(&self) -> Result<String> {
         let mut enc = base64::write::EncoderStringWriter::new(base64::STANDARD);
         self.write_xdr(&mut enc)?;

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -227,7 +227,7 @@ where
         Ok(t)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: String) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
@@ -248,7 +248,7 @@ pub trait WriteXdr {
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "base64")]
     fn to_xdr_base64(&self) -> Result<String> {
         let mut enc = base64::write::EncoderStringWriter::new(base64::STANDARD);
         self.write_xdr(&mut enc)?;

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -227,7 +227,7 @@ where
         Ok(t)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: String) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
@@ -248,7 +248,7 @@ pub trait WriteXdr {
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "base64")]
     fn to_xdr_base64(&self) -> Result<String> {
         let mut enc = base64::write::EncoderStringWriter::new(base64::STANDARD);
         self.write_xdr(&mut enc)?;

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -227,7 +227,7 @@ where
         Ok(t)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: String) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
@@ -248,7 +248,7 @@ pub trait WriteXdr {
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "base64")]
     fn to_xdr_base64(&self) -> Result<String> {
         let mut enc = base64::write::EncoderStringWriter::new(base64::STANDARD);
         self.write_xdr(&mut enc)?;

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -227,7 +227,7 @@ where
         Ok(t)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: String) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
@@ -248,7 +248,7 @@ pub trait WriteXdr {
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "base64")]
     fn to_xdr_base64(&self) -> Result<String> {
         let mut enc = base64::write::EncoderStringWriter::new(base64::STANDARD);
         self.write_xdr(&mut enc)?;


### PR DESCRIPTION
### What
Add base64 feature to the Rust generated code that wraps functionality dependent on the base64 dependency.

### Why
To silo all dependency functionality behind optional dependencies.