### PR TITLE
Rust: Use relative use refs

### DIFF
--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1822,9 +1822,7 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use crate::WriteXdr;
-
-    use super::{Error, ReadXdr, VecM};
+    use super::{Error, ReadXdr, VecM, WriteXdr};
 
     #[test]
     pub fn vec_u8_read_without_padding() {
@@ -1929,7 +1927,7 @@ mod tests {
 
 #[cfg(all(test, feature = "std"))]
 mod test {
-    use crate::VecM;
+    use super::VecM;
 
     #[test]
     fn into_option_none() {
@@ -1958,7 +1956,7 @@ mod test {
 
 #[cfg(all(test, not(feature = "alloc")))]
 mod test {
-    use crate::VecM;
+    use super::VecM;
 
     #[test]
     fn to_option_none() {

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -1832,9 +1832,7 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use crate::WriteXdr;
-
-    use super::{Error, ReadXdr, VecM};
+    use super::{Error, ReadXdr, VecM, WriteXdr};
 
     #[test]
     pub fn vec_u8_read_without_padding() {
@@ -1939,7 +1937,7 @@ mod tests {
 
 #[cfg(all(test, feature = "std"))]
 mod test {
-    use crate::VecM;
+    use super::VecM;
 
     #[test]
     fn into_option_none() {
@@ -1968,7 +1966,7 @@ mod test {
 
 #[cfg(all(test, not(feature = "alloc")))]
 mod test {
-    use crate::VecM;
+    use super::VecM;
 
     #[test]
     fn to_option_none() {

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -1832,9 +1832,7 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use crate::WriteXdr;
-
-    use super::{Error, ReadXdr, VecM};
+    use super::{Error, ReadXdr, VecM, WriteXdr};
 
     #[test]
     pub fn vec_u8_read_without_padding() {
@@ -1939,7 +1937,7 @@ mod tests {
 
 #[cfg(all(test, feature = "std"))]
 mod test {
-    use crate::VecM;
+    use super::VecM;
 
     #[test]
     fn into_option_none() {
@@ -1968,7 +1966,7 @@ mod test {
 
 #[cfg(all(test, not(feature = "alloc")))]
 mod test {
-    use crate::VecM;
+    use super::VecM;
 
     #[test]
     fn to_option_none() {

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -1832,9 +1832,7 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use crate::WriteXdr;
-
-    use super::{Error, ReadXdr, VecM};
+    use super::{Error, ReadXdr, VecM, WriteXdr};
 
     #[test]
     pub fn vec_u8_read_without_padding() {
@@ -1939,7 +1937,7 @@ mod tests {
 
 #[cfg(all(test, feature = "std"))]
 mod test {
-    use crate::VecM;
+    use super::VecM;
 
     #[test]
     fn into_option_none() {
@@ -1968,7 +1966,7 @@ mod test {
 
 #[cfg(all(test, not(feature = "alloc")))]
 mod test {
-    use crate::VecM;
+    use super::VecM;
 
     #[test]
     fn to_option_none() {

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -1832,9 +1832,7 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use crate::WriteXdr;
-
-    use super::{Error, ReadXdr, VecM};
+    use super::{Error, ReadXdr, VecM, WriteXdr};
 
     #[test]
     pub fn vec_u8_read_without_padding() {
@@ -1939,7 +1937,7 @@ mod tests {
 
 #[cfg(all(test, feature = "std"))]
 mod test {
-    use crate::VecM;
+    use super::VecM;
 
     #[test]
     fn into_option_none() {
@@ -1968,7 +1966,7 @@ mod test {
 
 #[cfg(all(test, not(feature = "alloc")))]
 mod test {
-    use crate::VecM;
+    use super::VecM;
 
     #[test]
     fn to_option_none() {

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -1832,9 +1832,7 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use crate::WriteXdr;
-
-    use super::{Error, ReadXdr, VecM};
+    use super::{Error, ReadXdr, VecM, WriteXdr};
 
     #[test]
     pub fn vec_u8_read_without_padding() {
@@ -1939,7 +1937,7 @@ mod tests {
 
 #[cfg(all(test, feature = "std"))]
 mod test {
-    use crate::VecM;
+    use super::VecM;
 
     #[test]
     fn into_option_none() {
@@ -1968,7 +1966,7 @@ mod test {
 
 #[cfg(all(test, not(feature = "alloc")))]
 mod test {
-    use crate::VecM;
+    use super::VecM;
 
     #[test]
     fn to_option_none() {

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -1832,9 +1832,7 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use crate::WriteXdr;
-
-    use super::{Error, ReadXdr, VecM};
+    use super::{Error, ReadXdr, VecM, WriteXdr};
 
     #[test]
     pub fn vec_u8_read_without_padding() {
@@ -1939,7 +1937,7 @@ mod tests {
 
 #[cfg(all(test, feature = "std"))]
 mod test {
-    use crate::VecM;
+    use super::VecM;
 
     #[test]
     fn into_option_none() {
@@ -1968,7 +1966,7 @@ mod test {
 
 #[cfg(all(test, not(feature = "alloc")))]
 mod test {
-    use crate::VecM;
+    use super::VecM;
 
     #[test]
     fn to_option_none() {

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -1832,9 +1832,7 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use crate::WriteXdr;
-
-    use super::{Error, ReadXdr, VecM};
+    use super::{Error, ReadXdr, VecM, WriteXdr};
 
     #[test]
     pub fn vec_u8_read_without_padding() {
@@ -1939,7 +1937,7 @@ mod tests {
 
 #[cfg(all(test, feature = "std"))]
 mod test {
-    use crate::VecM;
+    use super::VecM;
 
     #[test]
     fn into_option_none() {
@@ -1968,7 +1966,7 @@ mod test {
 
 #[cfg(all(test, not(feature = "alloc")))]
 mod test {
-    use crate::VecM;
+    use super::VecM;
 
     #[test]
     fn to_option_none() {

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -1832,9 +1832,7 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use crate::WriteXdr;
-
-    use super::{Error, ReadXdr, VecM};
+    use super::{Error, ReadXdr, VecM, WriteXdr};
 
     #[test]
     pub fn vec_u8_read_without_padding() {
@@ -1939,7 +1937,7 @@ mod tests {
 
 #[cfg(all(test, feature = "std"))]
 mod test {
-    use crate::VecM;
+    use super::VecM;
 
     #[test]
     fn into_option_none() {
@@ -1968,7 +1966,7 @@ mod test {
 
 #[cfg(all(test, not(feature = "alloc")))]
 mod test {
-    use crate::VecM;
+    use super::VecM;
 
     #[test]
     fn to_option_none() {


### PR DESCRIPTION
### What
Use relative `use` refs in Rust generated code.

### Why
To allow the generated code to be used in places where it is not in the root crate module.