### PR TITLE
Add VecM::to_string_lossy to Rust generated code

### DIFF
--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -573,12 +573,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        String::from_utf8_lossy(&v.0)
+        String::from_utf8_lossy(&v.0).to_string()
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        String::from_utf8_lossy(&v.0)
+        String::from_utf8_lossy(&v.0).to_string()
     }
 }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -572,11 +572,13 @@ impl<const MAX: u32> VecM<u8, MAX> {
     }
 
     #[cfg(feature = "alloc")]
+    #[must_use]
     pub fn to_string_lossy(&self) -> String {
         String::from_utf8_lossy(&self.0).into_owned()
     }
 
     #[cfg(feature = "alloc")]
+    #[must_use]
     pub fn into_string_lossy(self) -> String {
         String::from_utf8_lossy(&self.0).into_owned()
     }

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -570,6 +570,16 @@ impl<const MAX: u32> VecM<u8, MAX> {
     pub fn into_string(self) -> Result<String> {
         self.try_into()
     }
+
+    #[cfg(feature = "alloc")]
+    pub fn to_string_lossy(&self) -> String {
+        Ok(String::from_utf8_lossy(&v.0))
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string_lossy(self) -> String {
+        Ok(String::from_utf8_lossy(&v.0))
+    }
 }
 
 impl<T: Clone> VecM<T, 1> {

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -573,12 +573,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        Ok(String::from_utf8_lossy(&v.0))
+        String::from_utf8_lossy(&v.0)
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        Ok(String::from_utf8_lossy(&v.0))
+        String::from_utf8_lossy(&v.0)
     }
 }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -573,12 +573,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        String::from_utf8_lossy(&v.0).to_string()
+        String::from_utf8_lossy(&self.0).into_owned()
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        String::from_utf8_lossy(&v.0).to_string()
+        String::from_utf8_lossy(&self.0).into_owned()
     }
 }
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        String::from_utf8_lossy(&v.0)
+        String::from_utf8_lossy(&v.0).to_string()
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        String::from_utf8_lossy(&v.0)
+        String::from_utf8_lossy(&v.0).to_string()
     }
 }
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -580,6 +580,16 @@ impl<const MAX: u32> VecM<u8, MAX> {
     pub fn into_string(self) -> Result<String> {
         self.try_into()
     }
+
+    #[cfg(feature = "alloc")]
+    pub fn to_string_lossy(&self) -> String {
+        Ok(String::from_utf8_lossy(&v.0))
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string_lossy(self) -> String {
+        Ok(String::from_utf8_lossy(&v.0))
+    }
 }
 
 impl<T: Clone> VecM<T, 1> {

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        Ok(String::from_utf8_lossy(&v.0))
+        String::from_utf8_lossy(&v.0)
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        Ok(String::from_utf8_lossy(&v.0))
+        String::from_utf8_lossy(&v.0)
     }
 }
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -582,11 +582,13 @@ impl<const MAX: u32> VecM<u8, MAX> {
     }
 
     #[cfg(feature = "alloc")]
+    #[must_use]
     pub fn to_string_lossy(&self) -> String {
         String::from_utf8_lossy(&self.0).into_owned()
     }
 
     #[cfg(feature = "alloc")]
+    #[must_use]
     pub fn into_string_lossy(self) -> String {
         String::from_utf8_lossy(&self.0).into_owned()
     }

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        String::from_utf8_lossy(&v.0).to_string()
+        String::from_utf8_lossy(&self.0).into_owned()
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        String::from_utf8_lossy(&v.0).to_string()
+        String::from_utf8_lossy(&self.0).into_owned()
     }
 }
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        String::from_utf8_lossy(&v.0)
+        String::from_utf8_lossy(&v.0).to_string()
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        String::from_utf8_lossy(&v.0)
+        String::from_utf8_lossy(&v.0).to_string()
     }
 }
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -580,6 +580,16 @@ impl<const MAX: u32> VecM<u8, MAX> {
     pub fn into_string(self) -> Result<String> {
         self.try_into()
     }
+
+    #[cfg(feature = "alloc")]
+    pub fn to_string_lossy(&self) -> String {
+        Ok(String::from_utf8_lossy(&v.0))
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string_lossy(self) -> String {
+        Ok(String::from_utf8_lossy(&v.0))
+    }
 }
 
 impl<T: Clone> VecM<T, 1> {

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        Ok(String::from_utf8_lossy(&v.0))
+        String::from_utf8_lossy(&v.0)
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        Ok(String::from_utf8_lossy(&v.0))
+        String::from_utf8_lossy(&v.0)
     }
 }
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -582,11 +582,13 @@ impl<const MAX: u32> VecM<u8, MAX> {
     }
 
     #[cfg(feature = "alloc")]
