### PR TITLE
Rust: add PartialEq impl for Error

### DIFF
--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -62,6 +62,7 @@ impl PartialEq for Error {
             // case for comparing errors outputted by the XDR library is for
             // error case testing, and a lack of the ability to compare has a
             // detrimental affect on failure testing, so this is a tradeoff.
+            #[cfg(feature = "std")]
             (Self::Io(l), Self::Io(r)) => l.kind() == r.kind(),
             _ => core::mem::discriminant(self) == core::mem::discriminant(other),
         }

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -38,6 +38,9 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
+/// Error contains all errors returned by functions in this crate. It can be
+/// compared via PartialEq, however any contained IO errors will only be
+/// compared on their ErrorKind.
 #[derive(Debug)]
 pub enum Error {
     Invalid,
@@ -47,6 +50,22 @@ pub enum Error {
     Utf8Error(core::str::Utf8Error),
     #[cfg(feature = "std")]
     Io(io::Error),
+}
+
+impl PartialEq for Error {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Utf8Error(l), Self::Utf8Error(r)) => l == r,
+            // IO errors cannot be compared, but in the absence of any more
+            // meaningful way to compare the errors we compare the kind of error
+            // and ignore the embedded source error or OS error. The main use
+            // case for comparing errors outputted by the XDR library is for
+            // error case testing, and a lack of the ability to compare has a
+            // detrimental affect on failure testing, so this is a tradeoff.
+            (Self::Io(l), Self::Io(r)) => l.kind() == r.kind(),
+            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
+        }
+    }
 }
 
 #[cfg(feature = "std")]

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -39,8 +39,8 @@ use std::{
 };
 
 /// Error contains all errors returned by functions in this crate. It can be
