### PR TITLE
Go: Misc code generation fixes

### DIFF
--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -410,7 +410,7 @@ module Xdrgen
         out.puts "// EncodeTo encodes this value using the Encoder."
         if is_fixed_array_type(type) ||
             (type.is_a?(AST::Identifier) && type.sub_type == :simple && type.resolved_type.is_a?(AST::Definitions::Typedef) && is_fixed_array_type(type.resolved_type.declaration.type))
-          # Implement EncodeTo by pointer in for Go array types
+          # Implement EncodeTo by pointer for Go array types
           # otherwise (if called by value), Go will make a heap allocation
           # for every by-value call since the copy required by the call
           # tends to escape the stack due to the large array sizes.

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -409,7 +409,7 @@ module Xdrgen
         type = typedef.declaration.type
         out.puts "// EncodeTo encodes this value using the Encoder."
         if is_fixed_opaque(type) ||
-           (type.is_a?(AST::Identifier) && type.resolved_type.is_a?(AST::Definitions::Typedef) && is_fixed_opaque(type.resolved_type.declaration.type))
+           (type.is_a?(AST::Identifier) && typedef.declaration.is_a?(AST::Declarations::Simple) && type.resolved_type.is_a?(AST::Definitions::Typedef) && is_fixed_opaque(type.resolved_type.declaration.type))
           # Implement EncodeTo by pointer in fixed opaque types (arrays)
           # otherwise (if called by value), Go will make a heap allocation
           # for every by-value call since the copy required by the call

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -400,17 +400,17 @@ module Xdrgen
         EOS
       end
 
-      def is_fixed_opaque(type)
-        type.is_a?(AST::Typespecs::Opaque) && type.fixed?
+      def results_in_go_array(type)
+        (type.is_a?(AST::Typespecs::Opaque) && type.fixed?) || type.sub_type == :array
       end
 
       def render_typedef_encode_to_interface(out, typedef)
         name = name(typedef)
         type = typedef.declaration.type
         out.puts "// EncodeTo encodes this value using the Encoder."
-        if is_fixed_opaque(type) ||
-           (type.is_a?(AST::Identifier) && typedef.declaration.is_a?(AST::Declarations::Simple) && type.resolved_type.is_a?(AST::Definitions::Typedef) && is_fixed_opaque(type.resolved_type.declaration.type))
-          # Implement EncodeTo by pointer in fixed opaque types (arrays)
+        if results_in_go_array(type) ||
+            (type.is_a?(AST::Identifier) && type.sub_type == :simple && type.resolved_type.is_a?(AST::Definitions::Typedef) && results_in_go_array(type.resolved_type.declaration.type))
+          # Implement EncodeTo by pointer in for Go array types
           # otherwise (if called by value), Go will make a heap allocation
           # for every by-value call since the copy required by the call
           # tends to escape the stack due to the large array sizes.
@@ -470,8 +470,8 @@ module Xdrgen
             end
             if self_encode
               newvar = "#{name type}(#{var})"
-              if type.resolved_type.is_a?(AST::Definitions::Typedef) && is_fixed_opaque(type.resolved_type.declaration.type)
-                # Fixed opaque types implement EncodeTo by pointer
+              if type.resolved_type.is_a?(AST::Definitions::Typedef) && results_in_go_array(type.resolved_type.declaration.type)
+                # Go array types implement EncodeTo by pointer
                 if type.is_a?(AST::Identifier)
                   # we are already calling by pointer, so we just need to cast
                   newvar = "(*#{name type})(#{var})"

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -400,7 +400,7 @@ module Xdrgen
         EOS
       end
 
-      def results_in_go_array(type)
+      def is_fixed_array_type(type)
         (type.is_a?(AST::Typespecs::Opaque) && type.fixed?) || type.sub_type == :array
       end
 
@@ -408,8 +408,8 @@ module Xdrgen
         name = name(typedef)
         type = typedef.declaration.type
         out.puts "// EncodeTo encodes this value using the Encoder."
-        if results_in_go_array(type) ||
-            (type.is_a?(AST::Identifier) && type.sub_type == :simple && type.resolved_type.is_a?(AST::Definitions::Typedef) && results_in_go_array(type.resolved_type.declaration.type))
+        if is_fixed_array_type(type) ||
+            (type.is_a?(AST::Identifier) && type.sub_type == :simple && type.resolved_type.is_a?(AST::Definitions::Typedef) && is_fixed_array_type(type.resolved_type.declaration.type))
           # Implement EncodeTo by pointer in for Go array types
           # otherwise (if called by value), Go will make a heap allocation
           # for every by-value call since the copy required by the call
@@ -470,7 +470,7 @@ module Xdrgen
             end
             if self_encode
               newvar = "#{name type}(#{var})"
-              if type.resolved_type.is_a?(AST::Definitions::Typedef) && results_in_go_array(type.resolved_type.declaration.type)
+              if type.resolved_type.is_a?(AST::Definitions::Typedef) && is_fixed_array_type(type.resolved_type.declaration.type)
                 # Go array types implement EncodeTo by pointer
                 if type.is_a?(AST::Identifier)
                   # we are already calling by pointer, so we just need to cast

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -822,7 +822,7 @@ module Xdrgen
         out.puts <<-EOS.strip_heredoc
         // XdrFilesSHA256 is the SHA256 hashes of source files.
         var XdrFilesSHA256 = map[string]string{
-          #{@output.relative_source_path_sha256_hashes.map(){ |path, hash| %{"#{path}": "#{hash}"} }.join(",\n")}
+          #{@output.relative_source_path_sha256_hashes.map(){ |path, hash| %{"#{path}": "#{hash}",} }.join("\n")}
         }
         EOS
         out.break

