### PR TITLE
Rust: Type Opaque as BytesM and String as StringM

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -577,7 +577,7 @@ module Xdrgen
           out.puts %{#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]}
           out.puts "#[derive(Default)]" if is_var_array_type(typedef.type)
           if is_fixed_array_opaque(typedef.type)
-          out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr), serde(rename_all = "camelCase"))]}
+          out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]}
           else
           out.puts "#[derive(Debug)]"
           out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]}

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -609,7 +609,7 @@ module Xdrgen
           }
 
           #[cfg(feature = "alloc")]
-          impl<const MAX: u32> core::str::FromStr for #{name typedef} {
+          impl core::str::FromStr for #{name typedef} {
             type Err = Error;
             fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
                 hex::decode(s).map_err(|_| Error::InvalidHex)?.try_into()

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -577,7 +577,12 @@ module Xdrgen
           out.puts %{#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]}
           out.puts "#[derive(Default)]" if is_var_array_type(typedef.type)
           out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]}
-          out.puts "pub struct #{name typedef}(pub #{reference(typedef, typedef.type)});"
+          out.puts <<-EOS.strip_heredoc
+          pub struct #{name typedef}(
+              #[cfg_attr(all(feature = "serde", feature = "alloc"), serde(with = "hex"))]
+              pub #{reference(typedef, typedef.type)}
+          );
+          EOS
           out.puts ""
           out.puts <<-EOS.strip_heredoc
           impl From<#{name typedef}> for #{reference(typedef, typedef.type)} {

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -763,17 +763,17 @@ module Xdrgen
           raise 'no quadruple support for rust'
         when AST::Typespecs::String
           if !type.decl.resolved_size.nil?
-            "VecM::<u8, #{type.decl.resolved_size}>"
+            "StringM::<#{type.decl.resolved_size}>"
           else
-            "VecM::<u8>"
+            "StringM"
           end
         when AST::Typespecs::Opaque
           if type.fixed?
             "[u8; #{type.size}]"
           elsif !type.decl.resolved_size.nil?
-            "VecM::<u8, #{type.decl.resolved_size}>"
+            "BytesM::<#{type.decl.resolved_size}>"
           else
-            "VecM::<u8>"
+            "BytesM"
           end
         when AST::Typespecs::Simple, AST::Definitions::Base, AST::Concerns::NestedDefinition
           if type.respond_to?(:resolved_type) && AST::Definitions::Typedef === type.resolved_type && is_builtin_type(type.resolved_type.type)
@@ -841,17 +841,17 @@ module Xdrgen
         case type
         when AST::Typespecs::String
           if !type.decl.resolved_size.nil?
-            "VecM::<u8, #{type.decl.resolved_size}>"
+            "StringM::<#{type.decl.resolved_size}>"
           else
-            "VecM::<u8>"
+            "StringM"
           end
         when AST::Typespecs::Opaque
           if type.fixed?
             "[u8; #{type.size}]"
           elsif !type.decl.resolved_size.nil?
-            "VecM::<u8, #{type.decl.resolved_size}>"
+            "BytesM::<#{type.decl.resolved_size}>"
           else
-            "VecM::<u8>"
+            "BytesM"
           end
         when AST::Typespecs::Simple, AST::Definitions::Base, AST::Concerns::NestedDefinition
           if type.respond_to?(:resolved_type) && AST::Definitions::Typedef === type.resolved_type && is_builtin_type(type.resolved_type.type)

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -577,12 +577,18 @@ module Xdrgen
           out.puts %{#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]}
           out.puts "#[derive(Default)]" if is_var_array_type(typedef.type)
           out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]}
-          out.puts <<-EOS.strip_heredoc
-          pub struct #{name typedef}(
-              #[cfg_attr(all(feature = "serde", feature = "alloc"), serde(with = "hex"))]
-              pub #{reference(typedef, typedef.type)}
-          );
-          EOS
+          if is_fixed_array_type(typedef.type)
+            out.puts <<-EOS.strip_heredoc
+            pub struct #{name typedef}(
+                #[cfg_attr(all(feature = "serde", feature = "alloc"), serde(with = "hex"))]
+                pub #{reference(typedef, typedef.type)}
+            );
+            EOS
+          else
+            out.puts <<-EOS.strip_heredoc
+            pub struct #{name typedef}(pub #{reference(typedef, typedef.type)});
+            EOS
+          end
           out.puts ""
           out.puts <<-EOS.strip_heredoc
           impl From<#{name typedef}> for #{reference(typedef, typedef.type)} {

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -579,7 +579,7 @@ module Xdrgen
           out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]}
           out.puts <<-EOS.strip_heredoc
           pub struct #{name typedef}(
-              #[cfg_attr(all(feature = "serde", feature = "alloc"), serde(with = "hex"))]
+              // TODO: #[cfg_attr(all(feature = "serde", feature = "alloc"), serde(with = "hex"))]
               pub #{reference(typedef, typedef.type)}
           );
           EOS

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -579,7 +579,7 @@ module Xdrgen
           out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "camelCase"))]}
           out.puts <<-EOS.strip_heredoc
           pub struct #{name typedef}(
-              // TODO: #[cfg_attr(all(feature = "serde", feature = "alloc"), serde(with = "hex"))]
+              #[cfg_attr(all(feature = "serde", feature = "alloc"), serde(with = "hex"))]
               pub #{reference(typedef, typedef.type)}
           );
           EOS

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1397,7 +1397,7 @@ fn write_utf8_lossy<F>(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core:
             Err(error) => {
                 let (valid, after_valid) = input.split_at(error.valid_up_to());
                 write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
-                write!(f, "{}", "\u{FFFD}")?;
+                write!(f, "\u{FFFD}")?;
 
                 if let Some(invalid_sequence_length) = error.error_len() {
                     input = &after_valid[invalid_sequence_length..];

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1360,7 +1360,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 #[cfg(feature = "alloc")]
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = ();
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
         s.try_into().map_err(|_| ())
     }
 }

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1385,9 +1385,10 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
+#[cfg(feature = "alloc")]
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        use core::str;
+        use alloc::str;
         #[cfg(feature = "alloc")]
         let v = &self.0;
         #[cfg(not(feature = "alloc"))]
@@ -1398,9 +1399,10 @@ impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        use core::str;
+        use alloc::str;
         #[cfg(feature = "alloc")]
         let v = &self.0;
         #[cfg(not(feature = "alloc"))]

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -93,6 +93,8 @@ impl fmt::Display for Error {
             Error::LengthMismatch => write!(f, "xdr value length does not match"),
             Error::NonZeroPadding => write!(f, "xdr padding contains non-zero bytes"),
             Error::Utf8Error(e) => write!(f, "{}", e),
+            #[cfg(feature = "alloc")]
+            Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{}", e),
         }

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1427,7 +1427,9 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
         let v = &self.0;
         #[cfg(not(feature = "alloc"))]
         let v = self.0;
+        write!(f, "StringM(")?;
         write_utf8_lossy(f, v)?;
+        write!(f, ")")?;
         Ok(())
     }
 }

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1387,7 +1387,7 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
 /// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
 /// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
-fn write_utf8_lossy<F>(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
+fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
     loop {
         match core::str::from_utf8(input) {
             Ok(valid) => {

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1342,7 +1342,7 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         use core::str;
-        let s = str::from_utf8(self.0).map_err(|_| core::fmt::Error)?;
+        let s = str::from_utf8(&self.0).map_err(|_| core::fmt::Error)?;
         write!(f, "{s}")?;
         Ok(())
     }
@@ -1351,7 +1351,7 @@ impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
 impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         use core::str;
-        let s = str::from_utf8(self.0).map_err(|_| core::fmt::Error)?;
+        let s = str::from_utf8(&self.0).map_err(|_| core::fmt::Error)?;
         write!(f, "StringM({s})")?;
         Ok(())
     }

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1342,7 +1342,7 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         use core::str;
-        let s = str::from_utf8(&self.0).map_err(|_| core::fmt::Error)?;
+        let s = str::from_utf8(self.0).map_err(|_| core::fmt::Error)?;
         write!(f, "{s}")?;
         Ok(())
     }
@@ -1351,7 +1351,7 @@ impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
 impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         use core::str;
-        let s = str::from_utf8(&self.0).map_err(|_| core::fmt::Error)?;
+        let s = str::from_utf8(self.0).map_err(|_| core::fmt::Error)?;
         write!(f, "StringM({s})")?;
         Ok(())
     }

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1342,13 +1342,11 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         use core::str;
-        let s = str::from_utf8({
-            #[cfg(feature = "alloc")]
-            &self.0
-            #[cfg(not(feature = "alloc"))]
-            self.0
-        })
-        .map_err(|_| core::fmt::Error)?;
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        let s = str::from_utf8(v).map_err(|_| core::fmt::Error)?;
         write!(f, "{s}")?;
         Ok(())
     }
@@ -1357,13 +1355,11 @@ impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
 impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         use core::str;
-        let s = str::from_utf8({
-            #[cfg(feature = "alloc")]
-            &self.0
-            #[cfg(not(feature = "alloc"))]
-            self.0
-        })
-        .map_err(|_| core::fmt::Error)?;
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        let s = str::from_utf8(v).map_err(|_| core::fmt::Error)?;
         write!(f, "StringM({s})")?;
         Ok(())
     }

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1561,7 +1561,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 }
 
 #[cfg(feature = "alloc")]
