### PR TITLE
make xdr hash scheme independent of white spaces

### DIFF
--- a/lib/xdrgen/output.rb
+++ b/lib/xdrgen/output.rb
@@ -18,7 +18,7 @@ module Xdrgen
     end
 
     def relative_source_path_sha256_hashes
-      relative_source_paths.map { |p| [p, Digest::SHA256.file(p).hexdigest] }.to_h
+      relative_source_paths.map { |p| [p, Digest::SHA256.hexdigest(File.read(p).gsub(/[[:space:]]/,''))] }.to_h
     end
 
     def open(child_path)

--- a/spec/output/generator_spec_go/block_comments.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/block_comments.x/MyXDR_generated.go
@@ -19,7 +19,7 @@ import (
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
 var XdrFilesSHA256 = map[string]string{
-  "spec/fixtures/generator/block_comments.x": "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30",
+  "spec/fixtures/generator/block_comments.x": "25a020c7235093dbb580251fab115afa41c47b0453b992d801d9d85e646ca927",
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/const.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/const.x/MyXDR_generated.go
@@ -19,7 +19,7 @@ import (
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
 var XdrFilesSHA256 = map[string]string{
-  "spec/fixtures/generator/const.x": "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37",
+  "spec/fixtures/generator/const.x": "c2ce6b47f92fc50e9f1cf675e9f3a375d3d418e86d8def79197416fa211dc5bb",
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/enum.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/enum.x/MyXDR_generated.go
@@ -19,7 +19,7 @@ import (
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
 var XdrFilesSHA256 = map[string]string{
-  "spec/fixtures/generator/enum.x": "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f",
+  "spec/fixtures/generator/enum.x": "26f6c8245ab186aa48ec0cf17d0e521258741d8d574de33f4631a45cc6d42af7",
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/nesting.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/nesting.x/MyXDR_generated.go
@@ -19,7 +19,7 @@ import (
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
 var XdrFilesSHA256 = map[string]string{
-  "spec/fixtures/generator/nesting.x": "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a",
+  "spec/fixtures/generator/nesting.x": "9b3966ba255e5b9a280115f56d43ff740ae30b89e84d2494d425cb966d67cfa1",
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/optional.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/optional.x/MyXDR_generated.go
@@ -19,7 +19,7 @@ import (
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
 var XdrFilesSHA256 = map[string]string{
-  "spec/fixtures/generator/optional.x": "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7",
+  "spec/fixtures/generator/optional.x": "f2c1e2609316c93e4d866b0aca1d72b445d3dc9c06172d327e551401adc0791a",
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/struct.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/struct.x/MyXDR_generated.go
@@ -19,7 +19,7 @@ import (
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
 var XdrFilesSHA256 = map[string]string{
-  "spec/fixtures/generator/struct.x": "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a",
+  "spec/fixtures/generator/struct.x": "57db6673d0bad3088958b3727cc2b94fd1172ff9c351e3552312ecf2f41917b1",
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/test.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/test.x/MyXDR_generated.go
@@ -19,7 +19,7 @@ import (
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
 var XdrFilesSHA256 = map[string]string{
-  "spec/fixtures/generator/test.x": "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41",
+  "spec/fixtures/generator/test.x": "cc5d9891ca84c09314a197dc50b749acbc1cc06a49d9459bff84f31895ba8e91",
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_go/union.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/union.x/MyXDR_generated.go
@@ -19,7 +19,7 @@ import (
 
 // XdrFilesSHA256 is the SHA256 hashes of source files.
 var XdrFilesSHA256 = map[string]string{
-  "spec/fixtures/generator/union.x": "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41",
+  "spec/fixtures/generator/union.x": "d6a5a0e0ce740ee4d7de5ef7a17ab255dc1a32596287124b65e147450a6fd6ce",
 }
 
 type xdrType interface {

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -5,7 +5,7 @@
 
 /// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
 pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
-  ("spec/fixtures/generator/block_comments.x", "e13131bc4134f38da17b9d5e9f67d2695a69ef98e3ef272833f4c18d0cc88a30")
+  ("spec/fixtures/generator/block_comments.x", "25a020c7235093dbb580251fab115afa41c47b0453b992d801d9d85e646ca927")
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -5,7 +5,7 @@
 
 /// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
 pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
-  ("spec/fixtures/generator/const.x", "0bff3b37592fcc16cad2fe10b9a72f5d39d033a114917c24e86a9ebd9cda9c37")
+  ("spec/fixtures/generator/const.x", "c2ce6b47f92fc50e9f1cf675e9f3a375d3d418e86d8def79197416fa211dc5bb")
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -5,7 +5,7 @@
 
 /// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
 pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
-  ("spec/fixtures/generator/enum.x", "35cf5e97e2057039640ed260e8b38bb2733a3c3ca8529c93877bdec02a999d7f")
+  ("spec/fixtures/generator/enum.x", "26f6c8245ab186aa48ec0cf17d0e521258741d8d574de33f4631a45cc6d42af7")
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -5,7 +5,7 @@
 
 /// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
 pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
-  ("spec/fixtures/generator/nesting.x", "5537949272c11f1bd09cf613a3751668b5018d686a1c2aaa3baa91183ca18f6a")
+  ("spec/fixtures/generator/nesting.x", "9b3966ba255e5b9a280115f56d43ff740ae30b89e84d2494d425cb966d67cfa1")
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -5,7 +5,7 @@
 
 /// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
 pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
-  ("spec/fixtures/generator/optional.x", "3241e832fcf00bca4315ecb6c259621dafb0e302a63a993f5504b0b5cebb6bd7")
+  ("spec/fixtures/generator/optional.x", "f2c1e2609316c93e4d866b0aca1d72b445d3dc9c06172d327e551401adc0791a")
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -5,7 +5,7 @@
 
 /// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
 pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
-  ("spec/fixtures/generator/struct.x", "c6911a83390e3b499c078fd0c579132eacce88a4a0538d3b8b5e57747a58db4a")
+  ("spec/fixtures/generator/struct.x", "57db6673d0bad3088958b3727cc2b94fd1172ff9c351e3552312ecf2f41917b1")
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -5,7 +5,7 @@
 
 /// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
 pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
-  ("spec/fixtures/generator/test.x", "d29a98a6a3b9bf533a3e6712d928e0bed655e0f462ac4dae810c65d52ca9af41")
+  ("spec/fixtures/generator/test.x", "cc5d9891ca84c09314a197dc50b749acbc1cc06a49d9459bff84f31895ba8e91")
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -5,7 +5,7 @@
 
 /// `XDR_FILES_SHA256` is a list of pairs of source files and their SHA256 hashes.
 pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
-  ("spec/fixtures/generator/union.x", "c251258d967223b341ebcf2d5bb0718e9a039b46232cb743865d9acd0c4bbe41")
+  ("spec/fixtures/generator/union.x", "d6a5a0e0ce740ee4d7de5ef7a17ab255dc1a32596287124b65e147450a6fd6ce")
 ];
 
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};


### PR DESCRIPTION
On some platforms (Windows, maybe others), .x files may differ only in line ending causing a hash mismatch.
This PR removes all whitespaces when computing hashes as to avoid this problem.