+    #[must_use]
     pub fn to_string_lossy(&self) -> String {
         String::from_utf8_lossy(&self.0).into_owned()
     }
 
     #[cfg(feature = "alloc")]
+    #[must_use]
     pub fn into_string_lossy(self) -> String {
         String::from_utf8_lossy(&self.0).into_owned()
     }

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        String::from_utf8_lossy(&v.0).to_string()
+        String::from_utf8_lossy(&self.0).into_owned()
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        String::from_utf8_lossy(&v.0).to_string()
+        String::from_utf8_lossy(&self.0).into_owned()
     }
 }
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        String::from_utf8_lossy(&v.0)
+        String::from_utf8_lossy(&v.0).to_string()
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        String::from_utf8_lossy(&v.0)
+        String::from_utf8_lossy(&v.0).to_string()
     }
 }
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -580,6 +580,16 @@ impl<const MAX: u32> VecM<u8, MAX> {
     pub fn into_string(self) -> Result<String> {
         self.try_into()
     }
+
+    #[cfg(feature = "alloc")]
+    pub fn to_string_lossy(&self) -> String {
+        Ok(String::from_utf8_lossy(&v.0))
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string_lossy(self) -> String {
+        Ok(String::from_utf8_lossy(&v.0))
+    }
 }
 
 impl<T: Clone> VecM<T, 1> {

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        Ok(String::from_utf8_lossy(&v.0))
+        String::from_utf8_lossy(&v.0)
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        Ok(String::from_utf8_lossy(&v.0))
+        String::from_utf8_lossy(&v.0)
     }
 }
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -582,11 +582,13 @@ impl<const MAX: u32> VecM<u8, MAX> {
     }
 
     #[cfg(feature = "alloc")]
+    #[must_use]
     pub fn to_string_lossy(&self) -> String {
         String::from_utf8_lossy(&self.0).into_owned()
     }
 
     #[cfg(feature = "alloc")]
+    #[must_use]
     pub fn into_string_lossy(self) -> String {
         String::from_utf8_lossy(&self.0).into_owned()
     }

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        String::from_utf8_lossy(&v.0).to_string()
+        String::from_utf8_lossy(&self.0).into_owned()
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        String::from_utf8_lossy(&v.0).to_string()
+        String::from_utf8_lossy(&self.0).into_owned()
     }
 }
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        String::from_utf8_lossy(&v.0)
+        String::from_utf8_lossy(&v.0).to_string()
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        String::from_utf8_lossy(&v.0)
+        String::from_utf8_lossy(&v.0).to_string()
     }
 }
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -580,6 +580,16 @@ impl<const MAX: u32> VecM<u8, MAX> {
     pub fn into_string(self) -> Result<String> {
         self.try_into()
     }
+
+    #[cfg(feature = "alloc")]
+    pub fn to_string_lossy(&self) -> String {
+        Ok(String::from_utf8_lossy(&v.0))
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string_lossy(self) -> String {
+        Ok(String::from_utf8_lossy(&v.0))
+    }
 }
 
 impl<T: Clone> VecM<T, 1> {

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        Ok(String::from_utf8_lossy(&v.0))
+        String::from_utf8_lossy(&v.0)
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        Ok(String::from_utf8_lossy(&v.0))
+        String::from_utf8_lossy(&v.0)
     }
 }
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -582,11 +582,13 @@ impl<const MAX: u32> VecM<u8, MAX> {
     }
 
     #[cfg(feature = "alloc")]
