### PR TITLE
Golang: add bool support to EncodeTo() and DecodeFrom()

### DIFF
--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -451,6 +451,8 @@ module Xdrgen
           out.puts check_error "_, err = e.EncodeUint(uint32(#{var}))"
         when AST::Typespecs::Int
           out.puts (check_error "_, err = e.EncodeInt(int32(#{var}))")
+        when AST::Typespecs::Bool
+          out.puts (check_error "_, err = e.EncodeBool(bool(#{var}))")
         when AST::Typespecs::String
           out.puts check_error "_, err = e.EncodeString(string(#{var}))"
         when AST::Typespecs::Opaque
@@ -658,6 +660,9 @@ module Xdrgen
           out.puts tail
         when AST::Typespecs::Int
           out.puts "  #{var}, nTmp, err = d.DecodeInt()"
+          out.puts tail
+        when AST::Typespecs::Bool
+          out.puts "  #{var}, nTmp, err = d.DecodeBool()"
           out.puts tail
         when AST::Typespecs::String
           arg = "0"

--- a/lib/xdrgen/generators/go.rb
+++ b/lib/xdrgen/generators/go.rb
@@ -757,7 +757,7 @@ module Xdrgen
           end
           out.puts tail
         else
-          out.puts "  nTmp, err = d.Decode(#{var})"
+          out.puts "  nTmp, err = d.Decode(&#{var})"
           out.puts tail
         end
         if optional

--- a/spec/output/generator_spec_go/test.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/test.x/MyXDR_generated.go
@@ -940,12 +940,12 @@ n += nTmp
 if err != nil {
   return n, fmt.Errorf("decoding Unsigned int: %s", err)
 }
-  nTmp, err = d.Decode(s.Field5)
+  nTmp, err = d.Decode(&s.Field5)
 n += nTmp
 if err != nil {
   return n, fmt.Errorf("decoding Float: %s", err)
 }
-  nTmp, err = d.Decode(s.Field6)
+  nTmp, err = d.Decode(&s.Field6)
 n += nTmp
 if err != nil {
   return n, fmt.Errorf("decoding Double: %s", err)

--- a/spec/output/generator_spec_go/test.x/MyXDR_generated.go
+++ b/spec/output/generator_spec_go/test.x/MyXDR_generated.go
@@ -899,7 +899,7 @@ if _, err = e.Encode(s.Field5); err != nil {
 if _, err = e.Encode(s.Field6); err != nil {
   return err
 }
-if _, err = e.Encode(s.Field7); err != nil {
+if _, err = e.EncodeBool(bool(s.Field7)); err != nil {
   return err
 }
   return nil
@@ -950,7 +950,7 @@ n += nTmp
 if err != nil {
   return n, fmt.Errorf("decoding Double: %s", err)
 }
-  nTmp, err = d.Decode(s.Field7)
+  s.Field7, nTmp, err = d.DecodeBool()
 n += nTmp
 if err != nil {
   return n, fmt.Errorf("decoding Bool: %s", err)


### PR DESCRIPTION
Closes #154 

Also, for types we can't or don't know how to decode directly,  make sure we always call `Decode()` on a pointer reference

You can see the result of this PR at https://github.com/stellar/go/pull/4818