-impl<const MAX: u32> TryFrom<&String> for StringM<u8, MAX> {
+impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
     fn try_from(v: &String) -> Result<Self> {
@@ -1575,7 +1575,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<u8, MAX> {
 }
 
 #[cfg(feature = "alloc")]
-impl<const MAX: u32> TryFrom<String> for StringM<u8, MAX> {
+impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
     fn try_from(v: String) -> Result<Self> {
@@ -1589,25 +1589,25 @@ impl<const MAX: u32> TryFrom<String> for StringM<u8, MAX> {
 }
 
 #[cfg(feature = "alloc")]
-impl<const MAX: u32> TryFrom<StringM<u8, MAX>> for String {
+impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self> {
         Ok(String::from_utf8(v.0)?)
     }
 }
 
 #[cfg(feature = "alloc")]
-impl<const MAX: u32> TryFrom<&StringM<u8, MAX>> for String {
+impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
 
 #[cfg(feature = "alloc")]
-impl<const MAX: u32> TryFrom<&str> for StringM<u8, MAX> {
+impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
     fn try_from(v: &str) -> Result<Self> {
@@ -1621,7 +1621,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<u8, MAX> {
 }
 
 #[cfg(not(feature = "alloc"))]
-impl<const MAX: u32> TryFrom<&'static str> for StringM<u8, MAX> {
+impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
     fn try_from(v: &'static str) -> Result<Self> {
@@ -1634,15 +1634,15 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<u8, MAX> {
     }
 }
 
-impl<'a, const MAX: u32> TryFrom<&'a StringM<u8, MAX>> for &'a str {
+impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
-impl<const MAX: u32> ReadXdr for StringM<u8, MAX> {
+impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr(r: &mut impl Read) -> Result<Self> {
         let len: u32 = u32::read_xdr(r)?;
@@ -1663,7 +1663,7 @@ impl<const MAX: u32> ReadXdr for StringM<u8, MAX> {
     }
 }
 
-impl<const MAX: u32> WriteXdr for StringM<u8, MAX> {
+impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
         let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1407,6 +1407,7 @@ fn write_utf8_lossy<F>(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core:
             }
         }
     }
+    Ok(())
 }
 
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1370,9 +1370,9 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 
 #[cfg(feature = "alloc")]
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
-    type Err = ();
+    type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        s.try_into().map_err(|_| ())
+        s.try_into()
     }
 }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1330,7 +1330,10 @@ impl<const MAX: u32> WriteXdr for BytesM<MAX> {
 
 #[cfg(feature = "alloc")]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
+)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1391,13 +1391,13 @@ fn write_utf8_lossy<F>(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core:
     loop {
         match core::str::from_utf8(input) {
             Ok(valid) => {
-                write!(f, valid)?;
+                write!(f, "{}", valid)?;
                 break;
             }
             Err(error) => {
                 let (valid, after_valid) = input.split_at(error.valid_up_to());
-                write!(f, core::str::from_utf8(valid).unwrap())?;
-                write!(f, "\u{FFFD}")?;
+                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
+                write!(f, "{}", "\u{FFFD}")?;
 
                 if let Some(invalid_sequence_length) = error.error_len() {
                     input = &after_valid[invalid_sequence_length..];

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1396,7 +1396,7 @@ fn from_utf8_lossy<F>(mut input: &[u8], mut push: F) where F: FnMut(&str) -> cor
             }
             Err(error) => {
                 let (valid, after_valid) = input.split_at(error.valid_up_to());
-                push(core::str::from_utf8(valid).unwrap())
+                push(core::str::from_utf8(valid).unwrap());
                 push("\u{FFFD}");
 
                 if let Some(invalid_sequence_length) = error.error_len() {

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1176,7 +1176,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
     type Error = BytesM<MAX>;
 
     fn try_from(v: BytesM<MAX>) -> core::result::Result<Self, Self::Error> {
-        let s: [u8; N] = v.0.try_into().map_err(|v: Vec<u8>| BytesM::<MAX>(v))?;
+        let s: [u8; N] = v.0.try_into().map_err(BytesM::<MAX>)?;
         Ok(s)
     }
 }
@@ -1495,7 +1495,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
     type Error = StringM<MAX>;
 
     fn try_from(v: StringM<MAX>) -> core::result::Result<Self, Self::Error> {
-        let s: [u8; N] = v.0.try_into().map_err(|v: Vec<u8>| StringM::<MAX>(v))?;
+        let s: [u8; N] = v.0.try_into().map_err(StringM::<MAX>)?;
         Ok(s)
     }
 }

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1392,7 +1392,7 @@ impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
         let v = &self.0;
         #[cfg(not(feature = "alloc"))]
         let v = self.0;
-        let s = str::from_utf8(v).map_err(|_| core::fmt::Error)?;
+        let s = str::from_utf8_lossy(v);
         write!(f, "{s}")?;
         Ok(())
     }
@@ -1405,7 +1405,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
         let v = &self.0;
         #[cfg(not(feature = "alloc"))]
         let v = self.0;
-        let s = str::from_utf8(v).map_err(|_| core::fmt::Error)?;
+        let s = str::from_utf8_lossy(v);
         write!(f, "StringM({s})")?;
         Ok(())
     }

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1018,9 +1018,7 @@ pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[cfg(not(feature = "alloc"))]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>)
-where
-    T: 'static;
+pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
 impl<const MAX: u32> Deref for BytesM<MAX> {
     type Target = Vec<u8>;
@@ -1371,9 +1369,7 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[cfg(not(feature = "alloc"))]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>)
-where
-    T: 'static;
+pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
 impl<const MAX: u32> Deref for StringM<MAX> {
     type Target = Vec<u8>;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1210,7 +1210,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 }
 
 #[cfg(feature = "alloc")]
-impl<const MAX: u32> TryFrom<&String> for BytesM<u8, MAX> {
+impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
     fn try_from(v: &String) -> Result<Self> {
@@ -1224,7 +1224,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<u8, MAX> {
 }
 
 #[cfg(feature = "alloc")]
-impl<const MAX: u32> TryFrom<String> for BytesM<u8, MAX> {
+impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
     fn try_from(v: String) -> Result<Self> {
@@ -1238,25 +1238,25 @@ impl<const MAX: u32> TryFrom<String> for BytesM<u8, MAX> {
 }
 
 #[cfg(feature = "alloc")]
-impl<const MAX: u32> TryFrom<BytesM<u8, MAX>> for String {
+impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self> {
         Ok(String::from_utf8(v.0)?)
     }
 }
 
 #[cfg(feature = "alloc")]
-impl<const MAX: u32> TryFrom<&BytesM<u8, MAX>> for String {
+impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
 
 #[cfg(feature = "alloc")]
-impl<const MAX: u32> TryFrom<&str> for BytesM<u8, MAX> {
+impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
     fn try_from(v: &str) -> Result<Self> {
@@ -1270,7 +1270,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<u8, MAX> {
 }
 
 #[cfg(not(feature = "alloc"))]
-impl<const MAX: u32> TryFrom<&'static str> for BytesM<u8, MAX> {
+impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
     fn try_from(v: &'static str) -> Result<Self> {
@@ -1283,15 +1283,15 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<u8, MAX> {
     }
 }
 
-impl<'a, const MAX: u32> TryFrom<&'a BytesM<u8, MAX>> for &'a str {
+impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
-impl<const MAX: u32> ReadXdr for BytesM<u8, MAX> {
+impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr(r: &mut impl Read) -> Result<Self> {
         let len: u32 = u32::read_xdr(r)?;
@@ -1312,7 +1312,7 @@ impl<const MAX: u32> ReadXdr for BytesM<u8, MAX> {
     }
 }
 
-impl<const MAX: u32> WriteXdr for BytesM<u8, MAX> {
+impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
         let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1416,7 +1416,7 @@ impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
         let v = &self.0;
         #[cfg(not(feature = "alloc"))]
         let v = self.0;
-        write_utf8_lossy(f, v);
+        write_utf8_lossy(f, v)?;
         Ok(())
     }
 }
@@ -1427,7 +1427,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
         let v = &self.0;
         #[cfg(not(feature = "alloc"))]
         let v = self.0;
-        write_utf8_lossy(f, v);
+        write_utf8_lossy(f, v)?;
         Ok(())
     }
 }

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1396,9 +1396,7 @@ fn from_utf8_lossy<F>(mut input: &[u8], mut push: F) where F: FnMut(&str) -> cor
             }
             Err(error) => {
                 let (valid, after_valid) = input.split_at(error.valid_up_to());
-                unsafe {
-                    push(core::str::from_utf8_unchecked(valid))
-                }
+                push(core::str::from_utf8(valid).unwrap())
                 push("\u{FFFD}");
 
                 if let Some(invalid_sequence_length) = error.error_len() {

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1339,7 +1339,7 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
-impl<const MAX: u32> Display for StringM<MAX> {
+impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let s = str::from_utf8(&self.0).map_err(|_| core::fmt::Error)?;
         write!(f, "{s}")?;
@@ -1347,7 +1347,7 @@ impl<const MAX: u32> Display for StringM<MAX> {
     }
 }
 
-impl<const MAX: u32> Debug for StringM<MAX> {
+impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let s = str::from_utf8(&self.0).map_err(|_| core::fmt::Error)?;
         write!(f, "StringM({s})")?;
@@ -1356,7 +1356,7 @@ impl<const MAX: u32> Debug for StringM<MAX> {
 }
 
 #[cfg(feature = "alloc")]
-impl<const MAX: u32> FromStr for StringM<MAX> {
+impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = ();
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         s.try_into().map_err(|_| ())

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1342,9 +1342,10 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         use core::str;
-        let s = str::from_utf8(if cfg!(feature = "alloc") {
+        let s = str::from_utf8({
+            #[cfg(feature = "alloc")]
             &self.0
-        } else {
+            #[cfg(not(feature = "alloc"))]
             self.0
         })
         .map_err(|_| core::fmt::Error)?;
@@ -1356,9 +1357,10 @@ impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
 impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         use core::str;
-        let s = str::from_utf8(if cfg!(feature = "alloc") {
+        let s = str::from_utf8({
+            #[cfg(feature = "alloc")]
             &self.0
-        } else {
+            #[cfg(not(feature = "alloc"))]
             self.0
         })
         .map_err(|_| core::fmt::Error)?;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1341,6 +1341,7 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        use core::str;
         let s = str::from_utf8(&self.0).map_err(|_| core::fmt::Error)?;
         write!(f, "{s}")?;
         Ok(())
@@ -1349,6 +1350,7 @@ impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
 
 impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        use core::str;
         let s = str::from_utf8(&self.0).map_err(|_| core::fmt::Error)?;
         write!(f, "StringM({s})")?;
         Ok(())

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1342,7 +1342,12 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         use core::str;
-        let s = str::from_utf8(&self.0).map_err(|_| core::fmt::Error)?;
+        let s = str::from_utf8(if cfg!(feature = "alloc") {
+            &self.0
+        } else {
+            self.0
+        })
+        .map_err(|_| core::fmt::Error)?;
         write!(f, "{s}")?;
         Ok(())
     }
@@ -1351,7 +1356,12 @@ impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
 impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         use core::str;
-        let s = str::from_utf8(&self.0).map_err(|_| core::fmt::Error)?;
+        let s = str::from_utf8(if cfg!(feature = "alloc") {
+            &self.0
+        } else {
+            self.0
+        })
+        .map_err(|_| core::fmt::Error)?;
         write!(f, "StringM({s})")?;
         Ok(())
     }

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1027,13 +1027,12 @@ pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
 impl<const MAX: u32> core::fmt::Display for BytesM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        use hex::ToHex;
         #[cfg(feature = "alloc")]
         let v = &self.0;
         #[cfg(not(feature = "alloc"))]
         let v = self.0;
-        for c in v.encode_to_hex() {
-            write!(f, "{c}")?;
+        for b in v {
+            write!(f, "{b:02x}")?;
         }
         Ok(())
     }
@@ -1046,8 +1045,8 @@ impl<const MAX: u32> core::fmt::Debug for BytesM<MAX> {
         #[cfg(not(feature = "alloc"))]
         let v = self.0;
         write!(f, "BytesM(")?;
-        for c in v.encode_to_hex() {
-            write!(f, "{c}")?;
+        for b in v {
+            write!(f, "{b:02x}")?;
         }
         write!(f, ")")?;
         Ok(())

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1011,7 +1011,10 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
+)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
@@ -1019,6 +1022,41 @@ pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> core::fmt::Display for BytesM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        let s = hex::encode(v);
+        write!(f, "{s}")?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> core::fmt::Debug for BytesM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        let s = hex::encode(v);
+        write!(f, "BytesM({s})")?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> core::str::FromStr for BytesM<MAX> {
+    type Err = Error;
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        let b = hex::decode(s)
+        s.try_into()
+    }
+}
 
 impl<const MAX: u32> Deref for BytesM<MAX> {
     type Target = Vec<u8>;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1329,15 +1329,39 @@ impl<const MAX: u32> WriteXdr for BytesM<MAX> {
 // StringM ------------------------------------------------------------------------
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+impl<const MAX: u32> Display for StringM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let s = str::from_utf8(&self.0).map_err(|_| core::fmt::Error)?;
+        write!(f, "{s}")?;
+        Ok(())
+    }
+}
+
+impl<const MAX: u32> Debug for StringM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let s = str::from_utf8(&self.0).map_err(|_| core::fmt::Error)?;
+        write!(f, "StringM({s})")?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> FromStr for StringM<MAX> {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.try_into().map_err(|_| ())
+    }
+}
 
 impl<const MAX: u32> Deref for StringM<MAX> {
     type Target = Vec<u8>;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1326,7 +1326,7 @@ impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     }
 }
 
-impl<T: ReadXdr, const MAX: u32> ReadXdr for BytesM<MAX> {
+impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr(r: &mut impl Read) -> Result<Self> {
         let len = u32::read_xdr(r)?;
@@ -1344,7 +1344,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for BytesM<MAX> {
     }
 }
 
-impl<T: WriteXdr, const MAX: u32> WriteXdr for BytesM<MAX> {
+impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
         let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
@@ -1677,7 +1677,7 @@ impl<const MAX: u32> WriteXdr for StringM<MAX> {
     }
 }
 
-impl<T: ReadXdr, const MAX: u32> ReadXdr for StringM<MAX> {
+impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr(r: &mut impl Read) -> Result<Self> {
         let len = u32::read_xdr(r)?;
@@ -1695,7 +1695,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for StringM<MAX> {
     }
 }
 
-impl<T: WriteXdr, const MAX: u32> WriteXdr for StringM<MAX> {
+impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
         let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -51,6 +51,8 @@ pub enum Error {
     LengthMismatch,
     NonZeroPadding,
     Utf8Error(core::str::Utf8Error),
+    #[cfg(feature = "alloc")]
+    InvalidHex,
     #[cfg(feature = "std")]
     Io(io::Error),
 }
@@ -1053,8 +1055,7 @@ impl<const MAX: u32> core::fmt::Debug for BytesM<MAX> {
 impl<const MAX: u32> core::str::FromStr for BytesM<MAX> {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        let b = hex::decode(s)
-        s.try_into()
+        hex::decode(s).map_err(|_| Error::InvalidHex)?.try_into()
     }
 }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1012,7 +1012,7 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
 // BytesM ------------------------------------------------------------------------
 
 #[cfg(feature = "alloc")]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(
     feature = "serde",
     derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
@@ -1021,32 +1021,35 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
 pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
 #[cfg(not(feature = "alloc"))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
-#[cfg(feature = "alloc")]
 impl<const MAX: u32> core::fmt::Display for BytesM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        use hex::ToHex;
         #[cfg(feature = "alloc")]
         let v = &self.0;
         #[cfg(not(feature = "alloc"))]
         let v = self.0;
-        let s = hex::encode(v);
-        write!(f, "{s}")?;
+        for c in v.encode_to_hex() {
+            write!(f, "{c}")?;
+        }
         Ok(())
     }
 }
 
-#[cfg(feature = "alloc")]
 impl<const MAX: u32> core::fmt::Debug for BytesM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         #[cfg(feature = "alloc")]
         let v = &self.0;
         #[cfg(not(feature = "alloc"))]
         let v = self.0;
-        let s = hex::encode(v);
-        write!(f, "BytesM({s})")?;
+        write!(f, "BytesM(")?;
+        for c in v.encode_to_hex() {
+            write!(f, "{c}")?;
+        }
+        write!(f, ")")?;
         Ok(())
     }
 }

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1392,7 +1392,7 @@ impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
         let v = &self.0;
         #[cfg(not(feature = "alloc"))]
         let v = self.0;
-        let s = str::from_utf8_lossy(v);
+        let s = escape8259::escape(v);
         write!(f, "{s}")?;
         Ok(())
     }
@@ -1405,7 +1405,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
         let v = &self.0;
         #[cfg(not(feature = "alloc"))]
         let v = self.0;
-        let s = str::from_utf8_lossy(v);
+        let s = escape8259::escape(v);
         write!(f, "StringM({s})")?;
         Ok(())
     }
@@ -1415,7 +1415,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        s.try_into()
+        escape8259::unescape(s).try_into()
     }
 }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1392,7 +1392,7 @@ impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
         let v = &self.0;
         #[cfg(not(feature = "alloc"))]
         let v = self.0;
-        let s = escape8259::escape(v);
+        let s = str::from_utf8_lossy(v);
         write!(f, "{s}")?;
         Ok(())
     }
@@ -1405,7 +1405,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
         let v = &self.0;
         #[cfg(not(feature = "alloc"))]
         let v = self.0;
-        let s = escape8259::escape(v);
+        let s = str::from_utf8_lossy(v);
         write!(f, "StringM({s})")?;
         Ok(())
     }
@@ -1415,7 +1415,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        escape8259::unescape(s).try_into()
+        s.try_into()
     }
 }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1326,38 +1326,6 @@ impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     }
 }
 
-impl<const MAX: u32> ReadXdr for BytesM<MAX> {
-    #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
-
-        let mut vec = Vec::with_capacity(len as usize);
-        for _ in 0..len {
-            let t = T::read_xdr(r)?;
-            vec.push(t);
-        }
-
-        Ok(BytesM(vec))
-    }
-}
-
-impl<const MAX: u32> WriteXdr for BytesM<MAX> {
-    #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
-
-        for t in &self.0 {
-            t.write_xdr(w)?;
-        }
-
-        Ok(())
-    }
-}
-
 // StringM ------------------------------------------------------------------------
 
 #[cfg(feature = "alloc")]