+    #[must_use]
     pub fn to_string_lossy(&self) -> String {
         String::from_utf8_lossy(&self.0).into_owned()
     }
 
     #[cfg(feature = "alloc")]
+    #[must_use]
     pub fn into_string_lossy(self) -> String {
         String::from_utf8_lossy(&self.0).into_owned()
     }

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        String::from_utf8_lossy(&v.0).to_string()
+        String::from_utf8_lossy(&self.0).into_owned()
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        String::from_utf8_lossy(&v.0).to_string()
+        String::from_utf8_lossy(&self.0).into_owned()
     }
 }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        String::from_utf8_lossy(&v.0)
+        String::from_utf8_lossy(&v.0).to_string()
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        String::from_utf8_lossy(&v.0)
+        String::from_utf8_lossy(&v.0).to_string()
     }
 }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -580,6 +580,16 @@ impl<const MAX: u32> VecM<u8, MAX> {
     pub fn into_string(self) -> Result<String> {
         self.try_into()
     }
+
+    #[cfg(feature = "alloc")]
+    pub fn to_string_lossy(&self) -> String {
+        Ok(String::from_utf8_lossy(&v.0))
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string_lossy(self) -> String {
+        Ok(String::from_utf8_lossy(&v.0))
+    }
 }
 
 impl<T: Clone> VecM<T, 1> {

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        Ok(String::from_utf8_lossy(&v.0))
+        String::from_utf8_lossy(&v.0)
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        Ok(String::from_utf8_lossy(&v.0))
+        String::from_utf8_lossy(&v.0)
     }
 }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -582,11 +582,13 @@ impl<const MAX: u32> VecM<u8, MAX> {
     }
 
     #[cfg(feature = "alloc")]
+    #[must_use]
     pub fn to_string_lossy(&self) -> String {
         String::from_utf8_lossy(&self.0).into_owned()
     }
 
     #[cfg(feature = "alloc")]
+    #[must_use]
     pub fn into_string_lossy(self) -> String {
         String::from_utf8_lossy(&self.0).into_owned()
     }

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        String::from_utf8_lossy(&v.0).to_string()
+        String::from_utf8_lossy(&self.0).into_owned()
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        String::from_utf8_lossy(&v.0).to_string()
+        String::from_utf8_lossy(&self.0).into_owned()
     }
 }
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        String::from_utf8_lossy(&v.0)
+        String::from_utf8_lossy(&v.0).to_string()
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        String::from_utf8_lossy(&v.0)
+        String::from_utf8_lossy(&v.0).to_string()
     }
 }
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -580,6 +580,16 @@ impl<const MAX: u32> VecM<u8, MAX> {
     pub fn into_string(self) -> Result<String> {
         self.try_into()
     }
+
+    #[cfg(feature = "alloc")]
+    pub fn to_string_lossy(&self) -> String {
+        Ok(String::from_utf8_lossy(&v.0))
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string_lossy(self) -> String {
+        Ok(String::from_utf8_lossy(&v.0))
+    }
 }
 
 impl<T: Clone> VecM<T, 1> {

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        Ok(String::from_utf8_lossy(&v.0))
+        String::from_utf8_lossy(&v.0)
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        Ok(String::from_utf8_lossy(&v.0))
+        String::from_utf8_lossy(&v.0)
     }
 }
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -582,11 +582,13 @@ impl<const MAX: u32> VecM<u8, MAX> {
     }
 
     #[cfg(feature = "alloc")]
+    #[must_use]
     pub fn to_string_lossy(&self) -> String {
         String::from_utf8_lossy(&self.0).into_owned()
     }
 
     #[cfg(feature = "alloc")]
