### PR TITLE
Rust: Add read xdr to end fns

### DIFF
--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -233,8 +233,8 @@ where
     #[cfg(feature = "std")]
     fn read_xdr(r: &mut impl Read) -> Result<Self>;
 
-    /// Read the XDR and construct the type, requiring the read implementation
-    /// be completely consumed.
+    /// Read the XDR and construct the type, and considering it an error if the
+    /// read does not completely consumed.
     ///
     /// Read bytes from the given read implementation, decoding the bytes as
     /// XDR, and construct the type implementing this interface from those

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -265,7 +265,7 @@ where
     }
 
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<str>) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -228,7 +228,7 @@ where
     /// Just enough bytes are read from the read implementation to construct the
     /// type. Any residual bytes remain in the read implementation.
     ///
-    /// Use [ReadXdr::read_xdr_to_end] when the intent is for all bytes in the
+    /// Use [`ReadXdr::read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
     fn read_xdr(r: &mut impl Read) -> Result<Self>;
@@ -269,8 +269,8 @@ where
     /// Just enough bytes are read from the read implementation to construct the
     /// type. Any residual bytes remain in the read implementation.
     ///
-    /// Use [ReadXdr::read_xdr_to_end] when the intent is for all bytes in the
-    /// read implementation to be consumed by the read.
+    /// Use [`ReadXdr::read_xdr_into_to_end`] when the intent is for all bytes
+    /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
     fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
         *self = Self::read_xdr(r)?;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -228,6 +228,9 @@ where
     /// Just enough bytes are read from the read implementation to construct the
     /// type. Any residual bytes remain in the read implementation.
     ///
+    /// All implementations should continue if the read implementation returns
+    /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
+    ///
     /// Use [`ReadXdr::read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
@@ -248,6 +251,9 @@ where
     /// may not be exhaustively read if there are residual bytes, and it is
     /// considered undefined how many residual bytes or how much of the residual
     /// buffer are consumed in this case.
+    ///
+    /// All implementations should continue if the read implementation returns
+    /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_to_end(r: &mut impl Read) -> Result<Self> {
         let s = Self::read_xdr(r)?;
@@ -268,6 +274,9 @@ where
     ///
     /// Just enough bytes are read from the read implementation to construct the
     /// type. Any residual bytes remain in the read implementation.
+    ///
+    /// All implementations should continue if the read implementation returns
+    /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     ///
     /// Use [`ReadXdr::read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
@@ -292,6 +301,9 @@ where
     /// may not be exhaustively read if there are residual bytes, and it is
     /// considered undefined how many residual bytes or how much of the residual
     /// buffer are consumed in this case.
+    ///
+    /// All implementations should continue if the read implementation returns
+    /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_into_to_end(&mut self, r: &mut impl Read) -> Result<()> {
         Self::read_xdr_into(self, r)?;
@@ -319,6 +331,9 @@ where
     /// may not be exhaustively read if there are residual bytes, and it is
     /// considered undefined how many residual bytes or how much of the residual
     /// buffer are consumed in this case.
+    ///
+    /// All implementations should continue if the read implementation returns
+    /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut R) -> ReadXdrIter<R, Self> {
         ReadXdrIter::new(r)

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -258,14 +258,14 @@ where
     }
 
     #[cfg(feature = "std")]
-    fn from_xdr<B: AsRef<[u8]>>(bytes: B) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
         let mut cursor = Cursor::new(bytes.as_ref());
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: String) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<str>) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -233,7 +233,7 @@ where
     #[cfg(feature = "std")]
     fn read_xdr(r: &mut impl Read) -> Result<Self>;
 
-    /// Read the XDR and construct the type, and considering it an error if the
+    /// Read the XDR and construct the type, and consider it an error if the
     /// read does not completely consume the read implementation.
     ///
     /// Read bytes from the given read implementation, decoding the bytes as
@@ -260,12 +260,38 @@ where
         }
     }
 
+    /// Read the XDR and construct the type.
+    ///
+    /// Read bytes from the given read implementation, decoding the bytes as
+    /// XDR, and construct the type implementing this interface from those
+    /// bytes.
+    ///
+    /// Just enough bytes are read from the read implementation to construct the
+    /// type. Any residual bytes remain in the read implementation.
+    ///
+    /// Use [ReadXdr::read_xdr_to_end] when the intent is for all bytes in the
+    /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
     fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
 