@@ -1672,38 +1640,6 @@ impl<const MAX: u32> WriteXdr for StringM<MAX> {
         w.write_all(&self.0)?;
 
         w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
-
-        Ok(())
-    }
-}
-
-impl<const MAX: u32> ReadXdr for StringM<MAX> {
-    #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
-
-        let mut vec = Vec::with_capacity(len as usize);
-        for _ in 0..len {
-            let t = T::read_xdr(r)?;
-            vec.push(t);
-        }
-
-        Ok(StringM(vec))
-    }
-}
-
-impl<const MAX: u32> WriteXdr for StringM<MAX> {
-    #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
-
-        for t in &self.0 {
-            t.write_xdr(w)?;
-        }
 
         Ok(())
     }

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -61,6 +61,8 @@ pub enum Error {
     LengthMismatch,
     NonZeroPadding,
     Utf8Error(core::str::Utf8Error),
+    #[cfg(feature = "alloc")]
+    InvalidHex,
     #[cfg(feature = "std")]
     Io(io::Error),
 }
@@ -101,6 +103,8 @@ impl fmt::Display for Error {
             Error::LengthMismatch => write!(f, "xdr value length does not match"),
             Error::NonZeroPadding => write!(f, "xdr padding contains non-zero bytes"),
             Error::Utf8Error(e) => write!(f, "{}", e),
+            #[cfg(feature = "alloc")]
+            Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{}", e),
         }
