### PR TITLE
Rust: Fix clippy lint warning introduced in Rust 1.65

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	docker run -it --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
+	podman run -it --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
 		bundle install && \
 		bundle exec rspec \
 	'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	podman run -it --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
+	docker run -it --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
 		bundle install && \
 		bundle exec rspec \
 	'

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -511,7 +511,7 @@ impl ReadXdr for bool {
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let i: u32 = if *self { 1 } else { 0 };
+        let i = u32::from(*self); // true = 1, false = 0
         i.write_xdr(w)?;
         Ok(())
     }

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -521,7 +521,7 @@ impl ReadXdr for bool {
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let i: u32 = if *self { 1 } else { 0 };
+        let i = u32::from(*self); // true = 1, false = 0
         i.write_xdr(w)?;
         Ok(())
     }

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -521,7 +521,7 @@ impl ReadXdr for bool {
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let i: u32 = if *self { 1 } else { 0 };
+        let i = u32::from(*self); // true = 1, false = 0
         i.write_xdr(w)?;
         Ok(())
     }

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -521,7 +521,7 @@ impl ReadXdr for bool {
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let i: u32 = if *self { 1 } else { 0 };
+        let i = u32::from(*self); // true = 1, false = 0
         i.write_xdr(w)?;
         Ok(())
     }

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -521,7 +521,7 @@ impl ReadXdr for bool {
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let i: u32 = if *self { 1 } else { 0 };
+        let i = u32::from(*self); // true = 1, false = 0
         i.write_xdr(w)?;
         Ok(())
     }

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -521,7 +521,7 @@ impl ReadXdr for bool {
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let i: u32 = if *self { 1 } else { 0 };
+        let i = u32::from(*self); // true = 1, false = 0
         i.write_xdr(w)?;
         Ok(())
     }

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -521,7 +521,7 @@ impl ReadXdr for bool {
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let i: u32 = if *self { 1 } else { 0 };
+        let i = u32::from(*self); // true = 1, false = 0
         i.write_xdr(w)?;
         Ok(())
     }

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -521,7 +521,7 @@ impl ReadXdr for bool {
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let i: u32 = if *self { 1 } else { 0 };
+        let i = u32::from(*self); // true = 1, false = 0
         i.write_xdr(w)?;
         Ok(())
     }

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -521,7 +521,7 @@ impl ReadXdr for bool {
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let i: u32 = if *self { 1 } else { 0 };
+        let i = u32::from(*self); // true = 1, false = 0
         i.write_xdr(w)?;
         Ok(())
     }


### PR DESCRIPTION
### What
Use u32::from for converting bools to u32 in Rust generated code.

### Why
To maintain the xdrgen generated Rust code as passing clippys checks.