+    /// Read the XDR into the existing value, and consider it an error if the
+    /// read does not completely consume the read implementation.
+    ///
+    /// Read bytes from the given read implementation, decoding the bytes as
+    /// XDR, and construct the type implementing this interface from those
+    /// bytes.
+    ///
+    /// Just enough bytes are read from the read implementation to construct the
+    /// type, and then confirm that no further bytes remain. To confirm no
+    /// further bytes remain additional bytes are attempted to be read from the
+    /// read implementation. If it is possible to read any residual bytes from
+    /// the read implementation an error is returned. The read implementation
+    /// may not be exhaustively read if there are residual bytes, and it is
+    /// considered undefined how many residual bytes or how much of the residual
+    /// buffer are consumed in this case.
     #[cfg(feature = "std")]
     fn read_xdr_into_to_end(&mut self, r: &mut impl Read) -> Result<()> {
         Self::read_xdr_into(self, r)?;
@@ -278,11 +304,30 @@ where
         }
     }
 
+    /// Create an iterator that reads the read implementation as a stream of
+    /// values that are read into the implementing type.
+    ///
+    /// Read bytes from the given read implementation, decoding the bytes as
+    /// XDR, and construct the type implementing this interface from those
+    /// bytes.
+    ///
+    /// Just enough bytes are read from the read implementation to construct the
+    /// type, and then confirm that no further bytes remain. To confirm no
+    /// further bytes remain additional bytes are attempted to be read from the
+    /// read implementation. If it is possible to read any residual bytes from
+    /// the read implementation an error is returned. The read implementation
+    /// may not be exhaustively read if there are residual bytes, and it is
+    /// considered undefined how many residual bytes or how much of the residual
+    /// buffer are consumed in this case.
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut R) -> ReadXdrIter<R, Self> {
         ReadXdrIter::new(r)
     }
 
+    /// Construct the type from the XDR bytes.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
     #[cfg(feature = "std")]
     fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
         let mut cursor = Cursor::new(bytes.as_ref());
@@ -290,6 +335,10 @@ where
         Ok(t)
     }
 
+    /// Construct the type from the XDR bytes base64 encoded.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -219,9 +219,35 @@ pub trait ReadXdr
 where
     Self: Sized,
 {
+    /// Read the XDR and construct the type.
+    ///
+    /// Read bytes from the given read implementation, decoding the bytes as
+    /// XDR, and construct the type implementing this interface from those
+    /// bytes.
+    ///
+    /// Just enough bytes are read from the read implementation to construct the
+    /// type. Any residual bytes remain in the read implementation.
+    ///
+    /// Use [ReadXdr::read_xdr_to_end] when the intent is for all bytes in the
+    /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
     fn read_xdr(r: &mut impl Read) -> Result<Self>;
 
+    /// Read the XDR and construct the type, requiring the read implementation
+    /// be completely consumed.
+    ///
+    /// Read bytes from the given read implementation, decoding the bytes as
+    /// XDR, and construct the type implementing this interface from those
+    /// bytes.
+    ///
+    /// Just enough bytes are read from the read implementation to construct the
+    /// type, and then confirm that no further bytes remain. To confirm no
+    /// further bytes remain additional bytes are attempted to be read from the
+    /// read implementation. If it is possible to read any residual bytes from
+    /// the read implementation an error is returned. The read implementation
+    /// may not be exhaustively read if there are residual bytes, and it is
+    /// considered undefined how many residual bytes or how much of the residual
+    /// buffer are consumed in this case.
     #[cfg(feature = "std")]
     fn read_xdr_to_end(r: &mut impl Read) -> Result<Self> {
         let s = Self::read_xdr(r)?;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -253,9 +253,6 @@ where
     }
 
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end(&mut self, r: &mut impl Read) -> Result<Self>;
-
-    #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut R) -> ReadXdrIter<R, Self> {
         ReadXdrIter::new(r)
     }

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -234,7 +234,7 @@ where
     fn read_xdr(r: &mut impl Read) -> Result<Self>;
 
     /// Read the XDR and construct the type, and considering it an error if the