@@ -629,6 +633,8 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     }
 }
 
+// VecM ------------------------------------------------------------------------
+
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -1010,6 +1016,743 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
         for t in &self.0 {
             t.write_xdr(w)?;
         }
+
+        Ok(())
+    }
+}
+
+// BytesM ------------------------------------------------------------------------
+
+#[cfg(feature = "alloc")]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
+)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+#[cfg(not(feature = "alloc"))]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+impl<const MAX: u32> core::fmt::Display for BytesM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        for b in v {
+            write!(f, "{b:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl<const MAX: u32> core::fmt::Debug for BytesM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        write!(f, "BytesM(")?;
+        for b in v {
+            write!(f, "{b:02x}")?;
+        }
+        write!(f, ")")?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> core::str::FromStr for BytesM<MAX> {
+    type Err = Error;
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        hex::decode(s).map_err(|_| Error::InvalidHex)?.try_into()
+    }
+}
+
+impl<const MAX: u32> Deref for BytesM<MAX> {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const MAX: u32> Default for BytesM<MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
+impl<const MAX: u32> BytesM<MAX> {
+    pub const MAX_LEN: usize = { MAX as usize };
+
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub fn max_len(&self) -> usize {
+        Self::MAX_LEN
+    }
+
+    #[must_use]
+    pub fn as_vec(&self) -> &Vec<u8> {
+        self.as_ref()
+    }
+}
+
+impl<const MAX: u32> BytesM<MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.into()
+    }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<u8> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> BytesM<MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn to_string_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn into_string_lossy(self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+}
+
+impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: Vec<u8>) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> From<BytesM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: BytesM<MAX>) -> Self {
+        v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> From<&BytesM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: &BytesM<MAX>) -> Self {
+        v.0.clone()
+    }
+}
+
+impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
+    #[must_use]
+    fn as_ref(&self) -> &Vec<u8> {
+        &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<u8>) -> Result<Self> {
+        v.as_slice().try_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+    #[cfg(not(feature = "alloc"))]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
+    type Error = BytesM<MAX>;
+
+    fn try_from(v: BytesM<MAX>) -> core::result::Result<Self, Self::Error> {
+        let s: [u8; N] = v.0.try_into().map_err(BytesM::<MAX>)?;
+        Ok(s)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?.to_owned())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.as_bytes()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
+    type Error = Error;
+
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?)
+    }
+}
+
+impl<const MAX: u32> ReadXdr for BytesM<MAX> {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        let len: u32 = u32::read_xdr(r)?;
+        if len > MAX {
+            return Err(Error::LengthExceedsMax);
+        }
+
+        let mut vec = vec![0u8; len as usize];
+        r.read_exact(&mut vec)?;
+
+        let pad = &mut [0u8; 3][..pad_len(len as usize)];
+        r.read_exact(pad)?;
+        if pad.iter().any(|b| *b != 0) {
+            return Err(Error::NonZeroPadding);
+        }
+
+        Ok(BytesM(vec))
+    }
+}
+
+impl<const MAX: u32> WriteXdr for BytesM<MAX> {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        len.write_xdr(w)?;
+
+        w.write_all(&self.0)?;
+
+        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+
+        Ok(())
+    }
+}
+
+// StringM ------------------------------------------------------------------------
+
+#[cfg(feature = "alloc")]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
+)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+#[cfg(not(feature = "alloc"))]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
+/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
+fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
+    loop {
+        match core::str::from_utf8(input) {
+            Ok(valid) => {
+                write!(f, "{}", valid)?;
+                break;
+            }
+            Err(error) => {
+                let (valid, after_valid) = input.split_at(error.valid_up_to());
+                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
+                write!(f, "\u{FFFD}")?;
+
+                if let Some(invalid_sequence_length) = error.error_len() {
+                    input = &after_valid[invalid_sequence_length..];
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        write_utf8_lossy(f, v)?;
+        Ok(())
+    }
+}
+
+impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        write!(f, "StringM(")?;
+        write_utf8_lossy(f, v)?;
+        write!(f, ")")?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
+    type Err = Error;
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        s.try_into()
+    }
+}
+
+impl<const MAX: u32> Deref for StringM<MAX> {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const MAX: u32> Default for StringM<MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
+impl<const MAX: u32> StringM<MAX> {
+    pub const MAX_LEN: usize = { MAX as usize };
+
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub fn max_len(&self) -> usize {
+        Self::MAX_LEN
+    }
+
+    #[must_use]
+    pub fn as_vec(&self) -> &Vec<u8> {
+        self.as_ref()
+    }
+}
+
+impl<const MAX: u32> StringM<MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.into()
+    }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<u8> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> StringM<MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn to_string_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn into_string_lossy(self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+}
+
+impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: Vec<u8>) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> From<StringM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: StringM<MAX>) -> Self {
+        v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> From<&StringM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: &StringM<MAX>) -> Self {
+        v.0.clone()
+    }
+}
+
+impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
+    #[must_use]
+    fn as_ref(&self) -> &Vec<u8> {
+        &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<u8>) -> Result<Self> {
+        v.as_slice().try_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+    #[cfg(not(feature = "alloc"))]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
+    type Error = StringM<MAX>;
+
+    fn try_from(v: StringM<MAX>) -> core::result::Result<Self, Self::Error> {
+        let s: [u8; N] = v.0.try_into().map_err(StringM::<MAX>)?;
+        Ok(s)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: StringM<MAX>) -> Result<Self> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?.to_owned())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.as_bytes()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
+    type Error = Error;
+
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?)
+    }
+}
+
+impl<const MAX: u32> ReadXdr for StringM<MAX> {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        let len: u32 = u32::read_xdr(r)?;
+        if len > MAX {
+            return Err(Error::LengthExceedsMax);
+        }
+
+        let mut vec = vec![0u8; len as usize];
+        r.read_exact(&mut vec)?;
+
+        let pad = &mut [0u8; 3][..pad_len(len as usize)];
+        r.read_exact(pad)?;
+        if pad.iter().any(|b| *b != 0) {
+            return Err(Error::NonZeroPadding);
+        }
+
+        Ok(StringM(vec))
+    }
+}
+
+impl<const MAX: u32> WriteXdr for StringM<MAX> {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        len.write_xdr(w)?;
+
+        w.write_all(&self.0)?;
+
+        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
         Ok(())
     }

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -61,6 +61,8 @@ pub enum Error {
     LengthMismatch,
     NonZeroPadding,
     Utf8Error(core::str::Utf8Error),
+    #[cfg(feature = "alloc")]
+    InvalidHex,
     #[cfg(feature = "std")]
     Io(io::Error),
 }
@@ -101,6 +103,8 @@ impl fmt::Display for Error {
             Error::LengthMismatch => write!(f, "xdr value length does not match"),
             Error::NonZeroPadding => write!(f, "xdr padding contains non-zero bytes"),
             Error::Utf8Error(e) => write!(f, "{}", e),
+            #[cfg(feature = "alloc")]
+            Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{}", e),
         }
@@ -629,6 +633,8 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     }
 }
 
+// VecM ------------------------------------------------------------------------
+
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -1010,6 +1016,743 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
         for t in &self.0 {
             t.write_xdr(w)?;
         }