--- a/spec/output/generator_spec_go/block_comments.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/block_comments.x/MyXDR_generated.go
@@ -19,7 +19,7 @@ import (
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
 var XdrFilesSHA256 = map[string]string{
-  "spec/fixtures/generator/block_comments.x": "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30"
+  "spec/fixtures/generator/block_comments.x": "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30",
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/const.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/const.x/MyXDR_generated.go
@@ -19,7 +19,7 @@ import (
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
 var XdrFilesSHA256 = map[string]string{
-  "spec/fixtures/generator/const.x": "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37"
+  "spec/fixtures/generator/const.x": "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37",
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/const.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/const.x/MyXDR_generated.go
@@ -67,7 +67,7 @@ const Foo = 1
 //
 type TestArray [Foo]int32
 // EncodeTo encodes this value using the Encoder.
-func (s TestArray) EncodeTo(e *xdr.Encoder) error {
+func (s *TestArray) EncodeTo(e *xdr.Encoder) error {
   var err error
 if _, err = e.EncodeInt(int32(s)); err != nil {
   return err

--- a/spec/output/generator_spec_go/enum.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/enum.x/MyXDR_generated.go
@@ -19,7 +19,7 @@ import (
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
 var XdrFilesSHA256 = map[string]string{
-  "spec/fixtures/generator/enum.x": "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f"
+  "spec/fixtures/generator/enum.x": "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f",
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/nesting.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/nesting.x/MyXDR_generated.go
@@ -19,7 +19,7 @@ import (
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
 var XdrFilesSHA256 = map[string]string{
-  "spec/fixtures/generator/nesting.x": "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a"
+  "spec/fixtures/generator/nesting.x": "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a",
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/optional.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/optional.x/MyXDR_generated.go
@@ -19,7 +19,7 @@ import (
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
 var XdrFilesSHA256 = map[string]string{
-  "spec/fixtures/generator/optional.x": "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7"
+  "spec/fixtures/generator/optional.x": "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7",
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/optional.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/optional.x/MyXDR_generated.go
@@ -61,7 +61,7 @@ func Marshal(w io.Writer, v interface{}) (int, error) {
 //
 type Arr [2]int32
 // EncodeTo encodes this value using the Encoder.
-func (s Arr) EncodeTo(e *xdr.Encoder) error {
+func (s *Arr) EncodeTo(e *xdr.Encoder) error {
   var err error
 if _, err = e.EncodeInt(int32(s)); err != nil {
   return err

--- a/spec/output/generator_spec_go/struct.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/struct.x/MyXDR_generated.go
@@ -19,7 +19,7 @@ import (
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
 var XdrFilesSHA256 = map[string]string{
-  "spec/fixtures/generator/struct.x": "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a"
+  "spec/fixtures/generator/struct.x": "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a",
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/test.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/test.x/MyXDR_generated.go
@@ -411,7 +411,7 @@ var _ xdrType = (*Hash)(nil)
 //
 type Hashes1 [12]Hash
 // EncodeTo encodes this value using the Encoder.
-func (s Hashes1) EncodeTo(e *xdr.Encoder) error {
+func (s *Hashes1) EncodeTo(e *xdr.Encoder) error {
   var err error
   for i := 0; i < len(s); i++ {
 if err = s[i].EncodeTo(e); err != nil {

--- a/spec/output/generator_spec_go/test.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/test.x/MyXDR_generated.go
@@ -19,7 +19,7 @@ import (
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
 var XdrFilesSHA256 = map[string]string{
-  "spec/fixtures/generator/test.x": "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41"
+  "spec/fixtures/generator/test.x": "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41",
 }
 
 type xdrType interface {
@@ -411,7 +411,7 @@ var _ xdrType = (*Hash)(nil)
 //
 type Hashes1 [12]Hash
 // EncodeTo encodes this value using the Encoder.
-func (s *Hashes1) EncodeTo(e *xdr.Encoder) error {
+func (s Hashes1) EncodeTo(e *xdr.Encoder) error {
   var err error
   for i := 0; i < len(s); i++ {
 if err = s[i].EncodeTo(e); err != nil {
@@ -473,7 +473,7 @@ func (e Hashes2) XDRMaxSize() int {
   return 12
 }
 // EncodeTo encodes this value using the Encoder.
-func (s *Hashes2) EncodeTo(e *xdr.Encoder) error {
+func (s Hashes2) EncodeTo(e *xdr.Encoder) error {
   var err error
 if _, err = e.EncodeUint(uint32(len(s))); err != nil {
   return err
@@ -547,7 +547,7 @@ var _ xdrType = (*Hashes2)(nil)
 //
 type Hashes3 []Hash
 // EncodeTo encodes this value using the Encoder.
-func (s *Hashes3) EncodeTo(e *xdr.Encoder) error {
+func (s Hashes3) EncodeTo(e *xdr.Encoder) error {
   var err error
 if _, err = e.EncodeUint(uint32(len(s))); err != nil {
   return err

--- a/spec/output/generator_spec_go/union.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/union.x/MyXDR_generated.go
@@ -19,7 +19,7 @@ import (
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
 var XdrFilesSHA256 = map[string]string{
-  "spec/fixtures/generator/union.x": "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41"
+  "spec/fixtures/generator/union.x": "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41",
 }
 
 type xdrType interface {


### PR DESCRIPTION
1. Fix the generation of file hashes
2. Make sure we only generate EncodeTo by pointer for fixed opaque types or fixed opaque synonyms