### PR TITLE
Rust: Fix clippy warning

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -242,6 +242,7 @@ module Xdrgen
             #[must_use]
             #[allow(clippy::too_many_lines)]
             pub fn value(&self) -> &dyn core::any::Any {
+                #[allow(clippy::match_same_arms)]
                 match self {
                     #{types.map { |t| "Self::#{t}(ref v) => v.as_ref()," }.join("\n")}
                 }

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -2218,6 +2218,7 @@ impl Type {
     #[must_use]
     #[allow(clippy::too_many_lines)]
     pub fn value(&self) -> &dyn core::any::Any {
+        #[allow(clippy::match_same_arms)]
         match self {
             Self::AccountFlags(ref v) => v.as_ref(),
         }

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -2157,6 +2157,7 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec).map(|
             #[must_use]
             #[allow(clippy::too_many_lines)]
             pub fn value(&self) -> &dyn core::any::Any {
+                #[allow(clippy::match_same_arms)]
                 match self {
                     Self::TestArray(ref v) => v.as_ref(),
 Self::TestArray2(ref v) => v.as_ref(),

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -2530,6 +2530,7 @@ TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(dec).map(|r| r.map
             #[must_use]
             #[allow(clippy::too_many_lines)]
             pub fn value(&self) -> &dyn core::any::Any {
+                #[allow(clippy::match_same_arms)]
                 match self {
                     Self::MessageType(ref v) => v.as_ref(),
 Self::Color(ref v) => v.as_ref(),

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -2466,6 +2466,7 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec).map(|
             #[must_use]
             #[allow(clippy::too_many_lines)]
             pub fn value(&self) -> &dyn core::any::Any {
+                #[allow(clippy::match_same_arms)]
                 match self {
                     Self::UnionKey(ref v) => v.as_ref(),
 Self::Foo(ref v) => v.as_ref(),

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -2184,6 +2184,7 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec).map(|
             #[must_use]
             #[allow(clippy::too_many_lines)]
             pub fn value(&self) -> &dyn core::any::Any {
+                #[allow(clippy::match_same_arms)]
                 match self {
                     Self::Arr(ref v) => v.as_ref(),
 Self::HasOptions(ref v) => v.as_ref(),

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -2192,6 +2192,7 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec).map(|r| r
             #[must_use]
             #[allow(clippy::too_many_lines)]
             pub fn value(&self) -> &dyn core::any::Any {
+                #[allow(clippy::match_same_arms)]
                 match self {
                     Self::Int64(ref v) => v.as_ref(),
 Self::MyStruct(ref v) => v.as_ref(),

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -3722,6 +3722,7 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::
             #[must_use]
             #[allow(clippy::too_many_lines)]
             pub fn value(&self) -> &dyn core::any::Any {
+                #[allow(clippy::match_same_arms)]
                 match self {
                     Self::Uint512(ref v) => v.as_ref(),
 Self::Uint513(ref v) => v.as_ref(),

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -2551,6 +2551,7 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec).map(|r|
             #[must_use]
             #[allow(clippy::too_many_lines)]
             pub fn value(&self) -> &dyn core::any::Any {
+                #[allow(clippy::match_same_arms)]
                 match self {
                     Self::SError(ref v) => v.as_ref(),
 Self::Multi(ref v) => v.as_ref(),


### PR DESCRIPTION
### What
Instruct clippy to ignore match statements with identical arms in the long type functions.

### Why
The arms are identical, and for code gen it is easier of they are duplicates rather than joined.