+
+        Ok(())
+    }
+}
+
+// BytesM ------------------------------------------------------------------------
+
+#[cfg(feature = "alloc")]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
+)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+#[cfg(not(feature = "alloc"))]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+impl<const MAX: u32> core::fmt::Display for BytesM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        for b in v {
+            write!(f, "{b:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl<const MAX: u32> core::fmt::Debug for BytesM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        write!(f, "BytesM(")?;
+        for b in v {
+            write!(f, "{b:02x}")?;
+        }
+        write!(f, ")")?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> core::str::FromStr for BytesM<MAX> {
+    type Err = Error;
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        hex::decode(s).map_err(|_| Error::InvalidHex)?.try_into()
+    }
+}
+
+impl<const MAX: u32> Deref for BytesM<MAX> {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const MAX: u32> Default for BytesM<MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
+impl<const MAX: u32> BytesM<MAX> {
+    pub const MAX_LEN: usize = { MAX as usize };
+
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub fn max_len(&self) -> usize {
+        Self::MAX_LEN
+    }
+
+    #[must_use]
+    pub fn as_vec(&self) -> &Vec<u8> {
+        self.as_ref()
+    }
+}
+
+impl<const MAX: u32> BytesM<MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.into()
+    }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<u8> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> BytesM<MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn to_string_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn into_string_lossy(self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+}
+
+impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: Vec<u8>) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> From<BytesM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: BytesM<MAX>) -> Self {
+        v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> From<&BytesM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: &BytesM<MAX>) -> Self {
+        v.0.clone()
+    }
+}
+
+impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
+    #[must_use]
+    fn as_ref(&self) -> &Vec<u8> {
+        &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<u8>) -> Result<Self> {
+        v.as_slice().try_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+    #[cfg(not(feature = "alloc"))]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
+    type Error = BytesM<MAX>;
+
+    fn try_from(v: BytesM<MAX>) -> core::result::Result<Self, Self::Error> {
+        let s: [u8; N] = v.0.try_into().map_err(BytesM::<MAX>)?;
+        Ok(s)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?.to_owned())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.as_bytes()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
+    type Error = Error;
+
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?)
+    }
+}
+
+impl<const MAX: u32> ReadXdr for BytesM<MAX> {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        let len: u32 = u32::read_xdr(r)?;
+        if len > MAX {
+            return Err(Error::LengthExceedsMax);
+        }
+
+        let mut vec = vec![0u8; len as usize];
+        r.read_exact(&mut vec)?;
+
+        let pad = &mut [0u8; 3][..pad_len(len as usize)];
+        r.read_exact(pad)?;
+        if pad.iter().any(|b| *b != 0) {
+            return Err(Error::NonZeroPadding);
+        }
+
+        Ok(BytesM(vec))
+    }
+}
+
+impl<const MAX: u32> WriteXdr for BytesM<MAX> {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        len.write_xdr(w)?;
+
+        w.write_all(&self.0)?;
+
+        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+
+        Ok(())
+    }
+}
+
+// StringM ------------------------------------------------------------------------
+
+#[cfg(feature = "alloc")]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
+)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+#[cfg(not(feature = "alloc"))]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
+/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
+fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
+    loop {
+        match core::str::from_utf8(input) {
+            Ok(valid) => {
+                write!(f, "{}", valid)?;
+                break;
+            }
+            Err(error) => {
+                let (valid, after_valid) = input.split_at(error.valid_up_to());
+                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
+                write!(f, "\u{FFFD}")?;
+
+                if let Some(invalid_sequence_length) = error.error_len() {
+                    input = &after_valid[invalid_sequence_length..];
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        write_utf8_lossy(f, v)?;
+        Ok(())
+    }
+}
+
+impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        write!(f, "StringM(")?;
+        write_utf8_lossy(f, v)?;
+        write!(f, ")")?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
+    type Err = Error;
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        s.try_into()
+    }
+}
+
+impl<const MAX: u32> Deref for StringM<MAX> {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const MAX: u32> Default for StringM<MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
+impl<const MAX: u32> StringM<MAX> {
+    pub const MAX_LEN: usize = { MAX as usize };
+
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub fn max_len(&self) -> usize {
+        Self::MAX_LEN
+    }
+
+    #[must_use]
+    pub fn as_vec(&self) -> &Vec<u8> {
+        self.as_ref()
+    }
+}
+
+impl<const MAX: u32> StringM<MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.into()
+    }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<u8> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> StringM<MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn to_string_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn into_string_lossy(self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+}
+
+impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: Vec<u8>) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> From<StringM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: StringM<MAX>) -> Self {
+        v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> From<&StringM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: &StringM<MAX>) -> Self {
+        v.0.clone()
+    }
+}
+
+impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
+    #[must_use]
+    fn as_ref(&self) -> &Vec<u8> {
+        &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<u8>) -> Result<Self> {
+        v.as_slice().try_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+    #[cfg(not(feature = "alloc"))]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
+    type Error = StringM<MAX>;
+
+    fn try_from(v: StringM<MAX>) -> core::result::Result<Self, Self::Error> {
+        let s: [u8; N] = v.0.try_into().map_err(StringM::<MAX>)?;
+        Ok(s)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: StringM<MAX>) -> Result<Self> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?.to_owned())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.as_bytes()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
+    type Error = Error;
+
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?)
+    }
+}
+
+impl<const MAX: u32> ReadXdr for StringM<MAX> {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        let len: u32 = u32::read_xdr(r)?;
+        if len > MAX {
+            return Err(Error::LengthExceedsMax);
+        }
+
+        let mut vec = vec![0u8; len as usize];
+        r.read_exact(&mut vec)?;
+
+        let pad = &mut [0u8; 3][..pad_len(len as usize)];
+        r.read_exact(pad)?;
+        if pad.iter().any(|b| *b != 0) {
+            return Err(Error::NonZeroPadding);
+        }
+
+        Ok(StringM(vec))
+    }
+}
+
+impl<const MAX: u32> WriteXdr for StringM<MAX> {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        len.write_xdr(w)?;
+
+        w.write_all(&self.0)?;
+
+        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
         Ok(())
     }

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -61,6 +61,8 @@ pub enum Error {
     LengthMismatch,
     NonZeroPadding,
     Utf8Error(core::str::Utf8Error),
+    #[cfg(feature = "alloc")]
+    InvalidHex,
     #[cfg(feature = "std")]
     Io(io::Error),
 }
@@ -101,6 +103,8 @@ impl fmt::Display for Error {
             Error::LengthMismatch => write!(f, "xdr value length does not match"),
             Error::NonZeroPadding => write!(f, "xdr padding contains non-zero bytes"),
             Error::Utf8Error(e) => write!(f, "{}", e),
+            #[cfg(feature = "alloc")]
+            Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{}", e),
         }
@@ -629,6 +633,8 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     }
 }
 
+// VecM ------------------------------------------------------------------------
+
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -1010,6 +1016,743 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
         for t in &self.0 {
             t.write_xdr(w)?;
         }
