### PR TITLE
Require alloc for value -> Any

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -151,6 +151,7 @@ module Xdrgen
                 Ok(t)
             }
 
+            #[cfg(feature = "alloc")]
             #[must_use]
             #[allow(clippy::too_many_lines)]
             pub fn value(&self) -> &dyn core::any::Any {


### PR DESCRIPTION
### What
Require alloc for value -> Any.

### Why
The as_ref() conversion to Any is only available when we have the alloc feature and the Box is the actual Box type.