-    /// read does not completely consumed.
+    /// read does not completely consume the read implementation.
     ///
     /// Read bytes from the given read implementation, decoding the bytes as
     /// XDR, and construct the type implementing this interface from those

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -233,9 +233,33 @@ where
     fn read_xdr(r: &mut impl Read) -> Result<Self>;
 
     #[cfg(feature = "std")]
+    fn read_xdr_to_end(r: &mut impl Read) -> Result<Self> {
+        let s = Self::read_xdr(r)?;
+        // Check that any further reads, such as this read of one byte, read no
+        // data, indicating EOF. If a byte is read the data is invalid.
+        if r.read(&mut [0u8; 1])? == 0 {
+            Ok(s)
+        } else {
+            Err(Error::Invalid)
+        }
+    }
+
+    #[cfg(feature = "std")]
     fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    fn read_xdr_into_to_end(&mut self, r: &mut impl Read) -> Result<()> {
+        Self::read_xdr_into(self, r)?;
+        // Check that any further reads, such as this read of one byte, read no
+        // data, indicating EOF. If a byte is read the data is invalid.
+        if r.read(&mut [0u8; 1])? == 0 {
+            Ok(())
+        } else {
+            Err(Error::Invalid)
+        }
     }
 
     #[cfg(feature = "std")]
@@ -244,17 +268,17 @@ where
     }
 
     #[cfg(feature = "std")]
-    fn from_xdr<B: AsRef<[u8]>>(bytes: B) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
         let mut cursor = Cursor::new(bytes.as_ref());
-        let t = Self::read_xdr(&mut cursor)?;
+        let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: String) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
-        let t = Self::read_xdr(&mut dec)?;
+        let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
 }

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -233,9 +233,33 @@ where
     fn read_xdr(r: &mut impl Read) -> Result<Self>;
 
     #[cfg(feature = "std")]
+    fn read_xdr_to_end(r: &mut impl Read) -> Result<Self> {
+        let s = Self::read_xdr(r)?;
+        // Check that any further reads, such as this read of one byte, read no
+        // data, indicating EOF. If a byte is read the data is invalid.
+        if r.read(&mut [0u8; 1])? == 0 {
+            Ok(s)
+        } else {
+            Err(Error::Invalid)
+        }
+    }
+
+    #[cfg(feature = "std")]
     fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    fn read_xdr_into_to_end(&mut self, r: &mut impl Read) -> Result<()> {
+        Self::read_xdr_into(self, r)?;
+        // Check that any further reads, such as this read of one byte, read no
+        // data, indicating EOF. If a byte is read the data is invalid.
+        if r.read(&mut [0u8; 1])? == 0 {
+            Ok(())
+        } else {
+            Err(Error::Invalid)
+        }
     }
 
     #[cfg(feature = "std")]
@@ -244,17 +268,17 @@ where
     }
 
     #[cfg(feature = "std")]
-    fn from_xdr<B: AsRef<[u8]>>(bytes: B) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
         let mut cursor = Cursor::new(bytes.as_ref());
-        let t = Self::read_xdr(&mut cursor)?;
+        let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: String) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
-        let t = Self::read_xdr(&mut dec)?;
+        let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
 }

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -233,9 +233,33 @@ where
     fn read_xdr(r: &mut impl Read) -> Result<Self>;
 
     #[cfg(feature = "std")]
+    fn read_xdr_to_end(r: &mut impl Read) -> Result<Self> {
+        let s = Self::read_xdr(r)?;
+        // Check that any further reads, such as this read of one byte, read no
+        // data, indicating EOF. If a byte is read the data is invalid.
+        if r.read(&mut [0u8; 1])? == 0 {
+            Ok(s)
+        } else {
+            Err(Error::Invalid)
+        }
+    }
+
+    #[cfg(feature = "std")]
     fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    fn read_xdr_into_to_end(&mut self, r: &mut impl Read) -> Result<()> {
+        Self::read_xdr_into(self, r)?;
+        // Check that any further reads, such as this read of one byte, read no
+        // data, indicating EOF. If a byte is read the data is invalid.
+        if r.read(&mut [0u8; 1])? == 0 {
+            Ok(())
+        } else {
+            Err(Error::Invalid)
+        }
     }
 
     #[cfg(feature = "std")]