+    #[must_use]
     pub fn into_string_lossy(self) -> String {
         String::from_utf8_lossy(&self.0).into_owned()
     }

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        String::from_utf8_lossy(&v.0).to_string()
+        String::from_utf8_lossy(&self.0).into_owned()
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        String::from_utf8_lossy(&v.0).to_string()
+        String::from_utf8_lossy(&self.0).into_owned()
     }
 }
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        String::from_utf8_lossy(&v.0)
+        String::from_utf8_lossy(&v.0).to_string()
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        String::from_utf8_lossy(&v.0)
+        String::from_utf8_lossy(&v.0).to_string()
     }
 }
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -580,6 +580,16 @@ impl<const MAX: u32> VecM<u8, MAX> {
     pub fn into_string(self) -> Result<String> {
         self.try_into()
     }
+
+    #[cfg(feature = "alloc")]
+    pub fn to_string_lossy(&self) -> String {
+        Ok(String::from_utf8_lossy(&v.0))
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string_lossy(self) -> String {
+        Ok(String::from_utf8_lossy(&v.0))
+    }
 }
 
 impl<T: Clone> VecM<T, 1> {

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        Ok(String::from_utf8_lossy(&v.0))
+        String::from_utf8_lossy(&v.0)
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        Ok(String::from_utf8_lossy(&v.0))
+        String::from_utf8_lossy(&v.0)
     }
 }
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -582,11 +582,13 @@ impl<const MAX: u32> VecM<u8, MAX> {
     }
 
     #[cfg(feature = "alloc")]
+    #[must_use]
     pub fn to_string_lossy(&self) -> String {
         String::from_utf8_lossy(&self.0).into_owned()
     }
 
     #[cfg(feature = "alloc")]
+    #[must_use]
     pub fn into_string_lossy(self) -> String {
         String::from_utf8_lossy(&self.0).into_owned()
     }

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        String::from_utf8_lossy(&v.0).to_string()
+        String::from_utf8_lossy(&self.0).into_owned()
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        String::from_utf8_lossy(&v.0).to_string()
+        String::from_utf8_lossy(&self.0).into_owned()
     }
 }
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        String::from_utf8_lossy(&v.0)
+        String::from_utf8_lossy(&v.0).to_string()
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        String::from_utf8_lossy(&v.0)
+        String::from_utf8_lossy(&v.0).to_string()
     }
 }
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -580,6 +580,16 @@ impl<const MAX: u32> VecM<u8, MAX> {
     pub fn into_string(self) -> Result<String> {
         self.try_into()
     }
+
+    #[cfg(feature = "alloc")]
+    pub fn to_string_lossy(&self) -> String {
+        Ok(String::from_utf8_lossy(&v.0))
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string_lossy(self) -> String {
+        Ok(String::from_utf8_lossy(&v.0))
+    }
 }
 
 impl<T: Clone> VecM<T, 1> {

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        Ok(String::from_utf8_lossy(&v.0))
+        String::from_utf8_lossy(&v.0)
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        Ok(String::from_utf8_lossy(&v.0))
+        String::from_utf8_lossy(&v.0)
     }
 }
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -582,11 +582,13 @@ impl<const MAX: u32> VecM<u8, MAX> {
     }
 
     #[cfg(feature = "alloc")]
+    #[must_use]
     pub fn to_string_lossy(&self) -> String {
         String::from_utf8_lossy(&self.0).into_owned()
     }
 
     #[cfg(feature = "alloc")]
+    #[must_use]
     pub fn into_string_lossy(self) -> String {
         String::from_utf8_lossy(&self.0).into_owned()
     }

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -583,12 +583,12 @@ impl<const MAX: u32> VecM<u8, MAX> {
 
     #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> String {
-        String::from_utf8_lossy(&v.0).to_string()
+        String::from_utf8_lossy(&self.0).into_owned()
     }
 
     #[cfg(feature = "alloc")]
     pub fn into_string_lossy(self) -> String {
-        String::from_utf8_lossy(&v.0).to_string()
+        String::from_utf8_lossy(&self.0).into_owned()
     }
 }
 


### PR DESCRIPTION
### What
Add VecM::to_string_lossy to Rust generated code.

### Why
To use in situations where it is okay if the strings are lossy converted and if there are non-utf8 characters we don't really care about handling them.

Close https://github.com/stellar/xdrgen/issues/131