-/// compared via PartialEq, however any contained IO errors will only be
-/// compared on their ErrorKind.
+/// compared via `PartialEq`, however any contained IO errors will only be
+/// compared on their `ErrorKind`.
 #[derive(Debug)]
 pub enum Error {
     Invalid,

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -49,8 +49,8 @@ use std::{
 };
 
 /// Error contains all errors returned by functions in this crate. It can be
-/// compared via PartialEq, however any contained IO errors will only be
-/// compared on their ErrorKind.
+/// compared via `PartialEq`, however any contained IO errors will only be
+/// compared on their `ErrorKind`.
 #[derive(Debug)]
 pub enum Error {
     Invalid,

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -72,6 +72,7 @@ impl PartialEq for Error {
             // case for comparing errors outputted by the XDR library is for
             // error case testing, and a lack of the ability to compare has a
             // detrimental affect on failure testing, so this is a tradeoff.
+            #[cfg(feature = "std")]
             (Self::Io(l), Self::Io(r)) => l.kind() == r.kind(),
             _ => core::mem::discriminant(self) == core::mem::discriminant(other),
         }

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -49,8 +49,8 @@ use std::{
 };
 
 /// Error contains all errors returned by functions in this crate. It can be
-/// compared via PartialEq, however any contained IO errors will only be
-/// compared on their ErrorKind.
+/// compared via `PartialEq`, however any contained IO errors will only be
+/// compared on their `ErrorKind`.
 #[derive(Debug)]
 pub enum Error {
     Invalid,

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -72,6 +72,7 @@ impl PartialEq for Error {
             // case for comparing errors outputted by the XDR library is for
             // error case testing, and a lack of the ability to compare has a
             // detrimental affect on failure testing, so this is a tradeoff.
+            #[cfg(feature = "std")]
             (Self::Io(l), Self::Io(r)) => l.kind() == r.kind(),
             _ => core::mem::discriminant(self) == core::mem::discriminant(other),
         }

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -49,8 +49,8 @@ use std::{
 };
 
 /// Error contains all errors returned by functions in this crate. It can be
-/// compared via PartialEq, however any contained IO errors will only be
-/// compared on their ErrorKind.
+/// compared via `PartialEq`, however any contained IO errors will only be
+/// compared on their `ErrorKind`.
 #[derive(Debug)]
 pub enum Error {
     Invalid,

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -72,6 +72,7 @@ impl PartialEq for Error {
             // case for comparing errors outputted by the XDR library is for
             // error case testing, and a lack of the ability to compare has a
             // detrimental affect on failure testing, so this is a tradeoff.
+            #[cfg(feature = "std")]
             (Self::Io(l), Self::Io(r)) => l.kind() == r.kind(),
             _ => core::mem::discriminant(self) == core::mem::discriminant(other),
         }

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -49,8 +49,8 @@ use std::{
 };
 
 /// Error contains all errors returned by functions in this crate. It can be
-/// compared via PartialEq, however any contained IO errors will only be
-/// compared on their ErrorKind.
+/// compared via `PartialEq`, however any contained IO errors will only be
+/// compared on their `ErrorKind`.
 #[derive(Debug)]
 pub enum Error {
     Invalid,

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -72,6 +72,7 @@ impl PartialEq for Error {
             // case for comparing errors outputted by the XDR library is for
             // error case testing, and a lack of the ability to compare has a
             // detrimental affect on failure testing, so this is a tradeoff.
+            #[cfg(feature = "std")]
             (Self::Io(l), Self::Io(r)) => l.kind() == r.kind(),
             _ => core::mem::discriminant(self) == core::mem::discriminant(other),
         }

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -49,8 +49,8 @@ use std::{
 };
 
 /// Error contains all errors returned by functions in this crate. It can be
-/// compared via PartialEq, however any contained IO errors will only be
-/// compared on their ErrorKind.
+/// compared via `PartialEq`, however any contained IO errors will only be
+/// compared on their `ErrorKind`.
 #[derive(Debug)]
 pub enum Error {
     Invalid,

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -72,6 +72,7 @@ impl PartialEq for Error {
             // case for comparing errors outputted by the XDR library is for
             // error case testing, and a lack of the ability to compare has a
             // detrimental affect on failure testing, so this is a tradeoff.
+            #[cfg(feature = "std")]
             (Self::Io(l), Self::Io(r)) => l.kind() == r.kind(),
             _ => core::mem::discriminant(self) == core::mem::discriminant(other),
         }

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -49,8 +49,8 @@ use std::{
 };
 
 /// Error contains all errors returned by functions in this crate. It can be
-/// compared via PartialEq, however any contained IO errors will only be
-/// compared on their ErrorKind.
+/// compared via `PartialEq`, however any contained IO errors will only be
+/// compared on their `ErrorKind`.
 #[derive(Debug)]
 pub enum Error {
     Invalid,

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -72,6 +72,7 @@ impl PartialEq for Error {
             // case for comparing errors outputted by the XDR library is for
             // error case testing, and a lack of the ability to compare has a
             // detrimental affect on failure testing, so this is a tradeoff.
+            #[cfg(feature = "std")]
             (Self::Io(l), Self::Io(r)) => l.kind() == r.kind(),
             _ => core::mem::discriminant(self) == core::mem::discriminant(other),
         }

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -49,8 +49,8 @@ use std::{
 };
 
 /// Error contains all errors returned by functions in this crate. It can be
-/// compared via PartialEq, however any contained IO errors will only be
-/// compared on their ErrorKind.
+/// compared via `PartialEq`, however any contained IO errors will only be
+/// compared on their `ErrorKind`.
 #[derive(Debug)]
 pub enum Error {
     Invalid,

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -72,6 +72,7 @@ impl PartialEq for Error {
             // case for comparing errors outputted by the XDR library is for
             // error case testing, and a lack of the ability to compare has a
             // detrimental affect on failure testing, so this is a tradeoff.
+            #[cfg(feature = "std")]
             (Self::Io(l), Self::Io(r)) => l.kind() == r.kind(),
             _ => core::mem::discriminant(self) == core::mem::discriminant(other),
         }

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -49,8 +49,8 @@ use std::{
 };
 
 /// Error contains all errors returned by functions in this crate. It can be
-/// compared via PartialEq, however any contained IO errors will only be
-/// compared on their ErrorKind.
+/// compared via `PartialEq`, however any contained IO errors will only be
+/// compared on their `ErrorKind`.
 #[derive(Debug)]
 pub enum Error {
     Invalid,

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -72,6 +72,7 @@ impl PartialEq for Error {
             // case for comparing errors outputted by the XDR library is for
             // error case testing, and a lack of the ability to compare has a
             // detrimental affect on failure testing, so this is a tradeoff.
+            #[cfg(feature = "std")]
             (Self::Io(l), Self::Io(r)) => l.kind() == r.kind(),
             _ => core::mem::discriminant(self) == core::mem::discriminant(other),
         }


### PR DESCRIPTION
### What
Add PartialEq implementation for the Error type that is part of the generated Rust code.

### Why
It is extremely inconvenient for testing failure cases if the Error type is not comparable.

To some degree adding a PartialEq implementation is controversial because the embedded IO error cannot be compared. The implementation compares the kind because it seems like the best broad way to compare an IO error if we can't compare it more absolutely and completely. The main use case for comparing these errors is to facilitate better testing of failure cases. So this is a trade off of a perfect comparison implementation over a useful one.