@@ -244,17 +268,17 @@ where
     }
 
     #[cfg(feature = "std")]
-    fn from_xdr<B: AsRef<[u8]>>(bytes: B) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
         let mut cursor = Cursor::new(bytes.as_ref());
-        let t = Self::read_xdr(&mut cursor)?;
+        let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: String) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
-        let t = Self::read_xdr(&mut dec)?;
+        let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
 }

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -233,9 +233,33 @@ where
     fn read_xdr(r: &mut impl Read) -> Result<Self>;
 
     #[cfg(feature = "std")]
+    fn read_xdr_to_end(r: &mut impl Read) -> Result<Self> {
+        let s = Self::read_xdr(r)?;
+        // Check that any further reads, such as this read of one byte, read no
+        // data, indicating EOF. If a byte is read the data is invalid.
+        if r.read(&mut [0u8; 1])? == 0 {
+            Ok(s)
+        } else {
+            Err(Error::Invalid)
+        }
+    }
+
+    #[cfg(feature = "std")]
     fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    fn read_xdr_into_to_end(&mut self, r: &mut impl Read) -> Result<()> {
+        Self::read_xdr_into(self, r)?;
+        // Check that any further reads, such as this read of one byte, read no
+        // data, indicating EOF. If a byte is read the data is invalid.
+        if r.read(&mut [0u8; 1])? == 0 {
+            Ok(())
+        } else {
+            Err(Error::Invalid)
+        }
     }
 
     #[cfg(feature = "std")]
@@ -244,17 +268,17 @@ where
     }
 
     #[cfg(feature = "std")]
-    fn from_xdr<B: AsRef<[u8]>>(bytes: B) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
         let mut cursor = Cursor::new(bytes.as_ref());
-        let t = Self::read_xdr(&mut cursor)?;
+        let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: String) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
-        let t = Self::read_xdr(&mut dec)?;
+        let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
 }

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -233,9 +233,33 @@ where
     fn read_xdr(r: &mut impl Read) -> Result<Self>;
 
     #[cfg(feature = "std")]
+    fn read_xdr_to_end(r: &mut impl Read) -> Result<Self> {
+        let s = Self::read_xdr(r)?;
+        // Check that any further reads, such as this read of one byte, read no
+        // data, indicating EOF. If a byte is read the data is invalid.
+        if r.read(&mut [0u8; 1])? == 0 {
+            Ok(s)
+        } else {
+            Err(Error::Invalid)
+        }
+    }
+
+    #[cfg(feature = "std")]
     fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    fn read_xdr_into_to_end(&mut self, r: &mut impl Read) -> Result<()> {
+        Self::read_xdr_into(self, r)?;
+        // Check that any further reads, such as this read of one byte, read no
+        // data, indicating EOF. If a byte is read the data is invalid.
+        if r.read(&mut [0u8; 1])? == 0 {
+            Ok(())
+        } else {
+            Err(Error::Invalid)
+        }
     }
 
     #[cfg(feature = "std")]
@@ -244,17 +268,17 @@ where
     }
 
     #[cfg(feature = "std")]
-    fn from_xdr<B: AsRef<[u8]>>(bytes: B) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
         let mut cursor = Cursor::new(bytes.as_ref());
-        let t = Self::read_xdr(&mut cursor)?;
+        let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: String) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
-        let t = Self::read_xdr(&mut dec)?;
+        let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
 }

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -233,9 +233,33 @@ where
     fn read_xdr(r: &mut impl Read) -> Result<Self>;
 
     #[cfg(feature = "std")]
+    fn read_xdr_to_end(r: &mut impl Read) -> Result<Self> {
+        let s = Self::read_xdr(r)?;
+        // Check that any further reads, such as this read of one byte, read no
+        // data, indicating EOF. If a byte is read the data is invalid.
+        if r.read(&mut [0u8; 1])? == 0 {
+            Ok(s)
+        } else {
+            Err(Error::Invalid)
+        }
+    }
+
+    #[cfg(feature = "std")]
     fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    fn read_xdr_into_to_end(&mut self, r: &mut impl Read) -> Result<()> {
+        Self::read_xdr_into(self, r)?;
+        // Check that any further reads, such as this read of one byte, read no
+        // data, indicating EOF. If a byte is read the data is invalid.
+        if r.read(&mut [0u8; 1])? == 0 {
+            Ok(())
+        } else {
+            Err(Error::Invalid)
+        }
     }
 
     #[cfg(feature = "std")]