+
+        Ok(())
+    }
+}
+
+// BytesM ------------------------------------------------------------------------
+
+#[cfg(feature = "alloc")]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
+)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+#[cfg(not(feature = "alloc"))]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+impl<const MAX: u32> core::fmt::Display for BytesM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        for b in v {
+            write!(f, "{b:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl<const MAX: u32> core::fmt::Debug for BytesM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        write!(f, "BytesM(")?;
+        for b in v {
+            write!(f, "{b:02x}")?;
+        }
+        write!(f, ")")?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> core::str::FromStr for BytesM<MAX> {
+    type Err = Error;
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        hex::decode(s).map_err(|_| Error::InvalidHex)?.try_into()
+    }
+}
+
+impl<const MAX: u32> Deref for BytesM<MAX> {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const MAX: u32> Default for BytesM<MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
+impl<const MAX: u32> BytesM<MAX> {
+    pub const MAX_LEN: usize = { MAX as usize };
+
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub fn max_len(&self) -> usize {
+        Self::MAX_LEN
+    }
+
+    #[must_use]
+    pub fn as_vec(&self) -> &Vec<u8> {
+        self.as_ref()
+    }
+}
+
+impl<const MAX: u32> BytesM<MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.into()
+    }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<u8> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> BytesM<MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn to_string_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn into_string_lossy(self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+}
+
+impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: Vec<u8>) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> From<BytesM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: BytesM<MAX>) -> Self {
+        v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> From<&BytesM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: &BytesM<MAX>) -> Self {
+        v.0.clone()
+    }
+}
+
+impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
+    #[must_use]
+    fn as_ref(&self) -> &Vec<u8> {
+        &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<u8>) -> Result<Self> {
+        v.as_slice().try_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+    #[cfg(not(feature = "alloc"))]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
+    type Error = BytesM<MAX>;
+
+    fn try_from(v: BytesM<MAX>) -> core::result::Result<Self, Self::Error> {
+        let s: [u8; N] = v.0.try_into().map_err(BytesM::<MAX>)?;
+        Ok(s)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?.to_owned())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.as_bytes()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
+    type Error = Error;
+
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?)
+    }
+}
+
+impl<const MAX: u32> ReadXdr for BytesM<MAX> {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        let len: u32 = u32::read_xdr(r)?;
+        if len > MAX {
+            return Err(Error::LengthExceedsMax);
+        }
+
+        let mut vec = vec![0u8; len as usize];
+        r.read_exact(&mut vec)?;
+
+        let pad = &mut [0u8; 3][..pad_len(len as usize)];
+        r.read_exact(pad)?;
+        if pad.iter().any(|b| *b != 0) {
+            return Err(Error::NonZeroPadding);
+        }
+
+        Ok(BytesM(vec))
+    }
+}
+
+impl<const MAX: u32> WriteXdr for BytesM<MAX> {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        len.write_xdr(w)?;
+
+        w.write_all(&self.0)?;
+
+        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+
+        Ok(())
+    }
+}
+
+// StringM ------------------------------------------------------------------------
+
+#[cfg(feature = "alloc")]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
+)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+#[cfg(not(feature = "alloc"))]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
+/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
+fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
+    loop {
+        match core::str::from_utf8(input) {
+            Ok(valid) => {
+                write!(f, "{}", valid)?;
+                break;
+            }
+            Err(error) => {
+                let (valid, after_valid) = input.split_at(error.valid_up_to());
+                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
+                write!(f, "\u{FFFD}")?;
+
+                if let Some(invalid_sequence_length) = error.error_len() {
+                    input = &after_valid[invalid_sequence_length..];
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        write_utf8_lossy(f, v)?;
+        Ok(())
+    }
+}
+
+impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        write!(f, "StringM(")?;
+        write_utf8_lossy(f, v)?;
+        write!(f, ")")?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
+    type Err = Error;
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        s.try_into()
+    }
+}
+
+impl<const MAX: u32> Deref for StringM<MAX> {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const MAX: u32> Default for StringM<MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
+impl<const MAX: u32> StringM<MAX> {
+    pub const MAX_LEN: usize = { MAX as usize };
+
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub fn max_len(&self) -> usize {
+        Self::MAX_LEN
+    }
+
+    #[must_use]
+    pub fn as_vec(&self) -> &Vec<u8> {
+        self.as_ref()
+    }
+}
+
+impl<const MAX: u32> StringM<MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.into()
+    }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<u8> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> StringM<MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn to_string_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn into_string_lossy(self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+}
+
+impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: Vec<u8>) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> From<StringM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: StringM<MAX>) -> Self {
+        v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> From<&StringM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: &StringM<MAX>) -> Self {
+        v.0.clone()
+    }
+}
+
+impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
+    #[must_use]
+    fn as_ref(&self) -> &Vec<u8> {
+        &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<u8>) -> Result<Self> {
+        v.as_slice().try_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+    #[cfg(not(feature = "alloc"))]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
+    type Error = StringM<MAX>;
+
+    fn try_from(v: StringM<MAX>) -> core::result::Result<Self, Self::Error> {
+        let s: [u8; N] = v.0.try_into().map_err(StringM::<MAX>)?;
+        Ok(s)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: StringM<MAX>) -> Result<Self> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?.to_owned())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.as_bytes()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
+    type Error = Error;
+
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?)
+    }
+}
+
+impl<const MAX: u32> ReadXdr for StringM<MAX> {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        let len: u32 = u32::read_xdr(r)?;
+        if len > MAX {
+            return Err(Error::LengthExceedsMax);
+        }
+
+        let mut vec = vec![0u8; len as usize];
+        r.read_exact(&mut vec)?;
+
+        let pad = &mut [0u8; 3][..pad_len(len as usize)];
+        r.read_exact(pad)?;
+        if pad.iter().any(|b| *b != 0) {
+            return Err(Error::NonZeroPadding);
+        }
+
+        Ok(StringM(vec))
+    }
+}
+
+impl<const MAX: u32> WriteXdr for StringM<MAX> {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        len.write_xdr(w)?;
+
+        w.write_all(&self.0)?;
+
+        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
         Ok(())
     }

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -61,6 +61,8 @@ pub enum Error {
     LengthMismatch,
     NonZeroPadding,
     Utf8Error(core::str::Utf8Error),
+    #[cfg(feature = "alloc")]
+    InvalidHex,
     #[cfg(feature = "std")]
     Io(io::Error),
 }
@@ -101,6 +103,8 @@ impl fmt::Display for Error {
             Error::LengthMismatch => write!(f, "xdr value length does not match"),
             Error::NonZeroPadding => write!(f, "xdr padding contains non-zero bytes"),
             Error::Utf8Error(e) => write!(f, "{}", e),
+            #[cfg(feature = "alloc")]
+            Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{}", e),
         }
@@ -629,6 +633,8 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     }
 }
 
+// VecM ------------------------------------------------------------------------
+
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -1010,6 +1016,743 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
         for t in &self.0 {
             t.write_xdr(w)?;
         }
+
+        Ok(())
+    }
+}
+
+// BytesM ------------------------------------------------------------------------
+
+#[cfg(feature = "alloc")]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
+)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+#[cfg(not(feature = "alloc"))]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+impl<const MAX: u32> core::fmt::Display for BytesM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        for b in v {
+            write!(f, "{b:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl<const MAX: u32> core::fmt::Debug for BytesM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        write!(f, "BytesM(")?;
+        for b in v {
+            write!(f, "{b:02x}")?;
+        }
+        write!(f, ")")?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> core::str::FromStr for BytesM<MAX> {
+    type Err = Error;
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        hex::decode(s).map_err(|_| Error::InvalidHex)?.try_into()
+    }
+}
+
+impl<const MAX: u32> Deref for BytesM<MAX> {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const MAX: u32> Default for BytesM<MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
+impl<const MAX: u32> BytesM<MAX> {
+    pub const MAX_LEN: usize = { MAX as usize };
+
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub fn max_len(&self) -> usize {
+        Self::MAX_LEN
+    }
+
+    #[must_use]
+    pub fn as_vec(&self) -> &Vec<u8> {
+        self.as_ref()
+    }
+}
+
+impl<const MAX: u32> BytesM<MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.into()
+    }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<u8> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> BytesM<MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn to_string_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn into_string_lossy(self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+}
+
+impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: Vec<u8>) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> From<BytesM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: BytesM<MAX>) -> Self {
+        v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> From<&BytesM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: &BytesM<MAX>) -> Self {
+        v.0.clone()
+    }
+}
+
+impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
+    #[must_use]
+    fn as_ref(&self) -> &Vec<u8> {
+        &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<u8>) -> Result<Self> {
+        v.as_slice().try_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+    #[cfg(not(feature = "alloc"))]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
+    type Error = BytesM<MAX>;
+
+    fn try_from(v: BytesM<MAX>) -> core::result::Result<Self, Self::Error> {
+        let s: [u8; N] = v.0.try_into().map_err(BytesM::<MAX>)?;
+        Ok(s)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?.to_owned())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.as_bytes()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
+    type Error = Error;
+
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?)
+    }
+}
+
+impl<const MAX: u32> ReadXdr for BytesM<MAX> {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        let len: u32 = u32::read_xdr(r)?;
+        if len > MAX {
+            return Err(Error::LengthExceedsMax);
+        }
+
+        let mut vec = vec![0u8; len as usize];
+        r.read_exact(&mut vec)?;
+
+        let pad = &mut [0u8; 3][..pad_len(len as usize)];
+        r.read_exact(pad)?;
+        if pad.iter().any(|b| *b != 0) {
+            return Err(Error::NonZeroPadding);
+        }
+
+        Ok(BytesM(vec))
+    }
+}
+
+impl<const MAX: u32> WriteXdr for BytesM<MAX> {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        len.write_xdr(w)?;
+
+        w.write_all(&self.0)?;
+
+        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+
+        Ok(())
+    }
+}
+
+// StringM ------------------------------------------------------------------------
+
+#[cfg(feature = "alloc")]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
+)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+#[cfg(not(feature = "alloc"))]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
+/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
+fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
+    loop {
+        match core::str::from_utf8(input) {
+            Ok(valid) => {
+                write!(f, "{}", valid)?;
+                break;
+            }
+            Err(error) => {
+                let (valid, after_valid) = input.split_at(error.valid_up_to());
+                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
+                write!(f, "\u{FFFD}")?;
+
+                if let Some(invalid_sequence_length) = error.error_len() {
+                    input = &after_valid[invalid_sequence_length..];
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        write_utf8_lossy(f, v)?;
+        Ok(())
+    }
+}
+
+impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        write!(f, "StringM(")?;
+        write_utf8_lossy(f, v)?;
+        write!(f, ")")?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
+    type Err = Error;
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        s.try_into()
+    }
+}
+
+impl<const MAX: u32> Deref for StringM<MAX> {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const MAX: u32> Default for StringM<MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
+impl<const MAX: u32> StringM<MAX> {
+    pub const MAX_LEN: usize = { MAX as usize };
+
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub fn max_len(&self) -> usize {
+        Self::MAX_LEN
+    }
+
+    #[must_use]
+    pub fn as_vec(&self) -> &Vec<u8> {
+        self.as_ref()
+    }
+}
+
+impl<const MAX: u32> StringM<MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.into()
+    }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<u8> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> StringM<MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn to_string_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn into_string_lossy(self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+}
+
+impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: Vec<u8>) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> From<StringM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: StringM<MAX>) -> Self {
+        v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> From<&StringM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: &StringM<MAX>) -> Self {
+        v.0.clone()
+    }
+}
+
+impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
+    #[must_use]
+    fn as_ref(&self) -> &Vec<u8> {
+        &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<u8>) -> Result<Self> {
+        v.as_slice().try_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+    #[cfg(not(feature = "alloc"))]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
+    type Error = StringM<MAX>;
+
+    fn try_from(v: StringM<MAX>) -> core::result::Result<Self, Self::Error> {
+        let s: [u8; N] = v.0.try_into().map_err(StringM::<MAX>)?;
+        Ok(s)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: StringM<MAX>) -> Result<Self> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?.to_owned())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.as_bytes()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
+    type Error = Error;
+
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?)
+    }
+}
+
+impl<const MAX: u32> ReadXdr for StringM<MAX> {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        let len: u32 = u32::read_xdr(r)?;
+        if len > MAX {
+            return Err(Error::LengthExceedsMax);
+        }
+
+        let mut vec = vec![0u8; len as usize];
+        r.read_exact(&mut vec)?;
+
+        let pad = &mut [0u8; 3][..pad_len(len as usize)];
+        r.read_exact(pad)?;
+        if pad.iter().any(|b| *b != 0) {
+            return Err(Error::NonZeroPadding);
+        }
+
+        Ok(StringM(vec))
+    }
+}
+
+impl<const MAX: u32> WriteXdr for StringM<MAX> {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        len.write_xdr(w)?;
+
+        w.write_all(&self.0)?;
+
+        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
         Ok(())
     }

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -61,6 +61,8 @@ pub enum Error {
     LengthMismatch,
     NonZeroPadding,
     Utf8Error(core::str::Utf8Error),
+    #[cfg(feature = "alloc")]
+    InvalidHex,
     #[cfg(feature = "std")]
     Io(io::Error),
 }
