### PR TITLE
Rust: Fix clippy warnings introduced in Rust 1.66

### DIFF
--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1844,7 +1844,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1854,7 +1854,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 
@@ -1894,7 +1894,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1904,7 +1904,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -94,11 +94,11 @@ impl fmt::Display for Error {
             Error::LengthExceedsMax => write!(f, "xdr value max length exceeded"),
             Error::LengthMismatch => write!(f, "xdr value length does not match"),
             Error::NonZeroPadding => write!(f, "xdr padding contains non-zero bytes"),
-            Error::Utf8Error(e) => write!(f, "{}", e),
+            Error::Utf8Error(e) => write!(f, "{e}"),
             #[cfg(feature = "alloc")]
             Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
-            Error::Io(e) => write!(f, "{}", e),
+            Error::Io(e) => write!(f, "{e}"),
         }
     }
 }
@@ -1425,7 +1425,7 @@ fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fm
     loop {
         match core::str::from_utf8(input) {
             Ok(valid) => {
-                write!(f, "{}", valid)?;
+                write!(f, "{valid}")?;
                 break;
             }
             Err(error) => {

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -1854,7 +1854,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1864,7 +1864,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 
@@ -1904,7 +1904,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1914,7 +1914,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -104,11 +104,11 @@ impl fmt::Display for Error {
             Error::LengthExceedsMax => write!(f, "xdr value max length exceeded"),
             Error::LengthMismatch => write!(f, "xdr value length does not match"),
             Error::NonZeroPadding => write!(f, "xdr padding contains non-zero bytes"),
-            Error::Utf8Error(e) => write!(f, "{}", e),
+            Error::Utf8Error(e) => write!(f, "{e}"),
             #[cfg(feature = "alloc")]
             Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
-            Error::Io(e) => write!(f, "{}", e),
+            Error::Io(e) => write!(f, "{e}"),
         }
     }
 }
@@ -1435,7 +1435,7 @@ fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fm
     loop {
         match core::str::from_utf8(input) {
             Ok(valid) => {
-                write!(f, "{}", valid)?;
+                write!(f, "{valid}")?;
                 break;
             }
             Err(error) => {

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -1854,7 +1854,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1864,7 +1864,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 
@@ -1904,7 +1904,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1914,7 +1914,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -104,11 +104,11 @@ impl fmt::Display for Error {
             Error::LengthExceedsMax => write!(f, "xdr value max length exceeded"),
             Error::LengthMismatch => write!(f, "xdr value length does not match"),
             Error::NonZeroPadding => write!(f, "xdr padding contains non-zero bytes"),
-            Error::Utf8Error(e) => write!(f, "{}", e),
+            Error::Utf8Error(e) => write!(f, "{e}"),
             #[cfg(feature = "alloc")]
             Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
-            Error::Io(e) => write!(f, "{}", e),
+            Error::Io(e) => write!(f, "{e}"),
         }
     }
 }
@@ -1435,7 +1435,7 @@ fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fm
     loop {
         match core::str::from_utf8(input) {
             Ok(valid) => {
-                write!(f, "{}", valid)?;
+                write!(f, "{valid}")?;
                 break;
             }
             Err(error) => {

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -1854,7 +1854,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1864,7 +1864,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 
@@ -1904,7 +1904,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1914,7 +1914,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -104,11 +104,11 @@ impl fmt::Display for Error {
             Error::LengthExceedsMax => write!(f, "xdr value max length exceeded"),
             Error::LengthMismatch => write!(f, "xdr value length does not match"),
             Error::NonZeroPadding => write!(f, "xdr padding contains non-zero bytes"),
-            Error::Utf8Error(e) => write!(f, "{}", e),
+            Error::Utf8Error(e) => write!(f, "{e}"),
             #[cfg(feature = "alloc")]
             Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
-            Error::Io(e) => write!(f, "{}", e),
+            Error::Io(e) => write!(f, "{e}"),
         }
     }
 }
@@ -1435,7 +1435,7 @@ fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fm
     loop {
         match core::str::from_utf8(input) {
             Ok(valid) => {
-                write!(f, "{}", valid)?;
+                write!(f, "{valid}")?;
                 break;
             }
             Err(error) => {

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -1854,7 +1854,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1864,7 +1864,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 
@@ -1904,7 +1904,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1914,7 +1914,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -104,11 +104,11 @@ impl fmt::Display for Error {
             Error::LengthExceedsMax => write!(f, "xdr value max length exceeded"),
             Error::LengthMismatch => write!(f, "xdr value length does not match"),
             Error::NonZeroPadding => write!(f, "xdr padding contains non-zero bytes"),
-            Error::Utf8Error(e) => write!(f, "{}", e),
+            Error::Utf8Error(e) => write!(f, "{e}"),
             #[cfg(feature = "alloc")]
             Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
-            Error::Io(e) => write!(f, "{}", e),
+            Error::Io(e) => write!(f, "{e}"),
         }
     }
 }
@@ -1435,7 +1435,7 @@ fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fm
     loop {
         match core::str::from_utf8(input) {
             Ok(valid) => {
-                write!(f, "{}", valid)?;
+                write!(f, "{valid}")?;
                 break;
             }
             Err(error) => {

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -1854,7 +1854,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1864,7 +1864,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 
@@ -1904,7 +1904,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1914,7 +1914,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -104,11 +104,11 @@ impl fmt::Display for Error {
             Error::LengthExceedsMax => write!(f, "xdr value max length exceeded"),
             Error::LengthMismatch => write!(f, "xdr value length does not match"),
             Error::NonZeroPadding => write!(f, "xdr padding contains non-zero bytes"),
-            Error::Utf8Error(e) => write!(f, "{}", e),
+            Error::Utf8Error(e) => write!(f, "{e}"),
             #[cfg(feature = "alloc")]
             Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
-            Error::Io(e) => write!(f, "{}", e),
+            Error::Io(e) => write!(f, "{e}"),
         }
     }
 }
@@ -1435,7 +1435,7 @@ fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fm
     loop {
         match core::str::from_utf8(input) {
             Ok(valid) => {
-                write!(f, "{}", valid)?;
+                write!(f, "{valid}")?;
                 break;
             }
             Err(error) => {

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -1854,7 +1854,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1864,7 +1864,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 
@@ -1904,7 +1904,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1914,7 +1914,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -104,11 +104,11 @@ impl fmt::Display for Error {
             Error::LengthExceedsMax => write!(f, "xdr value max length exceeded"),
             Error::LengthMismatch => write!(f, "xdr value length does not match"),
             Error::NonZeroPadding => write!(f, "xdr padding contains non-zero bytes"),
-            Error::Utf8Error(e) => write!(f, "{}", e),
+            Error::Utf8Error(e) => write!(f, "{e}"),
             #[cfg(feature = "alloc")]
             Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
-            Error::Io(e) => write!(f, "{}", e),
+            Error::Io(e) => write!(f, "{e}"),
         }
     }
 }
@@ -1435,7 +1435,7 @@ fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fm
     loop {
         match core::str::from_utf8(input) {
             Ok(valid) => {
-                write!(f, "{}", valid)?;
+                write!(f, "{valid}")?;
                 break;
             }
             Err(error) => {

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -1854,7 +1854,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1864,7 +1864,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 
@@ -1904,7 +1904,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1914,7 +1914,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -104,11 +104,11 @@ impl fmt::Display for Error {
             Error::LengthExceedsMax => write!(f, "xdr value max length exceeded"),
             Error::LengthMismatch => write!(f, "xdr value length does not match"),
             Error::NonZeroPadding => write!(f, "xdr padding contains non-zero bytes"),
-            Error::Utf8Error(e) => write!(f, "{}", e),
+            Error::Utf8Error(e) => write!(f, "{e}"),
             #[cfg(feature = "alloc")]
             Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
-            Error::Io(e) => write!(f, "{}", e),
+            Error::Io(e) => write!(f, "{e}"),
         }
     }
 }
@@ -1435,7 +1435,7 @@ fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fm
     loop {
         match core::str::from_utf8(input) {
             Ok(valid) => {
-                write!(f, "{}", valid)?;
+                write!(f, "{valid}")?;
                 break;
             }
             Err(error) => {

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -1854,7 +1854,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1864,7 +1864,7 @@ mod tests {
         let res = VecM::<u8, 8>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 
@@ -1904,7 +1904,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::Io(_)) => (),
-            _ => panic!("expected IO error got {:?}", res),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
@@ -1914,7 +1914,7 @@ mod tests {
         let res = <[u8; 1]>::read_xdr(&mut buf);
         match res {
             Err(Error::NonZeroPadding) => (),
-            _ => panic!("expected NonZeroPadding got {:?}", res),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -104,11 +104,11 @@ impl fmt::Display for Error {
             Error::LengthExceedsMax => write!(f, "xdr value max length exceeded"),
             Error::LengthMismatch => write!(f, "xdr value length does not match"),
             Error::NonZeroPadding => write!(f, "xdr padding contains non-zero bytes"),
-            Error::Utf8Error(e) => write!(f, "{}", e),
+            Error::Utf8Error(e) => write!(f, "{e}"),
             #[cfg(feature = "alloc")]
             Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
-            Error::Io(e) => write!(f, "{}", e),
+            Error::Io(e) => write!(f, "{e}"),
         }
     }
 }
@@ -1435,7 +1435,7 @@ fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fm
     loop {
         match core::str::from_utf8(input) {
             Ok(valid) => {
-                write!(f, "{}", valid)?;
+                write!(f, "{valid}")?;
                 break;
             }
             Err(error) => {


### PR DESCRIPTION
### What
Move variables in write! and panic! macro calls into the format string.

### Why
Clippy in Rust 1.66 started requiring variables to be specified in the string rather than as an argument.