@@ -244,17 +268,17 @@ where
     }
 
     #[cfg(feature = "std")]
-    fn from_xdr<B: AsRef<[u8]>>(bytes: B) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
         let mut cursor = Cursor::new(bytes.as_ref());
-        let t = Self::read_xdr(&mut cursor)?;
+        let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: String) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
-        let t = Self::read_xdr(&mut dec)?;
+        let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
 }

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -233,9 +233,33 @@ where
     fn read_xdr(r: &mut impl Read) -> Result<Self>;
 
     #[cfg(feature = "std")]
+    fn read_xdr_to_end(r: &mut impl Read) -> Result<Self> {
+        let s = Self::read_xdr(r)?;
+        // Check that any further reads, such as this read of one byte, read no
+        // data, indicating EOF. If a byte is read the data is invalid.
+        if r.read(&mut [0u8; 1])? == 0 {
+            Ok(s)
+        } else {
+            Err(Error::Invalid)
+        }
+    }
+
+    #[cfg(feature = "std")]
     fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    fn read_xdr_into_to_end(&mut self, r: &mut impl Read) -> Result<()> {
+        Self::read_xdr_into(self, r)?;
+        // Check that any further reads, such as this read of one byte, read no
+        // data, indicating EOF. If a byte is read the data is invalid.
+        if r.read(&mut [0u8; 1])? == 0 {
+            Ok(())
+        } else {
+            Err(Error::Invalid)
+        }
     }
 
     #[cfg(feature = "std")]
@@ -244,17 +268,17 @@ where
     }
 
     #[cfg(feature = "std")]
-    fn from_xdr<B: AsRef<[u8]>>(bytes: B) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
         let mut cursor = Cursor::new(bytes.as_ref());
-        let t = Self::read_xdr(&mut cursor)?;
+        let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: String) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
-        let t = Self::read_xdr(&mut dec)?;
+        let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
 }

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -233,9 +233,33 @@ where
     fn read_xdr(r: &mut impl Read) -> Result<Self>;
 
     #[cfg(feature = "std")]
+    fn read_xdr_to_end(r: &mut impl Read) -> Result<Self> {
+        let s = Self::read_xdr(r)?;
+        // Check that any further reads, such as this read of one byte, read no
+        // data, indicating EOF. If a byte is read the data is invalid.
+        if r.read(&mut [0u8; 1])? == 0 {
+            Ok(s)
+        } else {
+            Err(Error::Invalid)
+        }
+    }
+
+    #[cfg(feature = "std")]
     fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    fn read_xdr_into_to_end(&mut self, r: &mut impl Read) -> Result<()> {
+        Self::read_xdr_into(self, r)?;
+        // Check that any further reads, such as this read of one byte, read no
+        // data, indicating EOF. If a byte is read the data is invalid.
+        if r.read(&mut [0u8; 1])? == 0 {
+            Ok(())
+        } else {
+            Err(Error::Invalid)
+        }
     }
 
     #[cfg(feature = "std")]
@@ -244,17 +268,17 @@ where
     }
 
     #[cfg(feature = "std")]
-    fn from_xdr<B: AsRef<[u8]>>(bytes: B) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
         let mut cursor = Cursor::new(bytes.as_ref());
-        let t = Self::read_xdr(&mut cursor)?;
+        let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: String) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
-        let t = Self::read_xdr(&mut dec)?;
+        let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
 }


### PR DESCRIPTION
### What
Add read xdr to end fns to the generated Rust code, and use them for base64 decoding.

### Why
A lot of the time when reading from a stream into a value we want to read the entire stream into that one value, and for there to be extra data in the stream that is an error, because we don't expect there to be any extra data, and that data might be something we're discarding when we shouldn't be.

It's helpful to have functions that do this for us, so that the caller doesn't have to do this themselves.

The _to_end style functions are aligned with an existing pattern in the std::io::Read trait, where functions that end in _to_end read the stream all the way to the end. Although the function names do read a little odd. There might be a better name for this, but I haven't found it.