@@ -101,6 +103,8 @@ impl fmt::Display for Error {
             Error::LengthMismatch => write!(f, "xdr value length does not match"),
             Error::NonZeroPadding => write!(f, "xdr padding contains non-zero bytes"),
             Error::Utf8Error(e) => write!(f, "{}", e),
+            #[cfg(feature = "alloc")]
+            Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{}", e),
         }
@@ -629,6 +633,8 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     }
 }
 
+// VecM ------------------------------------------------------------------------
+
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -1010,6 +1016,743 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
         for t in &self.0 {
             t.write_xdr(w)?;
         }
+
+        Ok(())
+    }
+}
+
+// BytesM ------------------------------------------------------------------------
+
+#[cfg(feature = "alloc")]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
+)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+#[cfg(not(feature = "alloc"))]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+impl<const MAX: u32> core::fmt::Display for BytesM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        for b in v {
+            write!(f, "{b:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl<const MAX: u32> core::fmt::Debug for BytesM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        write!(f, "BytesM(")?;
+        for b in v {
+            write!(f, "{b:02x}")?;
+        }
+        write!(f, ")")?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> core::str::FromStr for BytesM<MAX> {
+    type Err = Error;
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        hex::decode(s).map_err(|_| Error::InvalidHex)?.try_into()
+    }
+}
+
+impl<const MAX: u32> Deref for BytesM<MAX> {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const MAX: u32> Default for BytesM<MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
+impl<const MAX: u32> BytesM<MAX> {
+    pub const MAX_LEN: usize = { MAX as usize };
+
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub fn max_len(&self) -> usize {
+        Self::MAX_LEN
+    }
+
+    #[must_use]
+    pub fn as_vec(&self) -> &Vec<u8> {
+        self.as_ref()
+    }
+}
+
+impl<const MAX: u32> BytesM<MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.into()
+    }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<u8> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> BytesM<MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn to_string_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn into_string_lossy(self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+}
+
+impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: Vec<u8>) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> From<BytesM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: BytesM<MAX>) -> Self {
+        v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> From<&BytesM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: &BytesM<MAX>) -> Self {
+        v.0.clone()
+    }
+}
+
+impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
+    #[must_use]
+    fn as_ref(&self) -> &Vec<u8> {
+        &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<u8>) -> Result<Self> {
+        v.as_slice().try_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+    #[cfg(not(feature = "alloc"))]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
+    type Error = BytesM<MAX>;
+
+    fn try_from(v: BytesM<MAX>) -> core::result::Result<Self, Self::Error> {
+        let s: [u8; N] = v.0.try_into().map_err(BytesM::<MAX>)?;
+        Ok(s)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?.to_owned())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.as_bytes()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
+    type Error = Error;
+
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?)
+    }
+}
+
+impl<const MAX: u32> ReadXdr for BytesM<MAX> {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        let len: u32 = u32::read_xdr(r)?;
+        if len > MAX {
+            return Err(Error::LengthExceedsMax);
+        }
+
+        let mut vec = vec![0u8; len as usize];
+        r.read_exact(&mut vec)?;
+
+        let pad = &mut [0u8; 3][..pad_len(len as usize)];
+        r.read_exact(pad)?;
+        if pad.iter().any(|b| *b != 0) {
+            return Err(Error::NonZeroPadding);
+        }
+
+        Ok(BytesM(vec))
+    }
+}
+
+impl<const MAX: u32> WriteXdr for BytesM<MAX> {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        len.write_xdr(w)?;
+
+        w.write_all(&self.0)?;
+
+        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+
+        Ok(())
+    }
+}
+
+// StringM ------------------------------------------------------------------------
+
+#[cfg(feature = "alloc")]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
+)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+#[cfg(not(feature = "alloc"))]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
+/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
+fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
+    loop {
+        match core::str::from_utf8(input) {
+            Ok(valid) => {
+                write!(f, "{}", valid)?;
+                break;
+            }
+            Err(error) => {
+                let (valid, after_valid) = input.split_at(error.valid_up_to());
+                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
+                write!(f, "\u{FFFD}")?;
+
+                if let Some(invalid_sequence_length) = error.error_len() {
+                    input = &after_valid[invalid_sequence_length..];
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        write_utf8_lossy(f, v)?;
+        Ok(())
+    }
+}
+
+impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        write!(f, "StringM(")?;
+        write_utf8_lossy(f, v)?;
+        write!(f, ")")?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
+    type Err = Error;
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        s.try_into()
+    }
+}
+
+impl<const MAX: u32> Deref for StringM<MAX> {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const MAX: u32> Default for StringM<MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
+impl<const MAX: u32> StringM<MAX> {
+    pub const MAX_LEN: usize = { MAX as usize };
+
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub fn max_len(&self) -> usize {
+        Self::MAX_LEN
+    }
+
+    #[must_use]
+    pub fn as_vec(&self) -> &Vec<u8> {
+        self.as_ref()
+    }
+}
+
+impl<const MAX: u32> StringM<MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.into()
+    }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<u8> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> StringM<MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn to_string_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn into_string_lossy(self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+}
+
+impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: Vec<u8>) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> From<StringM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: StringM<MAX>) -> Self {
+        v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> From<&StringM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: &StringM<MAX>) -> Self {
+        v.0.clone()
+    }
+}
+
+impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
+    #[must_use]
+    fn as_ref(&self) -> &Vec<u8> {
+        &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<u8>) -> Result<Self> {
+        v.as_slice().try_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+    #[cfg(not(feature = "alloc"))]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
+    type Error = StringM<MAX>;
+
+    fn try_from(v: StringM<MAX>) -> core::result::Result<Self, Self::Error> {
+        let s: [u8; N] = v.0.try_into().map_err(StringM::<MAX>)?;
+        Ok(s)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: StringM<MAX>) -> Result<Self> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?.to_owned())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.as_bytes()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
+    type Error = Error;
+
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?)
+    }
+}
+
+impl<const MAX: u32> ReadXdr for StringM<MAX> {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        let len: u32 = u32::read_xdr(r)?;
+        if len > MAX {
+            return Err(Error::LengthExceedsMax);
+        }
+
+        let mut vec = vec![0u8; len as usize];
+        r.read_exact(&mut vec)?;
+
+        let pad = &mut [0u8; 3][..pad_len(len as usize)];
+        r.read_exact(pad)?;
+        if pad.iter().any(|b| *b != 0) {
+            return Err(Error::NonZeroPadding);
+        }
+
+        Ok(StringM(vec))
+    }
+}
+
+impl<const MAX: u32> WriteXdr for StringM<MAX> {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        len.write_xdr(w)?;
+
+        w.write_all(&self.0)?;
+
+        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
         Ok(())
     }

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -61,6 +61,8 @@ pub enum Error {
     LengthMismatch,
     NonZeroPadding,
     Utf8Error(core::str::Utf8Error),
+    #[cfg(feature = "alloc")]
+    InvalidHex,
     #[cfg(feature = "std")]
     Io(io::Error),
 }
@@ -101,6 +103,8 @@ impl fmt::Display for Error {
             Error::LengthMismatch => write!(f, "xdr value length does not match"),
             Error::NonZeroPadding => write!(f, "xdr padding contains non-zero bytes"),
             Error::Utf8Error(e) => write!(f, "{}", e),
+            #[cfg(feature = "alloc")]
+            Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{}", e),
         }
@@ -629,6 +633,8 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     }
 }
 
+// VecM ------------------------------------------------------------------------
+
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -1015,6 +1021,743 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     }
 }
 
