### PR TITLE
Fix ci complete job (again)

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,10 +8,12 @@ on:
 jobs:
 
   complete:
+    if: always()
     needs: [test]
     runs-on: ubuntu-latest
     steps:
-    - run: exit 0
+    - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+      run: exit 1
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What
Change ci complete job to always run and explicitly check the results of the depended jobs.

### Why
In #126 I changed the way the complete job worked to catch cancelled jobs, but apparently I made the situation worse and caused failing jobs to be ignored, because the complete job was being skipped and skipped jobs are interpreted as success by GitHub's required checks.