+// BytesM ------------------------------------------------------------------------
+
+#[cfg(feature = "alloc")]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
+)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+#[cfg(not(feature = "alloc"))]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct BytesM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+impl<const MAX: u32> core::fmt::Display for BytesM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        for b in v {
+            write!(f, "{b:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl<const MAX: u32> core::fmt::Debug for BytesM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        write!(f, "BytesM(")?;
+        for b in v {
+            write!(f, "{b:02x}")?;
+        }
+        write!(f, ")")?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> core::str::FromStr for BytesM<MAX> {
+    type Err = Error;
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        hex::decode(s).map_err(|_| Error::InvalidHex)?.try_into()
+    }
+}
+
+impl<const MAX: u32> Deref for BytesM<MAX> {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const MAX: u32> Default for BytesM<MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
+impl<const MAX: u32> BytesM<MAX> {
+    pub const MAX_LEN: usize = { MAX as usize };
+
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub fn max_len(&self) -> usize {
+        Self::MAX_LEN
+    }
+
+    #[must_use]
+    pub fn as_vec(&self) -> &Vec<u8> {
+        self.as_ref()
+    }
+}
+
+impl<const MAX: u32> BytesM<MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.into()
+    }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<u8> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> BytesM<MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn to_string_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn into_string_lossy(self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+}
+
+impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: Vec<u8>) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> From<BytesM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: BytesM<MAX>) -> Self {
+        v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> From<&BytesM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: &BytesM<MAX>) -> Self {
+        v.0.clone()
+    }
+}
+
+impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
+    #[must_use]
+    fn as_ref(&self) -> &Vec<u8> {
+        &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<u8>) -> Result<Self> {
+        v.as_slice().try_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+    #[cfg(not(feature = "alloc"))]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
+    type Error = BytesM<MAX>;
+
+    fn try_from(v: BytesM<MAX>) -> core::result::Result<Self, Self::Error> {
+        let s: [u8; N] = v.0.try_into().map_err(BytesM::<MAX>)?;
+        Ok(s)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?.to_owned())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(BytesM(v.as_bytes()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
+    type Error = Error;
+
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?)
+    }
+}
+
+impl<const MAX: u32> ReadXdr for BytesM<MAX> {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        let len: u32 = u32::read_xdr(r)?;
+        if len > MAX {
+            return Err(Error::LengthExceedsMax);
+        }
+
+        let mut vec = vec![0u8; len as usize];
+        r.read_exact(&mut vec)?;
+
+        let pad = &mut [0u8; 3][..pad_len(len as usize)];
+        r.read_exact(pad)?;
+        if pad.iter().any(|b| *b != 0) {
+            return Err(Error::NonZeroPadding);
+        }
+
+        Ok(BytesM(vec))
+    }
+}
+
+impl<const MAX: u32> WriteXdr for BytesM<MAX> {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        len.write_xdr(w)?;
+
+        w.write_all(&self.0)?;
+
+        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+
+        Ok(())
+    }
+}
+
+// StringM ------------------------------------------------------------------------
+
+#[cfg(feature = "alloc")]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr)
+)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+#[cfg(not(feature = "alloc"))]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
+
+/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
+/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
+fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
+    loop {
+        match core::str::from_utf8(input) {
+            Ok(valid) => {
+                write!(f, "{}", valid)?;
+                break;
+            }
+            Err(error) => {
+                let (valid, after_valid) = input.split_at(error.valid_up_to());
+                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
+                write!(f, "\u{FFFD}")?;
+
+                if let Some(invalid_sequence_length) = error.error_len() {
+                    input = &after_valid[invalid_sequence_length..];
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        write_utf8_lossy(f, v)?;
+        Ok(())
+    }
+}
+
+impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(feature = "alloc")]
+        let v = &self.0;
+        #[cfg(not(feature = "alloc"))]
+        let v = self.0;
+        write!(f, "StringM(")?;
+        write_utf8_lossy(f, v)?;
+        write!(f, ")")?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
+    type Err = Error;
+    fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
+        s.try_into()
+    }
+}
+
+impl<const MAX: u32> Deref for StringM<MAX> {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const MAX: u32> Default for StringM<MAX> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
+impl<const MAX: u32> StringM<MAX> {
+    pub const MAX_LEN: usize = { MAX as usize };
+
+    #[must_use]
+    #[allow(clippy::unused_self)]
+    pub fn max_len(&self) -> usize {
+        Self::MAX_LEN
+    }
+
+    #[must_use]
+    pub fn as_vec(&self) -> &Vec<u8> {
+        self.as_ref()
+    }
+}
+
+impl<const MAX: u32> StringM<MAX> {
+    #[must_use]
+    #[cfg(feature = "alloc")]
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.into()
+    }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<u8> {
+        self.into()
+    }
+}
+
+impl<const MAX: u32> StringM<MAX> {
+    #[cfg(feature = "alloc")]
+    pub fn to_string(&self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn into_string(self) -> Result<String> {
+        self.try_into()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn to_string_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn into_string_lossy(self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+}
+
+impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: Vec<u8>) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> From<StringM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: StringM<MAX>) -> Self {
+        v.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> From<&StringM<MAX>> for Vec<u8> {
+    #[must_use]
+    fn from(v: &StringM<MAX>) -> Self {
+        v.0.clone()
+    }
+}
+
+impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
+    #[must_use]
+    fn as_ref(&self) -> &Vec<u8> {
+        &self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &Vec<u8>) -> Result<Self> {
+        v.as_slice().try_into()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+    #[cfg(not(feature = "alloc"))]
+    #[must_use]
+    fn as_ref(&self) -> &[u8] {
+        self.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
+    type Error = StringM<MAX>;
+
+    fn try_from(v: StringM<MAX>) -> core::result::Result<Self, Self::Error> {
+        let s: [u8; N] = v.0.try_into().map_err(StringM::<MAX>)?;
+        Ok(s)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &[u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.as_bytes().to_vec()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: String) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: StringM<MAX>) -> Result<Self> {
+        Ok(String::from_utf8(v.0)?)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
+    type Error = Error;
+
+    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?.to_owned())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.into()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
+    type Error = Error;
+
+    fn try_from(v: &'static str) -> Result<Self> {
+        let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        if len <= MAX {
+            Ok(StringM(v.as_bytes()))
+        } else {
+            Err(Error::LengthExceedsMax)
+        }
+    }
+}
+
+impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
+    type Error = Error;
+
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+        Ok(core::str::from_utf8(v.as_ref())?)
+    }
+}
+
+impl<const MAX: u32> ReadXdr for StringM<MAX> {
+    #[cfg(feature = "std")]
+    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+        let len: u32 = u32::read_xdr(r)?;
+        if len > MAX {
+            return Err(Error::LengthExceedsMax);
+        }
+
+        let mut vec = vec![0u8; len as usize];
+        r.read_exact(&mut vec)?;
+
+        let pad = &mut [0u8; 3][..pad_len(len as usize)];
+        r.read_exact(pad)?;
+        if pad.iter().any(|b| *b != 0) {
+            return Err(Error::NonZeroPadding);
+        }
+
+        Ok(StringM(vec))
+    }
+}
+
+impl<const MAX: u32> WriteXdr for StringM<MAX> {
+    #[cfg(feature = "std")]
+    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+        len.write_xdr(w)?;
+
+        w.write_all(&self.0)?;
+
+        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+
+        Ok(())
+    }
+}
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -1194,8 +1937,8 @@ pub struct MyStruct {
   pub some_int: i32,
   pub a_big_int: i64,
   pub some_opaque: [u8; 10],
-  pub some_string: VecM::<u8>,
-  pub max_string: VecM::<u8, 100>,
+  pub some_string: StringM,
+  pub max_string: StringM::<100>,
 }
 
         impl ReadXdr for MyStruct {
@@ -1205,8 +1948,8 @@ pub struct MyStruct {
                   some_int: i32::read_xdr(r)?,
 a_big_int: i64::read_xdr(r)?,
 some_opaque: <[u8; 10]>::read_xdr(r)?,
-some_string: VecM::<u8>::read_xdr(r)?,
-max_string: VecM::<u8, 100>::read_xdr(r)?,
+some_string: StringM::read_xdr(r)?,
+max_string: StringM::<100>::read_xdr(r)?,
                 })
             }
         }


### PR DESCRIPTION
### What
Rust: Type Opaque as BytesM and String as StringM

### Why
The ultimate goal of this change is to get us to a place where we can improve the rendering of XDR Strings and XDR Opaque types in stringified renderings of XDR values either in Rust Debug form or in JSON.

Rust has a powerful type system, but also some limitations that haven't been worked out yet, and so because we put Strings, Opaques (Bytes), and arrays for types into the same Rust type, VecM, we cannot specialize their rendering. This results in the default rendering being used by whatever rendering system is rendering the type. Most rendering systems in Rust, like the default Debug implementations, and serde_json, all rely on using types to distinguish how the rendering occurs, or they require adding attributes to field attributes which only works for values encoded within another type and not values encoded just as themselves.

This is an experiment at this point, and I'm reasonably confident there are dragons to be found.

There's a risk that this is reasonably disruptive to existing code. Not in the sense of changing behavior, as the behavior will stay the same, but in terms of just lines changed and potential collissions with other work. So if we proceed with it, some care will have to be taken on when to make the upstream changes. And some care can be taken to weigh up if the benefits of this change really outweigh any costs we discover along the way.

Close https://github.com/stellar/xdrgen/issues/125
Close https://github.com/stellar/xdrgen/issues/119
Close https://github.com/stellar/xdrgen/issues/118