### PR TITLE
Add `DepthLimiter` and adapt to the Read/WriteXDR

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -166,21 +166,21 @@ module Xdrgen
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 match v {
-                    #{types.map { |t| "TypeVariant::#{t} => Ok(Self::#{t}(Box::new(#{t}::read_xdr(r)?)))," }.join("\n")}
+                    #{types.map { |t| "TypeVariant::#{t} => r.with_limited_depth(|r| Ok(Self::#{t}(Box::new(#{t}::read_xdr(r)?))))," }.join("\n")}
                 }
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
-                let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+            pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(r, base64::STANDARD), depth_limit);
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -192,48 +192,48 @@ module Xdrgen
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
-                let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+            pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(r, base64::STANDARD), depth_limit);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit: u32) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, #{t}>::new(r).map(|r| r.map(|t| Self::#{t}(Box::new(t)))))," }.join("\n")}
+                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, #{t}>::new(r, depth_limit).map(|r| r.map(|t| Self::#{t}(Box::new(t)))))," }.join("\n")}
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit: u32) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, Frame<#{t}>>::new(r).map(|r| r.map(|t| Self::#{t}(Box::new(t.0)))))," }.join("\n")}
+                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, Frame<#{t}>>::new(r, depth_limit).map(|r| r.map(|t| Self::#{t}(Box::new(t.0)))))," }.join("\n")}
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit: u32) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
                 match v {
-                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, #{t}>::new(dec).map(|r| r.map(|t| Self::#{t}(Box::new(t)))))," }.join("\n")}
+                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, #{t}>::new(dec, depth_limit).map(|r| r.map(|t| Self::#{t}(Box::new(t)))))," }.join("\n")}
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = Cursor::new(bytes.as_ref());
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, depth_limit: u32) -> Result<Self> {
+                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String, depth_limit: u32) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), depth_limit);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -356,22 +356,26 @@ module Xdrgen
         out.puts <<-EOS.strip_heredoc
         impl ReadXdr for #{name struct} {
             #[cfg(feature = "std")]
-            fn read_xdr(r: &mut impl Read) -> Result<Self> {
-                Ok(Self{
-                  #{struct.members.map do |m|
-                    "#{field_name(m)}: #{reference_to_call(struct, m.declaration.type)}::read_xdr(r)?,"
-                  end.join("\n")}
+            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                r.with_limited_depth(|r| {
+                    Ok(Self{
+                      #{struct.members.map do |m|
+                        "#{field_name(m)}: #{reference_to_call(struct, m.declaration.type)}::read_xdr(r)?,"
+                      end.join("\n")}
+                    })
                 })
             }
         }
 
         impl WriteXdr for #{name struct} {
             #[cfg(feature = "std")]
-            fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-                #{struct.members.map do |m|
-                  "self.#{field_name(m)}.write_xdr(w)?;"
-                end.join("\n")}
-                Ok(())
+            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+                w.with_limited_depth(|w| {
+                    #{struct.members.map do |m|
+                      "self.#{field_name(m)}.write_xdr(w)?;"
+                    end.join("\n")}
+                    Ok(())
+                })
             }
         }
         EOS
@@ -455,18 +459,22 @@ module Xdrgen
 
         impl ReadXdr for #{name enum} {
             #[cfg(feature = "std")]
-            fn read_xdr(r: &mut impl Read) -> Result<Self> {
-                let e = i32::read_xdr(r)?;
-                let v: Self = e.try_into()?;
-                Ok(v)
+            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                r.with_limited_depth(|r| {
+                    let e = i32::read_xdr(r)?;
+                    let v: Self = e.try_into()?;
+                    Ok(v)
+                })
             }
         }
 
         impl WriteXdr for #{name enum} {
             #[cfg(feature = "std")]
-            fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-                let i: i32 = (*self).into();
-                i.write_xdr(w)
+            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+                w.with_limited_depth(|w| {
+                    let i: i32 = (*self).into();
+                    i.write_xdr(w)
+                })
             }
         }
         EOS
@@ -583,39 +591,43 @@ module Xdrgen
 
         impl ReadXdr for #{name union} {
             #[cfg(feature = "std")]
-            fn read_xdr(r: &mut impl Read) -> Result<Self> {
-                let dv: #{discriminant_type} = <#{discriminant_type} as ReadXdr>::read_xdr(r)?;
-                #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
-                let v = match dv {
-                    #{union_cases(union) do |case_name, arm, value|
-                      "#{
-                        value.nil? ? "#{discriminant_type}::#{case_name}" : "#{value}"
-                      } => #{
-                        arm.void? ? "Self::#{case_name}" : "Self::#{case_name}(#{reference_to_call(union, arm.type)}::read_xdr(r)?)"
-                      },"
-                    end.join("\n")}
-                    #[allow(unreachable_patterns)]
-                    _ => return Err(Error::Invalid),
-                };
-                Ok(v)
+            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                r.with_limited_depth(|r| {
+                    let dv: #{discriminant_type} = <#{discriminant_type} as ReadXdr>::read_xdr(r)?;
+                    #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
+                    let v = match dv {
+                        #{union_cases(union) do |case_name, arm, value|
+                          "#{
+                            value.nil? ? "#{discriminant_type}::#{case_name}" : "#{value}"
+                          } => #{
+                            arm.void? ? "Self::#{case_name}" : "Self::#{case_name}(#{reference_to_call(union, arm.type)}::read_xdr(r)?)"
+                          },"
+                        end.join("\n")}
+                        #[allow(unreachable_patterns)]
+                        _ => return Err(Error::Invalid),
+                    };
+                    Ok(v)
+                })
             }
         }
 
         impl WriteXdr for #{name union} {
             #[cfg(feature = "std")]
-            fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-                self.discriminant().write_xdr(w)?;
-                #[allow(clippy::match_same_arms)]
-                match self {
-                    #{union_cases(union) do |case_name, arm, value|
-                      if arm.void?
-                        "Self::#{case_name} => ().write_xdr(w)?,"
-                      else
-                        "Self::#{case_name}(v) => v.write_xdr(w)?,"
-                      end
-                    end.join("\n")}
-                };
-                Ok(())
+            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+                w.with_limited_depth(|w| {
+                    self.discriminant().write_xdr(w)?;
+                    #[allow(clippy::match_same_arms)]
+                    match self {
+                        #{union_cases(union) do |case_name, arm, value|
+                          if arm.void?
+                            "Self::#{case_name} => ().write_xdr(w)?,"
+                          else
+                            "Self::#{case_name}(v) => v.write_xdr(w)?,"
+                          end
+                        end.join("\n")}
+                    };
+                    Ok(())
+                })
             }
         }
         EOS
@@ -694,17 +706,19 @@ module Xdrgen
 
           impl ReadXdr for #{name typedef} {
               #[cfg(feature = "std")]
-              fn read_xdr(r: &mut impl Read) -> Result<Self> {
-                  let i = #{reference_to_call(typedef, typedef.type)}::read_xdr(r)?;
-                  let v = #{name typedef}(i);
-                  Ok(v)
+              fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                  r.with_limited_depth(|r| {
+                      let i = #{reference_to_call(typedef, typedef.type)}::read_xdr(r)?;
+                      let v = #{name typedef}(i);
+                      Ok(v)
+                  })
               }
           }
 
           impl WriteXdr for #{name typedef} {
               #[cfg(feature = "std")]
-              fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-                  self.0.write_xdr(w)
+              fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+                  w.with_limited_depth(|w|{ self.0.write_xdr(w) })
               }
           }
           EOS

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -174,7 +174,7 @@ module Xdrgen
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -193,7 +193,7 @@ module Xdrgen
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -202,7 +202,7 @@ module Xdrgen
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, #{t}>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::#{t}(Box::new(t)))))," }.join("\n")}
+                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, #{t}>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::#{t}(Box::new(t)))))," }.join("\n")}
                 }
             }
 
@@ -210,7 +210,7 @@ module Xdrgen
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, Frame<#{t}>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::#{t}(Box::new(t.0)))))," }.join("\n")}
+                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, Frame<#{t}>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::#{t}(Box::new(t.0)))))," }.join("\n")}
                 }
             }
 
@@ -219,7 +219,7 @@ module Xdrgen
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, #{t}>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::#{t}(Box::new(t)))))," }.join("\n")}
+                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, #{t}>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::#{t}(Box::new(t)))))," }.join("\n")}
                 }
             }
 

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -224,16 +224,16 @@ module Xdrgen
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, depth_limit: u32) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
+                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String, depth_limit: u32) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), depth_limit);
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_MAX_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -174,7 +174,7 @@ module Xdrgen
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -193,7 +193,7 @@ module Xdrgen
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -202,7 +202,7 @@ module Xdrgen
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, #{t}>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::#{t}(Box::new(t)))))," }.join("\n")}
+                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, #{t}>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::#{t}(Box::new(t)))))," }.join("\n")}
                 }
             }
 
@@ -210,7 +210,7 @@ module Xdrgen
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, Frame<#{t}>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::#{t}(Box::new(t.0)))))," }.join("\n")}
+                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, Frame<#{t}>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::#{t}(Box::new(t.0)))))," }.join("\n")}
                 }
             }
 
@@ -219,7 +219,7 @@ module Xdrgen
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, #{t}>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::#{t}(Box::new(t)))))," }.join("\n")}
+                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, #{t}>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::#{t}(Box::new(t)))))," }.join("\n")}
                 }
             }
 

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -225,7 +225,7 @@ module Xdrgen
 
             #[cfg(feature = "std")]
             pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
+                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
@@ -233,7 +233,7 @@ module Xdrgen
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_MAX_DEPTH_LIMIT);
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/lib/xdrgen/generators/rust/Cargo.lock
+++ b/lib/xdrgen/generators/rust/Cargo.lock
@@ -3,14 +3,77 @@
 version = 3
 
 [[package]]
+name = "arbitrary"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "rs-xdr-types"
 version = "0.0.0"
 dependencies = [
+ "arbitrary",
  "base64",
+ "hex",
 ]
+
+[[package]]
+name = "syn"
+version = "2.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"

--- a/lib/xdrgen/generators/rust/Cargo.toml
+++ b/lib/xdrgen/generators/rust/Cargo.toml
@@ -4,10 +4,12 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-base64 = "0.13.0"
+base64 = { version = "0.13.0", optional = true }
 arbitrary = { version = "1.1.3", features = ["derive"] }
+hex = { version = "0.4.3", optional = true }
 
 [features]
 default = ["std"]
 std = ["alloc", "base64/std"]
-alloc = []
+alloc = ["dep:hex"]
+base64 = ["std", "dep:base64"]

--- a/lib/xdrgen/generators/rust/src/lib.rs
+++ b/lib/xdrgen/generators/rust/src/lib.rs
@@ -1,4 +1,4 @@
-// #![forbid(unsafe_code)]
+#![forbid(unsafe_code)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod types;

--- a/lib/xdrgen/generators/rust/src/lib.rs
+++ b/lib/xdrgen/generators/rust/src/lib.rs
@@ -1,4 +1,4 @@
-#![forbid(unsafe_code)]
+// #![forbid(unsafe_code)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod types;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -216,11 +216,12 @@ pub trait DepthLimiter {
 }
 
 /// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth` state tracking remaining recursion depth.
+/// recursive read operations. It maintains a `depth_remaining` state tracking
+/// remaining allowed recursion depth.
 #[cfg(feature = "std")]
 pub struct DepthLimitedRead<R: Read> {
     pub inner: R,
-    pub(crate) depth: RefCell<u32>,
+    pub(crate) depth_remaining: RefCell<u32>,
 }
 
 #[cfg(feature = "std")]
@@ -228,11 +229,11 @@ impl<R: Read> DepthLimitedRead<R> {
     /// Constructs a new `DepthLimitedRead`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
-    /// - `depth`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth: u32) -> Self {
+    /// - `depth_limit`: The maximum allowed recursion depth.
+    pub fn new(inner: R, depth_limit: u32) -> Self {
         DepthLimitedRead {
             inner,
-            depth: RefCell::new(depth),
+            depth_remaining: RefCell::new(depth_limit),
         }
     }
 }
@@ -241,21 +242,21 @@ impl<R: Read> DepthLimitedRead<R> {
 impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
     type DepthError = Error;
 
-    /// Decrements the depth. If the depth is already zero, an error is returned indicating
-    /// that the maximum depth limit has been exceeded.
+    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
+    /// returned indicating that the maximum depth limit has been exceeded.
     fn enter(&self) -> core::result::Result<(), Error> {
-        let depth = *self.depth.borrow();
+        let depth = *self.depth_remaining.borrow();
         if depth == 0 {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth.replace(depth - 1);
+        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
     /// Increments the depth, without exceeding the initial depth value.
     fn leave(&self) {
-        let depth = *self.depth.borrow();
-        self.depth.replace(depth.saturating_add(1));
+        let depth = *self.depth_remaining.borrow();
+        self.depth_remaining.replace(depth.saturating_add(1));
     }
 }
 
@@ -268,11 +269,12 @@ impl<R: Read> Read for DepthLimitedRead<R> {
 }
 
 /// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth` state tracking remaining recursion depth.
+/// recursive write operations. It maintains a `depth_remaining` state tracking
+/// remaining allowed recursion depth.
 #[cfg(feature = "std")]
 pub struct DepthLimitedWrite<W: Write> {
     pub inner: W,
-    pub(crate) depth: RefCell<u32>,
+    pub(crate) depth_remaining: RefCell<u32>,
 }
 
 #[cfg(feature = "std")]
@@ -280,11 +282,11 @@ impl<W: Write> DepthLimitedWrite<W> {
     /// Constructs a new `DepthLimitedWrite`.
     ///
     /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth: u32) -> Self {
+    /// - `depth_limit`: The maximum allowed recursion depth.
+    pub fn new(inner: W, depth_limit: u32) -> Self {
         DepthLimitedWrite {
             inner,
-            depth: RefCell::new(depth),
+            depth_remaining: RefCell::new(depth_limit),
         }
     }
 }
@@ -293,21 +295,21 @@ impl<W: Write> DepthLimitedWrite<W> {
 impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
     type DepthError = Error;
 
-    /// Decrements the depth. If the depth is already zero, an error is returned indicating
-    /// that the maximum depth limit has been exceeded.
+    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
+    /// returned indicating that the maximum depth limit has been exceeded.
     fn enter(&self) -> Result<()> {
-        let depth = *self.depth.borrow();
+        let depth = *self.depth_remaining.borrow();
         if depth == 0 {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth.replace(depth - 1);
+        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
     /// Increments the depth, without exceeding the initial depth value.
     fn leave(&self) {
-        let depth = *self.depth.borrow();
-        self.depth.replace(depth.saturating_add(1));
+        let depth = *self.depth_remaining.borrow();
+        self.depth_remaining.replace(depth.saturating_add(1));
     }
 }
 
@@ -332,11 +334,11 @@ pub struct ReadXdrIter<R: Read, S: ReadXdr> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth: u32) -> Self {
+    fn new(r: R, depth_limit: u32) -> Self {
         Self {
             reader: DepthLimitedRead {
                 inner: BufReader::new(r),
-                depth: RefCell::new(depth),
+                depth_remaining: RefCell::new(depth_limit),
             },
             _s: PhantomData,
         }
@@ -408,7 +410,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth.take(),
+            r.depth_remaining.take(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -452,7 +454,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth.take(),
+            r.depth_remaining.take(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -528,7 +530,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth.take())
+        ReadXdrIter::new(&mut r.inner, r.depth_remaining.take())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -538,34 +540,51 @@ where
         r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth.take())
+        ReadXdrIter::new(dec, r.depth_remaining.take())
     }
 
-    /// Construct the type from the XDR bytes.
+    /// Construct the type from the XDR bytes, specifying a depth limit.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
+    #[cfg(feature = "std")]
+    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+        let t = Self::read_xdr_to_end(&mut cursor)?;
+        Ok(t)
+    }
+
+    /// Construct the type from the XDR bytes, using the default depth limit.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
     fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        let mut cursor =
-            DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
-        let t = Self::read_xdr_to_end(&mut cursor)?;
+        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_MAX_DEPTH_LIMIT)
+    }
+
+    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
+    #[cfg(feature = "base64")]
+    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut b64_reader = Cursor::new(b64);
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            depth_limit,
+        );
+        let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes base64 encoded.
+    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            DEFAULT_MAX_DEPTH_LIMIT,
-        );
-        let t = Self::read_xdr_to_end(&mut dec)?;
-        Ok(t)
+        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_MAX_DEPTH_LIMIT)
     }
 }
 
@@ -574,22 +593,32 @@ pub trait WriteXdr {
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), DEFAULT_MAX_DEPTH_LIMIT);
+    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
+    #[cfg(feature = "std")]
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        self.to_xdr_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+    }
+
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
+    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
         let mut enc = DepthLimitedWrite::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            depth_limit,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
+    }
+
+    #[cfg(feature = "base64")]
+    fn to_xdr_base64(&self) -> Result<String> {
+        self.to_xdr_base64_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
     }
 }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1,7 +1,7 @@
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
-use core::marker::PhantomData;
+use core::{cell::RefCell, marker::PhantomData};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -56,6 +56,7 @@ pub enum Error {
     InvalidHex,
     #[cfg(feature = "std")]
     Io(io::Error),
+    DepthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -99,6 +100,7 @@ impl fmt::Display for Error {
             Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{e}"),
+            Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
         }
     }
 }
@@ -170,17 +172,123 @@ where
 {
 }
 
+pub trait DepthLimiter {
+    type DepthError;
+
+    fn enter(&self) -> core::result::Result<(), Self::DepthError>;
+
+    fn leave(&self);
+
+    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthError>
+    where
+        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthError>,
+    {
+        self.enter()?;
+        let res = f(self)?;
+        self.leave();
+        Ok(res)
+    }
+}
+
+#[cfg(feature = "std")]
+pub struct DepthLimitedRead<R: Read> {
+    pub(crate) inner: R,
+    depth: RefCell<u32>,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> DepthLimitedRead<R> {
+    pub fn new(inner: R, depth: u32) -> Self {
+        DepthLimitedRead {
+            inner,
+            depth: RefCell::new(depth),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
+    type DepthError = Error;
+
+    fn enter(&self) -> core::result::Result<(), Error> {
+        let depth = *self.depth.borrow();
+        if depth == 0 {
+            return Err(Error::DepthLimitExceeded);
+        }
+        self.depth.replace(depth - 1);
+        Ok(())
+    }
+
+    fn leave(&self) {
+        let depth = *self.depth.borrow();
+        self.depth.replace(depth.saturating_add(1));
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for DepthLimitedRead<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+pub struct DepthLimitedWrite<W: Write> {
+    pub(crate) inner: W,
+    depth: RefCell<u32>,
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> DepthLimitedWrite<W> {
+    pub fn new(inner: W, depth: u32) -> Self {
+        DepthLimitedWrite {
+            inner,
+            depth: RefCell::new(depth),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
+    type DepthError = Error;
+
+    fn enter(&self) -> Result<()> {
+        let depth = *self.depth.borrow();
+        if depth == 0 {
+            return Err(Error::DepthLimitExceeded);
+        }
+        self.depth.replace(depth - 1);
+        Ok(())
+    }
+
+    fn leave(&self) {
+        let depth = *self.depth.borrow();
+        self.depth.replace(depth.saturating_add(1));
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for DepthLimitedWrite<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: BufReader<R>,
+    reader: DepthLimitedRead<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R) -> Self {
+    fn new(r: R, depth_limit: u32) -> Self {
         Self {
-            reader: BufReader::new(r),
+            reader: DepthLimitedRead::new(BufReader::new(r), depth_limit),
             _s: PhantomData,
         }
     }
@@ -204,7 +312,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.fill_buf() {
+        match self.reader.inner.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -214,7 +322,8 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
             Ok([..]) => (),
         };
         // Read the buf into the type.
-        match S::read_xdr(&mut self.reader) {
+        let r = self.reader.with_limited_depth(|dlr| S::read_xdr(dlr));
+        match r {
             Ok(s) => Some(Ok(s)),
             Err(e) => Some(Err(e)),
         }
@@ -237,18 +346,21 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     ///
-    /// Use [`ReadXdr::read_xdr_to_end`] when the intent is for all bytes in the
+    /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64(r: &mut impl Read) -> Result<Self> {
-        let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+    fn read_xdr_base64(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(r, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
     }
@@ -272,7 +384,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -288,8 +400,11 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end(r: &mut impl Read) -> Result<Self> {
-        let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+    fn read_xdr_base64_to_end(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(r, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
@@ -306,10 +421,10 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     ///
-    /// Use [`ReadXdr::read_xdr_into_to_end`] when the intent is for all bytes
+    /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -333,7 +448,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end(&mut self, r: &mut impl Read) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -363,8 +478,8 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut R) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(r)
+    fn read_xdr_iter<R: Read>(r: &mut R, depth_limit: u32) -> ReadXdrIter<&mut R, Self> {
+        ReadXdrIter::new(r, depth_limit)
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -372,9 +487,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut R,
+        depth_limit: u32,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
-        ReadXdrIter::new(dec)
+        ReadXdrIter::new(dec, depth_limit)
     }
 
     /// Construct the type from the XDR bytes.
@@ -382,8 +498,8 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        let mut cursor = Cursor::new(bytes.as_ref());
+    fn from_xdr(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
@@ -393,9 +509,12 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
@@ -403,21 +522,24 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        let mut cursor = Cursor::new(vec![]);
+    fn to_xdr(&self, depth_limit: u32) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
         self.write_xdr(&mut cursor)?;
-        let bytes = cursor.into_inner();
+        let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        let mut enc = base64::write::EncoderStringWriter::new(base64::STANDARD);
+    fn to_xdr_base64(&self, depth_limit: u32) -> Result<String> {
+        let mut enc = DepthLimitedWrite::new(
+            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            depth_limit,
+        );
         self.write_xdr(&mut enc)?;
-        let b64 = enc.into_inner();
+        let b64 = enc.inner.into_inner();
         Ok(b64)
     }
 }
@@ -431,229 +553,240 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 4];
-        r.read_exact(&mut b)?;
-        let i = i32::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(i32::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 4];
-        r.read_exact(&mut b)?;
-        let i = u32::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(u32::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 8];
-        r.read_exact(&mut b)?;
-        let i = i64::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(i64::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 8];
-        r.read_exact(&mut b)?;
-        let i = u64::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(u64::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = u32::read_xdr(r)?;
-        let b = i == 1;
-        Ok(b)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = u32::read_xdr(r)?;
+            let b = i == 1;
+            Ok(b)
+        })
     }
 }
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let i = u32::from(*self); // true = 1, false = 0
-        i.write_xdr(w)?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let i = u32::from(*self); // true = 1, false = 0
+            i.write_xdr(w)
+        })
     }
 }
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = u32::read_xdr(r)?;
-        match i {
-            0 => Ok(None),
-            1 => {
-                let t = T::read_xdr(r)?;
-                Ok(Some(t))
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = u32::read_xdr(r)?;
+            match i {
+                0 => Ok(None),
+                1 => {
+                    let t = T::read_xdr(r)?;
+                    Ok(Some(t))
+                }
+                _ => Err(Error::Invalid),
             }
-            _ => Err(Error::Invalid),
-        }
+        })
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        if let Some(t) = self {
-            1u32.write_xdr(w)?;
-            t.write_xdr(w)?;
-        } else {
-            0u32.write_xdr(w)?;
-        }
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            if let Some(t) = self {
+                1u32.write_xdr(w)?;
+                t.write_xdr(w)?;
+            } else {
+                0u32.write_xdr(w)?;
+            }
+            Ok(())
+        })
     }
 }
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let t = T::read_xdr(r)?;
-        Ok(Box::new(t))
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        T::write_xdr(self, w)?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let mut arr = [0u8; N];
-        r.read_exact(&mut arr)?;
-
-        let pad = &mut [0u8; 3][..pad_len(N)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
-
-        Ok(arr)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let mut arr = [0u8; N];
+            r.read_exact(&mut arr)?;
+            let pad = &mut [0u8; 3][..pad_len(N)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
+            Ok(arr)
+        })
     }
 }
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        w.write_all(self)?;
-        w.write_all(&[0u8; 3][..pad_len(N)])?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            w.write_all(self)?;
+            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            Ok(())
+        })
     }
 }
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let mut vec = Vec::with_capacity(N);
-        for _ in 0..N {
-            let t = T::read_xdr(r)?;
-            vec.push(t);
-        }
-        let arr: [T; N] = vec.try_into().unwrap_or_else(|_: Vec<T>| unreachable!());
-        Ok(arr)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let mut vec = Vec::with_capacity(N);
+            for _ in 0..N {
+                let t = T::read_xdr(r)?;
+                vec.push(t);
+            }
+            let arr: [T; N] = vec.try_into().unwrap_or_else(|_: Vec<T>| unreachable!());
+            Ok(arr)
+        })
     }
 }
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        for t in self {
-            t.write_xdr(w)?;
-        }
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            for t in self {
+                t.write_xdr(w)?;
+            }
+            Ok(())
+        })
     }
 }
 
@@ -980,68 +1113,76 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(VecM(vec))
+            Ok(VecM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = Vec::with_capacity(len as usize);
-        for _ in 0..len {
-            let t = T::read_xdr(r)?;
-            vec.push(t);
-        }
+            let mut vec = Vec::with_capacity(len as usize);
+            for _ in 0..len {
+                let t = T::read_xdr(r)?;
+                vec.push(t);
+            }
 
-        Ok(VecM(vec))
+            Ok(VecM(vec))
+        })
     }
 }
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        for t in &self.0 {
-            t.write_xdr(w)?;
-        }
+            for t in &self.0 {
+                t.write_xdr(w)?;
+            }
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1370,36 +1511,40 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(BytesM(vec))
+            Ok(BytesM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1749,36 +1894,40 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(StringM(vec))
+            Ok(StringM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1799,7 +1948,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -1822,26 +1971,28 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use super::{Error, ReadXdr, VecM, WriteXdr};
+    use super::{DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr};
+
+    const DEPTH_LIMIT: u32 = 10;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1850,8 +2001,8 @@ mod tests {
 
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1862,7 +2013,12 @@ mod tests {
     pub fn vec_u8_write_without_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
-        v.write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+
+        v.write_xdr(&mut DepthLimitedWrite::new(
+            Cursor::new(&mut buf),
+            DEPTH_LIMIT,
+        ))
+        .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1870,28 +2026,32 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+        v.write_xdr(&mut DepthLimitedWrite::new(
+            Cursor::new(&mut buf),
+            DEPTH_LIMIT,
+        ))
+        .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
     #[test]
     pub fn arr_u8_read_without_padding() {
-        let mut buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![2, 2, 2, 2]);
+        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
-        let mut buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![2, 0, 0, 0]);
+        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
-        let mut buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![2, 0, 0]);
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1900,8 +2060,8 @@ mod tests {
 
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
-        let mut buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![2, 3, 0, 0]);
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1912,7 +2072,10 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Cursor::new(&mut buf))
+            .write_xdr(&mut DepthLimitedWrite::new(
+                Cursor::new(&mut buf),
+                DEPTH_LIMIT,
+            ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -1920,14 +2083,19 @@ mod tests {
     #[test]
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
-        [2u8].write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+        [2u8]
+            .write_xdr(&mut DepthLimitedWrite::new(
+                Cursor::new(&mut buf),
+                DEPTH_LIMIT,
+            ))
+            .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
 }
 
 #[cfg(all(test, feature = "std"))]
 mod test {
-    use super::VecM;
+    use super::*;
 
     #[test]
     fn into_option_none() {
@@ -1951,6 +2119,36 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = vec![1].try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+
+    #[test]
+    fn depth_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[should_panic]
+    #[test]
+    fn write_over_depth_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 3);
+        a.write_xdr(&mut buf).unwrap();
+    }
+
+    #[should_panic]
+    #[test]
+    fn read_over_depth_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 5);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 3);
+        let _: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
     }
 }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -41,6 +41,10 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
+/// Depth limit for recursive calls in `Read/WriteXdr`. Mimics the stack depth
+/// and its purpose is to avoid the running program from reaching the Rust's
+/// stack size limit (see https://doc.rust-lang.org/std/thread/#stack-size),
+/// which leads to an unrecoverable `SIGABRT`.
 pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
@@ -174,13 +178,31 @@ where
 {
 }
 
+/// `DepthLimiter` is a trait designed for managing the depth of recursive operations.
+/// It provides a mechanism to limit recursion depth, and defines the behavior upon
+/// entering and leaving a recursion level.
 pub trait DepthLimiter {
+    /// The error type returned by methods when they fail due to exceeding the depth limit.
     type DepthError;
 
+    /// Defines the behavior for entering a new recursion level.
+    /// A `DepthError` is returned if the new level exceeds the depth limit.
     fn enter(&self) -> core::result::Result<(), Self::DepthError>;
 
+    /// Defines the behavior for leaving a recursion level.
     fn leave(&self);
 
+    /// Wraps a given function `f` with depth limiting guards.
+    /// It triggers an `enter` before, and a `leave` after the execution of `f`.
+    ///
+    /// # Parameters
+    ///
+    /// - `f`: The function to be executed under depth limit constraints.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok` with function result if `f` executes without exceeding depth limits,
+    ///   `Err` otherwise.
     fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthError>
     where
         F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthError>,
@@ -192,6 +214,8 @@ pub trait DepthLimiter {
     }
 }
 
+/// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
+/// recursive read operations. It maintains a `depth` state tracking remaining recursion depth.
 #[cfg(feature = "std")]
 pub struct DepthLimitedRead<R: Read> {
     pub inner: R,
@@ -200,6 +224,10 @@ pub struct DepthLimitedRead<R: Read> {
 
 #[cfg(feature = "std")]
 impl<R: Read> DepthLimitedRead<R> {
+    /// Constructs a new `DepthLimitedRead`.
+    ///
+    /// - `inner`: The object implementing the `Read` trait.
+    /// - `depth`: The maximum allowed recursion depth.
     pub fn new(inner: R, depth: u32) -> Self {
         DepthLimitedRead {
             inner,
@@ -212,6 +240,8 @@ impl<R: Read> DepthLimitedRead<R> {
 impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
     type DepthError = Error;
 
+    /// Decrements the depth. If the depth is already zero, an error is returned indicating
+    /// that the maximum depth limit has been exceeded.
     fn enter(&self) -> core::result::Result<(), Error> {
         let depth = *self.depth.borrow();
         if depth == 0 {
@@ -221,6 +251,7 @@ impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
         Ok(())
     }
 
+    /// Increments the depth, without exceeding the initial depth value.
     fn leave(&self) {
         let depth = *self.depth.borrow();
         self.depth.replace(depth.saturating_add(1));
@@ -229,11 +260,14 @@ impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
 
 #[cfg(feature = "std")]
 impl<R: Read> Read for DepthLimitedRead<R> {
+    /// Forwards the read operation to the wrapped object.
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         self.inner.read(buf)
     }
 }
 
+/// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
+/// recursive write operations. It maintains a `depth` state tracking remaining recursion depth.
 #[cfg(feature = "std")]
 pub struct DepthLimitedWrite<W: Write> {
     pub inner: W,
@@ -242,6 +276,10 @@ pub struct DepthLimitedWrite<W: Write> {
 
 #[cfg(feature = "std")]
 impl<W: Write> DepthLimitedWrite<W> {
+    /// Constructs a new `DepthLimitedWrite`.
+    ///
+    /// - `inner`: The object implementing the `Write` trait.
+    /// - `depth`: The maximum allowed recursion depth.
     pub fn new(inner: W, depth: u32) -> Self {
         DepthLimitedWrite {
             inner,
@@ -254,6 +292,8 @@ impl<W: Write> DepthLimitedWrite<W> {
 impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
     type DepthError = Error;
 
+    /// Decrements the depth. If the depth is already zero, an error is returned indicating
+    /// that the maximum depth limit has been exceeded.
     fn enter(&self) -> Result<()> {
         let depth = *self.depth.borrow();
         if depth == 0 {
@@ -263,6 +303,7 @@ impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
         Ok(())
     }
 
+    /// Increments the depth, without exceeding the initial depth value.
     fn leave(&self) {
         let depth = *self.depth.borrow();
         self.depth.replace(depth.saturating_add(1));
@@ -271,10 +312,12 @@ impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
 
 #[cfg(feature = "std")]
 impl<W: Write> Write for DepthLimitedWrite<W> {
+    /// Forwards the write operation to the wrapped object.
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.inner.write(buf)
     }
 
+    /// Forwards the flush operation to the wrapped object.
     fn flush(&mut self) -> std::io::Result<()> {
         self.inner.flush()
     }

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -45,7 +45,8 @@ use std::{
 ///
 /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
 /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+/// For more information about Rust's stack size limit, refer to the
+/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
 pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -41,10 +41,11 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Depth limit for recursive calls in `Read/WriteXdr`. Mimics the stack depth
-/// and its purpose is to avoid the running program from reaching the Rust's
-/// stack size limit (see https://doc.rust-lang.org/std/thread/#stack-size),
-/// which leads to an unrecoverable `SIGABRT`.
+/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+///
+/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+/// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
 pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1,7 +1,7 @@
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
-use core::{cell::RefCell, marker::PhantomData};
+use core::marker::PhantomData;
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -184,15 +184,18 @@ where
 /// It provides a mechanism to limit recursion depth, and defines the behavior upon
 /// entering and leaving a recursion level.
 pub trait DepthLimiter {
-    /// The error type returned by methods when they fail due to exceeding the depth limit.
-    type DepthError;
+    /// A general error type for any type implementing, or an operation under the guard of
+    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
+    /// which is returned from `enter`.
+    type DepthLimiterError;
 
     /// Defines the behavior for entering a new recursion level.
-    /// A `DepthError` is returned if the new level exceeds the depth limit.
-    fn enter(&self) -> core::result::Result<(), Self::DepthError>;
+    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
+    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
 
     /// Defines the behavior for leaving a recursion level.
-    fn leave(&self);
+    /// A `DepthLimiterError` is returned if an error occurs.
+    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
 
     /// Wraps a given function `f` with depth limiting guards.
     /// It triggers an `enter` before, and a `leave` after the execution of `f`.
@@ -203,16 +206,17 @@ pub trait DepthLimiter {
     ///
     /// # Returns
     ///
-    /// - `Ok` with function result if `f` executes without exceeding depth limits,
-    ///   `Err` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthError>
+    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
+    ///         with an error 3. if error occurs on `leave`.
+    ///   `Ok` otherwise.
+    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
     where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthError>,
+        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
     {
         self.enter()?;
-        let res = f(self)?;
-        self.leave();
-        Ok(res)
+        let res = f(self);
+        self.leave()?;
+        res
     }
 }
 
@@ -222,7 +226,7 @@ pub trait DepthLimiter {
 #[cfg(feature = "std")]
 pub struct DepthLimitedRead<R: Read> {
     pub inner: R,
-    pub(crate) depth_remaining: RefCell<u32>,
+    pub(crate) depth_remaining: u32,
 }
 
 #[cfg(feature = "std")]
@@ -234,30 +238,31 @@ impl<R: Read> DepthLimitedRead<R> {
     pub fn new(inner: R, depth_limit: u32) -> Self {
         DepthLimitedRead {
             inner,
-            depth_remaining: RefCell::new(depth_limit),
+            depth_remaining: depth_limit,
         }
     }
 }
 
 #[cfg(feature = "std")]
 impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthError = Error;
+    type DepthLimiterError = Error;
 
     /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
     /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&self) -> core::result::Result<(), Error> {
-        let depth = *self.depth_remaining.borrow();
-        if depth == 0 {
+    fn enter(&mut self) -> core::result::Result<(), Error> {
+        if let Some(depth) = self.depth_remaining.checked_sub(1) {
+            self.depth_remaining = depth;
+        } else {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
-    /// Increments the depth, without exceeding the initial depth value.
-    fn leave(&self) {
-        let depth = *self.depth_remaining.borrow();
-        self.depth_remaining.replace(depth.saturating_add(1));
+    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
+    /// doesn't exceed the initial depth limit.
+    fn leave(&mut self) -> core::result::Result<(), Error> {
+        self.depth_remaining = self.depth_remaining.saturating_add(1);
+        Ok(())
     }
 }
 
@@ -275,7 +280,7 @@ impl<R: Read> Read for DepthLimitedRead<R> {
 #[cfg(feature = "std")]
 pub struct DepthLimitedWrite<W: Write> {
     pub inner: W,
-    pub(crate) depth_remaining: RefCell<u32>,
+    pub(crate) depth_remaining: u32,
 }
 
 #[cfg(feature = "std")]
@@ -287,30 +292,31 @@ impl<W: Write> DepthLimitedWrite<W> {
     pub fn new(inner: W, depth_limit: u32) -> Self {
         DepthLimitedWrite {
             inner,
-            depth_remaining: RefCell::new(depth_limit),
+            depth_remaining: depth_limit,
         }
     }
 }
 
 #[cfg(feature = "std")]
 impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthError = Error;
+    type DepthLimiterError = Error;
 
     /// Decrements the `depth_remaining`. If the depth is already zero, an error is
     /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&self) -> Result<()> {
-        let depth = *self.depth_remaining.borrow();
-        if depth == 0 {
+    fn enter(&mut self) -> Result<()> {
+        if let Some(depth) = self.depth_remaining.checked_sub(1) {
+            self.depth_remaining = depth;
+        } else {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
-    /// Increments the depth, without exceeding the initial depth value.
-    fn leave(&self) {
-        let depth = *self.depth_remaining.borrow();
-        self.depth_remaining.replace(depth.saturating_add(1));
+    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
+    /// doesn't exceed the initial depth limit.
+    fn leave(&mut self) -> core::result::Result<(), Error> {
+        self.depth_remaining = self.depth_remaining.saturating_add(1);
+        Ok(())
     }
 }
 
@@ -339,7 +345,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
         Self {
             reader: DepthLimitedRead {
                 inner: BufReader::new(r),
-                depth_remaining: RefCell::new(depth_limit),
+                depth_remaining: depth_limit,
             },
             _s: PhantomData,
         }
@@ -411,7 +417,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining.take(),
+            r.depth_remaining,
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -455,7 +461,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining.take(),
+            r.depth_remaining,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -531,7 +537,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining.take())
+        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -541,7 +547,7 @@ where
         r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining.take())
+        ReadXdrIter::new(dec, r.depth_remaining)
     }
 
     /// Construct the type from the XDR bytes, specifying a depth limit.

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -172,8 +172,6 @@ where
 {
 }
 
-pub static mut DEFAULT_DEPTH_LIMIT: u32 = 100;
-
 pub trait DepthLimiter {
     type DepthError;
 
@@ -502,13 +500,10 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        unsafe {
-            let mut cursor =
-                DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_DEPTH_LIMIT);
-            let t = Self::read_xdr_to_end(&mut cursor)?;
-            Ok(t)
-        }
+    fn from_xdr(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+        let t = Self::read_xdr_to_end(&mut cursor)?;
+        Ok(t)
     }
 
     /// Construct the type from the XDR bytes base64 encoded.
@@ -516,16 +511,14 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        unsafe {
-            let mut dec = DepthLimitedRead::new(
-                base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-                DEFAULT_DEPTH_LIMIT,
-            );
-            let t = Self::read_xdr_to_end(&mut dec)?;
-            Ok(t)
-        }
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            depth_limit,
+        );
+        let t = Self::read_xdr_to_end(&mut dec)?;
+        Ok(t)
     }
 }
 
@@ -534,26 +527,22 @@ pub trait WriteXdr {
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        unsafe {
-            let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), DEFAULT_DEPTH_LIMIT);
-            self.write_xdr(&mut cursor)?;
-            let bytes = cursor.inner.into_inner();
-            Ok(bytes)
-        }
+    fn to_xdr(&self, depth_limit: u32) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
+        self.write_xdr(&mut cursor)?;
+        let bytes = cursor.inner.into_inner();
+        Ok(bytes)
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        unsafe {
-            let mut enc = DepthLimitedWrite::new(
-                base64::write::EncoderStringWriter::new(base64::STANDARD),
-                DEFAULT_DEPTH_LIMIT,
-            );
-            self.write_xdr(&mut enc)?;
-            let b64 = enc.inner.into_inner();
-            Ok(b64)
-        }
+    fn to_xdr_base64(&self, depth_limit: u32) -> Result<String> {
+        let mut enc = DepthLimitedWrite::new(
+            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            depth_limit,
+        );
+        self.write_xdr(&mut enc)?;
+        let b64 = enc.inner.into_inner();
+        Ok(b64)
     }
 }
 
@@ -1984,51 +1973,41 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use super::{
-        DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr, DEFAULT_DEPTH_LIMIT,
-    };
+    use super::{DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr};
+
+    const DEPTH_LIMIT: u32 = 10;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        unsafe {
-            let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_DEPTH_LIMIT))
-                .unwrap();
-            assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
-        }
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        unsafe {
-            let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_DEPTH_LIMIT))
-                .unwrap();
-            assert_eq!(v.to_vec(), vec![2]);
-        }
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        unsafe {
-            let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_DEPTH_LIMIT));
-            match res {
-                Err(Error::Io(_)) => (),
-                _ => panic!("expected IO error got {res:?}"),
-            }
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        match res {
+            Err(Error::Io(_)) => (),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        unsafe {
-            let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_DEPTH_LIMIT));
-            match res {
-                Err(Error::NonZeroPadding) => (),
-                _ => panic!("expected NonZeroPadding got {res:?}"),
-            }
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        match res {
+            Err(Error::NonZeroPadding) => (),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 
@@ -2037,100 +2016,82 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        unsafe {
-            v.write_xdr(&mut DepthLimitedWrite::new(
-                Cursor::new(&mut buf),
-                DEFAULT_DEPTH_LIMIT,
-            ))
-            .unwrap();
-            assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        }
+        v.write_xdr(&mut DepthLimitedWrite::new(
+            Cursor::new(&mut buf),
+            DEPTH_LIMIT,
+        ))
+        .unwrap();
+        assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        unsafe {
-            v.write_xdr(&mut DepthLimitedWrite::new(
-                Cursor::new(&mut buf),
-                DEFAULT_DEPTH_LIMIT,
-            ))
-            .unwrap();
-            assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        }
+        v.write_xdr(&mut DepthLimitedWrite::new(
+            Cursor::new(&mut buf),
+            DEPTH_LIMIT,
+        ))
+        .unwrap();
+        assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        unsafe {
-            let v =
-                <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_DEPTH_LIMIT)).unwrap();
-            assert_eq!(v, [2, 2, 2, 2]);
-        }
+        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        unsafe {
-            let v =
-                <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_DEPTH_LIMIT)).unwrap();
-            assert_eq!(v, [2]);
-        }
+        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        unsafe {
-            let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_DEPTH_LIMIT));
-            match res {
-                Err(Error::Io(_)) => (),
-                _ => panic!("expected IO error got {res:?}"),
-            }
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        match res {
+            Err(Error::Io(_)) => (),
+            _ => panic!("expected IO error got {res:?}"),
         }
     }
 
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        unsafe {
-            let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_DEPTH_LIMIT));
-            match res {
-                Err(Error::NonZeroPadding) => (),
-                _ => panic!("expected NonZeroPadding got {res:?}"),
-            }
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        match res {
+            Err(Error::NonZeroPadding) => (),
+            _ => panic!("expected NonZeroPadding got {res:?}"),
         }
     }
 
     #[test]
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
-        unsafe {
-            [2u8, 2, 2, 2]
-                .write_xdr(&mut DepthLimitedWrite::new(
-                    Cursor::new(&mut buf),
-                    DEFAULT_DEPTH_LIMIT,
-                ))
-                .unwrap();
-            assert_eq!(buf, vec![2, 2, 2, 2]);
-        }
+        [2u8, 2, 2, 2]
+            .write_xdr(&mut DepthLimitedWrite::new(
+                Cursor::new(&mut buf),
+                DEPTH_LIMIT,
+            ))
+            .unwrap();
+        assert_eq!(buf, vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
-        unsafe {
-            [2u8]
-                .write_xdr(&mut DepthLimitedWrite::new(
-                    Cursor::new(&mut buf),
-                    DEFAULT_DEPTH_LIMIT,
-                ))
-                .unwrap();
-            assert_eq!(buf, vec![2, 0, 0, 0]);
-        }
+        [2u8]
+            .write_xdr(&mut DepthLimitedWrite::new(
+                Cursor::new(&mut buf),
+                DEPTH_LIMIT,
+            ))
+            .unwrap();
+        assert_eq!(buf, vec![2, 0, 0, 0]);
     }
 }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -46,7 +46,7 @@ use std::{
 /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
 /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
 /// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
+pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
@@ -560,7 +560,7 @@ where
     /// deserialization.
     #[cfg(feature = "std")]
     fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_MAX_DEPTH_LIMIT)
+        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 
     /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
@@ -584,7 +584,7 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_MAX_DEPTH_LIMIT)
+        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -602,7 +602,7 @@ pub trait WriteXdr {
 
     #[cfg(feature = "std")]
     fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 
     #[cfg(feature = "base64")]
@@ -618,7 +618,7 @@ pub trait WriteXdr {
 
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -2051,29 +2051,32 @@ mod tests {
 
     use super::{
         DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_MAX_DEPTH_LIMIT,
+        DEFAULT_XDR_RW_DEPTH_LIMIT,
     };
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
-            .unwrap();
+        let v =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+                .unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
-            .unwrap();
+        let v =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+                .unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2083,7 +2086,8 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2097,7 +2101,7 @@ mod tests {
 
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
@@ -2109,7 +2113,7 @@ mod tests {
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
@@ -2118,23 +2122,23 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v =
-            <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v =
-            <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2144,7 +2148,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2157,7 +2161,7 @@ mod tests {
         [2u8, 2, 2, 2]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEFAULT_MAX_DEPTH_LIMIT,
+                DEFAULT_XDR_RW_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2169,7 +2173,7 @@ mod tests {
         [2u8]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEFAULT_MAX_DEPTH_LIMIT,
+                DEFAULT_XDR_RW_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -11,10 +11,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
-use super::depth_limiter::*;
-
-#[cfg(feature = "std")]
-use core::marker::PhantomData;
+use core::{cell::RefCell, marker::PhantomData};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -53,6 +50,8 @@ use std::{
     error, io,
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
+
+pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
@@ -185,6 +184,112 @@ where
 {
 }
 
+pub trait DepthLimiter {
+    type DepthError;
+
+    fn enter(&self) -> core::result::Result<(), Self::DepthError>;
+
+    fn leave(&self);
+
+    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthError>
+    where
+        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthError>,
+    {
+        self.enter()?;
+        let res = f(self)?;
+        self.leave();
+        Ok(res)
+    }
+}
+
+#[cfg(feature = "std")]
+pub struct DepthLimitedRead<R: Read> {
+    pub inner: R,
+    pub(crate) depth: RefCell<u32>,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> DepthLimitedRead<R> {
+    pub fn new(inner: R, depth: u32) -> Self {
+        DepthLimitedRead {
+            inner,
+            depth: RefCell::new(depth),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
+    type DepthError = Error;
+
+    fn enter(&self) -> core::result::Result<(), Error> {
+        let depth = *self.depth.borrow();
+        if depth == 0 {
+            return Err(Error::DepthLimitExceeded);
+        }
+        self.depth.replace(depth - 1);
+        Ok(())
+    }
+
+    fn leave(&self) {
+        let depth = *self.depth.borrow();
+        self.depth.replace(depth.saturating_add(1));
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for DepthLimitedRead<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+pub struct DepthLimitedWrite<W: Write> {
+    pub inner: W,
+    pub(crate) depth: RefCell<u32>,
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> DepthLimitedWrite<W> {
+    pub fn new(inner: W, depth: u32) -> Self {
+        DepthLimitedWrite {
+            inner,
+            depth: RefCell::new(depth),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
+    type DepthError = Error;
+
+    fn enter(&self) -> Result<()> {
+        let depth = *self.depth.borrow();
+        if depth == 0 {
+            return Err(Error::DepthLimitExceeded);
+        }
+        self.depth.replace(depth - 1);
+        Ok(())
+    }
+
+    fn leave(&self) {
+        let depth = *self.depth.borrow();
+        self.depth.replace(depth.saturating_add(1));
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for DepthLimitedWrite<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
     reader: DepthLimitedRead<BufReader<R>>,
@@ -193,9 +298,12 @@ pub struct ReadXdrIter<R: Read, S: ReadXdr> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth_limit: u32) -> Self {
+    fn new(r: R, depth: u32) -> Self {
         Self {
-            reader: DepthLimitedRead::new(BufReader::new(r), depth_limit),
+            reader: DepthLimitedRead {
+                inner: BufReader::new(r),
+                depth: RefCell::new(depth),
+            },
             _s: PhantomData,
         }
     }
@@ -263,10 +371,10 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
-            base64::read::DecoderReader::new(r, base64::STANDARD),
-            depth_limit,
+            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            r.depth.take(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -307,10 +415,10 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
-            base64::read::DecoderReader::new(r, base64::STANDARD),
-            depth_limit,
+            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            r.depth.take(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -385,19 +493,18 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut R, depth_limit: u32) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(r, depth_limit)
+    fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
+        ReadXdrIter::new(&mut r.inner, r.depth.take())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
     /// values that are read into the implementing type.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
-        r: &mut R,
-        depth_limit: u32,
+        r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
-        ReadXdrIter::new(dec, depth_limit)
+        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        ReadXdrIter::new(dec, r.depth.take())
     }
 
     /// Construct the type from the XDR bytes.
@@ -405,8 +512,9 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
+        let mut cursor =
+            DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
@@ -416,11 +524,11 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            depth_limit,
+            DEFAULT_MAX_DEPTH_LIMIT,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -432,18 +540,18 @@ pub trait WriteXdr {
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, depth_limit: u32) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), DEFAULT_MAX_DEPTH_LIMIT);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, depth_limit: u32) -> Result<String> {
+    fn to_xdr_base64(&self) -> Result<String> {
         let mut enc = DepthLimitedWrite::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            depth_limit,
+            DEFAULT_MAX_DEPTH_LIMIT,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
@@ -604,12 +712,13 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         w.with_limited_depth(|w| {
-            Ok(if let Some(t) = self {
+            if let Some(t) = self {
                 1u32.write_xdr(w)?;
                 t.write_xdr(w)?;
             } else {
                 0u32.write_xdr(w)?;
-            })
+            }
+            Ok(())
         })
     }
 }
@@ -1877,30 +1986,31 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use crate::{DepthLimitedRead, DepthLimitedWrite};
-
-    use super::{Error, ReadXdr, VecM, WriteXdr};
-
-    const DEPTH_LIMIT: u32 = 10;
+    use super::{
+        DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
+        DEFAULT_MAX_DEPTH_LIMIT,
+    };
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1910,7 +2020,7 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1924,7 +2034,7 @@ mod tests {
 
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEPTH_LIMIT,
+            DEFAULT_MAX_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
@@ -1936,7 +2046,7 @@ mod tests {
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEPTH_LIMIT,
+            DEFAULT_MAX_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
@@ -1945,21 +2055,23 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v =
+            <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v =
+            <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1969,7 +2081,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1982,7 +2094,7 @@ mod tests {
         [2u8, 2, 2, 2]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEPTH_LIMIT,
+                DEFAULT_MAX_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -1994,7 +2106,7 @@ mod tests {
         [2u8]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEPTH_LIMIT,
+                DEFAULT_MAX_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2040,23 +2152,32 @@ mod test {
         assert_eq!(a, a_back);
     }
 
-    #[should_panic]
     #[test]
     fn write_over_depth_limit_fail() {
+        let depth_limit = 3;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 3);
-        a.write_xdr(&mut buf).unwrap();
+        let mut buf = DepthLimitedWrite::new(Vec::new(), depth_limit);
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::DepthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
     }
 
-    #[should_panic]
     #[test]
     fn read_over_depth_limit_fail() {
+        let read_depth_limit = 3;
+        let write_depth_limit = 5;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 5);
+        let mut buf = DepthLimitedWrite::new(Vec::new(), write_depth_limit);
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 3);
-        let _: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), read_depth_limit);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::DepthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
     }
 }
 
@@ -2165,7 +2286,7 @@ impl ReadXdr for AccountFlags {
 impl WriteXdr for AccountFlags {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
-        w.with_limited_write(|w| {
+        w.with_limited_depth(|w| {
             let i: i32 = (*self).into();
             i.write_xdr(w)
         })
@@ -2244,16 +2365,13 @@ impl Type {
     #[allow(clippy::too_many_lines)]
     pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
         match v {
-            TypeVariant::AccountFlags => r.with_limited_depth(|r| Ok(Self::AccountFlags(Box::new(AccountFlags::read_xdr(r)?))))?,
+            TypeVariant::AccountFlags => r.with_limited_depth(|r| Ok(Self::AccountFlags(Box::new(AccountFlags::read_xdr(r)?)))),
         }
     }
 
     #[cfg(feature = "base64")]
-    pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
-          base64::read::DecoderReader::new(r, base64::STANDARD),
-          depth_limit,
-        );
+    pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
         let t = Self::read_xdr(v, &mut dec)?;
         Ok(t)
     }
@@ -2271,51 +2389,48 @@ impl Type {
     }
 
     #[cfg(feature = "base64")]
-    pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
-          base64::read::DecoderReader::new(r, base64::STANDARD),
-          depth_limit,
-        );
+    pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
     }
 
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit: u32) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+    pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(r, depth_limit).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
     }
 
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+    pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, Frame<AccountFlags>>::new(r, depth_limit).map(|r| r.map(|t| Self::AccountFlags(Box::new(t.0))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, Frame<AccountFlags>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t.0))))),
         }
     }
 
     #[cfg(feature = "base64")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-        let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+    pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec, depth_limit).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
     }
 
     #[cfg(feature = "std")]
-    pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, depth_limit: u32) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+    pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
+        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
         let t = Self::read_xdr_to_end(v, &mut cursor)?;
         Ok(t)
     }
 
     #[cfg(feature = "base64")]
-    pub fn from_xdr_base64(v: TypeVariant, b64: String, depth_limit: u32) -> Result<Self> {
+    pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), depth_limit);
+        let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_MAX_DEPTH_LIMIT);
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
     }

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -55,7 +55,8 @@ use std::{
 ///
 /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
 /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+/// For more information about Rust's stack size limit, refer to the
+/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
 pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -56,7 +56,7 @@ use std::{
 /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
 /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
 /// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
+pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
@@ -570,7 +570,7 @@ where
     /// deserialization.
     #[cfg(feature = "std")]
     fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_MAX_DEPTH_LIMIT)
+        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 
     /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
@@ -594,7 +594,7 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_MAX_DEPTH_LIMIT)
+        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -612,7 +612,7 @@ pub trait WriteXdr {
 
     #[cfg(feature = "std")]
     fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 
     #[cfg(feature = "base64")]
@@ -628,7 +628,7 @@ pub trait WriteXdr {
 
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -2061,29 +2061,32 @@ mod tests {
 
     use super::{
         DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_MAX_DEPTH_LIMIT,
+        DEFAULT_XDR_RW_DEPTH_LIMIT,
     };
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
-            .unwrap();
+        let v =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+                .unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
-            .unwrap();
+        let v =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+                .unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2093,7 +2096,8 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2107,7 +2111,7 @@ mod tests {
 
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
@@ -2119,7 +2123,7 @@ mod tests {
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
@@ -2128,23 +2132,23 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v =
-            <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v =
-            <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2154,7 +2158,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2167,7 +2171,7 @@ mod tests {
         [2u8, 2, 2, 2]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEFAULT_MAX_DEPTH_LIMIT,
+                DEFAULT_XDR_RW_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2179,7 +2183,7 @@ mod tests {
         [2u8]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEFAULT_MAX_DEPTH_LIMIT,
+                DEFAULT_XDR_RW_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2495,7 +2499,7 @@ impl Type {
 
     #[cfg(feature = "std")]
     pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
+        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
         let t = Self::read_xdr_to_end(v, &mut cursor)?;
         Ok(t)
     }
@@ -2503,7 +2507,7 @@ impl Type {
     #[cfg(feature = "base64")]
     pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_MAX_DEPTH_LIMIT);
+        let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
     }

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -11,7 +11,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
-use core::{cell::RefCell, marker::PhantomData};
+use core::marker::PhantomData;
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -194,15 +194,18 @@ where
 /// It provides a mechanism to limit recursion depth, and defines the behavior upon
 /// entering and leaving a recursion level.
 pub trait DepthLimiter {
-    /// The error type returned by methods when they fail due to exceeding the depth limit.
-    type DepthError;
+    /// A general error type for any type implementing, or an operation under the guard of
+    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
+    /// which is returned from `enter`.
+    type DepthLimiterError;
 
     /// Defines the behavior for entering a new recursion level.
-    /// A `DepthError` is returned if the new level exceeds the depth limit.
-    fn enter(&self) -> core::result::Result<(), Self::DepthError>;
+    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
+    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
 
     /// Defines the behavior for leaving a recursion level.
-    fn leave(&self);
+    /// A `DepthLimiterError` is returned if an error occurs.
+    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
 
     /// Wraps a given function `f` with depth limiting guards.
     /// It triggers an `enter` before, and a `leave` after the execution of `f`.
@@ -213,16 +216,17 @@ pub trait DepthLimiter {
     ///
     /// # Returns
     ///
-    /// - `Ok` with function result if `f` executes without exceeding depth limits,
-    ///   `Err` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthError>
+    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
+    ///         with an error 3. if error occurs on `leave`.
+    ///   `Ok` otherwise.
+    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
     where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthError>,
+        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
     {
         self.enter()?;
-        let res = f(self)?;
-        self.leave();
-        Ok(res)
+        let res = f(self);
+        self.leave()?;
+        res
     }
 }
 
@@ -232,7 +236,7 @@ pub trait DepthLimiter {
 #[cfg(feature = "std")]
 pub struct DepthLimitedRead<R: Read> {
     pub inner: R,
-    pub(crate) depth_remaining: RefCell<u32>,
+    pub(crate) depth_remaining: u32,
 }
 
 #[cfg(feature = "std")]
@@ -244,30 +248,31 @@ impl<R: Read> DepthLimitedRead<R> {
     pub fn new(inner: R, depth_limit: u32) -> Self {
         DepthLimitedRead {
             inner,
-            depth_remaining: RefCell::new(depth_limit),
+            depth_remaining: depth_limit,
         }
     }
 }
 
 #[cfg(feature = "std")]
 impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthError = Error;
+    type DepthLimiterError = Error;
 
     /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
     /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&self) -> core::result::Result<(), Error> {
-        let depth = *self.depth_remaining.borrow();
-        if depth == 0 {
+    fn enter(&mut self) -> core::result::Result<(), Error> {
+        if let Some(depth) = self.depth_remaining.checked_sub(1) {
+            self.depth_remaining = depth;
+        } else {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
-    /// Increments the depth, without exceeding the initial depth value.
-    fn leave(&self) {
-        let depth = *self.depth_remaining.borrow();
-        self.depth_remaining.replace(depth.saturating_add(1));
+    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
+    /// doesn't exceed the initial depth limit.
+    fn leave(&mut self) -> core::result::Result<(), Error> {
+        self.depth_remaining = self.depth_remaining.saturating_add(1);
+        Ok(())
     }
 }
 
@@ -285,7 +290,7 @@ impl<R: Read> Read for DepthLimitedRead<R> {
 #[cfg(feature = "std")]
 pub struct DepthLimitedWrite<W: Write> {
     pub inner: W,
-    pub(crate) depth_remaining: RefCell<u32>,
+    pub(crate) depth_remaining: u32,
 }
 
 #[cfg(feature = "std")]
@@ -297,30 +302,31 @@ impl<W: Write> DepthLimitedWrite<W> {
     pub fn new(inner: W, depth_limit: u32) -> Self {
         DepthLimitedWrite {
             inner,
-            depth_remaining: RefCell::new(depth_limit),
+            depth_remaining: depth_limit,
         }
     }
 }
 
 #[cfg(feature = "std")]
 impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthError = Error;
+    type DepthLimiterError = Error;
 
     /// Decrements the `depth_remaining`. If the depth is already zero, an error is
     /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&self) -> Result<()> {
-        let depth = *self.depth_remaining.borrow();
-        if depth == 0 {
+    fn enter(&mut self) -> Result<()> {
+        if let Some(depth) = self.depth_remaining.checked_sub(1) {
+            self.depth_remaining = depth;
+        } else {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
-    /// Increments the depth, without exceeding the initial depth value.
-    fn leave(&self) {
-        let depth = *self.depth_remaining.borrow();
-        self.depth_remaining.replace(depth.saturating_add(1));
+    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
+    /// doesn't exceed the initial depth limit.
+    fn leave(&mut self) -> core::result::Result<(), Error> {
+        self.depth_remaining = self.depth_remaining.saturating_add(1);
+        Ok(())
     }
 }
 
@@ -349,7 +355,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
         Self {
             reader: DepthLimitedRead {
                 inner: BufReader::new(r),
-                depth_remaining: RefCell::new(depth_limit),
+                depth_remaining: depth_limit,
             },
             _s: PhantomData,
         }
@@ -421,7 +427,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining.take(),
+            r.depth_remaining,
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -465,7 +471,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining.take(),
+            r.depth_remaining,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -541,7 +547,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining.take())
+        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -551,7 +557,7 @@ where
         r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining.take())
+        ReadXdrIter::new(dec, r.depth_remaining)
     }
 
     /// Construct the type from the XDR bytes, specifying a depth limit.
@@ -2449,7 +2455,7 @@ impl Type {
 
     #[cfg(feature = "base64")]
     pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
+        let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
         let t = Self::read_xdr(v, &mut dec)?;
         Ok(t)
     }
@@ -2468,7 +2474,7 @@ impl Type {
 
     #[cfg(feature = "base64")]
     pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
+        let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
     }
@@ -2477,7 +2483,7 @@ impl Type {
     #[allow(clippy::too_many_lines)]
     pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
     }
 
@@ -2485,7 +2491,7 @@ impl Type {
     #[allow(clippy::too_many_lines)]
     pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, Frame<AccountFlags>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t.0))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, Frame<AccountFlags>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::AccountFlags(Box::new(t.0))))),
         }
     }
 
@@ -2494,7 +2500,7 @@ impl Type {
     pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
     }
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -11,6 +11,9 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
+use super::depth_limiter::*;
+
+#[cfg(feature = "std")]
 use core::marker::PhantomData;
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
@@ -66,6 +69,7 @@ pub enum Error {
     InvalidHex,
     #[cfg(feature = "std")]
     Io(io::Error),
+    DepthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -109,6 +113,7 @@ impl fmt::Display for Error {
             Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{e}"),
+            Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
         }
     }
 }
@@ -182,15 +187,15 @@ where
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: BufReader<R>,
+    reader: DepthLimitedRead<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R) -> Self {
+    fn new(r: R, depth_limit: u32) -> Self {
         Self {
-            reader: BufReader::new(r),
+            reader: DepthLimitedRead::new(BufReader::new(r), depth_limit),
             _s: PhantomData,
         }
     }
@@ -214,7 +219,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.fill_buf() {
+        match self.reader.inner.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -224,7 +229,8 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
             Ok([..]) => (),
         };
         // Read the buf into the type.
-        match S::read_xdr(&mut self.reader) {
+        let r = self.reader.with_limited_depth(|dlr| S::read_xdr(dlr));
+        match r {
             Ok(s) => Some(Ok(s)),
             Err(e) => Some(Err(e)),
         }
@@ -247,18 +253,21 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     ///
-    /// Use [`ReadXdr::read_xdr_to_end`] when the intent is for all bytes in the
+    /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64(r: &mut impl Read) -> Result<Self> {
-        let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+    fn read_xdr_base64(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(r, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
     }
@@ -282,7 +291,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -298,8 +307,11 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end(r: &mut impl Read) -> Result<Self> {
-        let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+    fn read_xdr_base64_to_end(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(r, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
@@ -316,10 +328,10 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     ///
-    /// Use [`ReadXdr::read_xdr_into_to_end`] when the intent is for all bytes
+    /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -343,7 +355,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end(&mut self, r: &mut impl Read) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -373,8 +385,8 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut R) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(r)
+    fn read_xdr_iter<R: Read>(r: &mut R, depth_limit: u32) -> ReadXdrIter<&mut R, Self> {
+        ReadXdrIter::new(r, depth_limit)
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -382,9 +394,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut R,
+        depth_limit: u32,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
-        ReadXdrIter::new(dec)
+        ReadXdrIter::new(dec, depth_limit)
     }
 
     /// Construct the type from the XDR bytes.
@@ -392,8 +405,8 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        let mut cursor = Cursor::new(bytes.as_ref());
+    fn from_xdr(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
@@ -403,9 +416,12 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
@@ -413,21 +429,24 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        let mut cursor = Cursor::new(vec![]);
+    fn to_xdr(&self, depth_limit: u32) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
         self.write_xdr(&mut cursor)?;
-        let bytes = cursor.into_inner();
+        let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        let mut enc = base64::write::EncoderStringWriter::new(base64::STANDARD);
+    fn to_xdr_base64(&self, depth_limit: u32) -> Result<String> {
+        let mut enc = DepthLimitedWrite::new(
+            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            depth_limit,
+        );
         self.write_xdr(&mut enc)?;
-        let b64 = enc.into_inner();
+        let b64 = enc.inner.into_inner();
         Ok(b64)
     }
 }
@@ -441,229 +460,239 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 4];
-        r.read_exact(&mut b)?;
-        let i = i32::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(i32::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 4];
-        r.read_exact(&mut b)?;
-        let i = u32::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(u32::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 8];
-        r.read_exact(&mut b)?;
-        let i = i64::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(i64::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 8];
-        r.read_exact(&mut b)?;
-        let i = u64::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(u64::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = u32::read_xdr(r)?;
-        let b = i == 1;
-        Ok(b)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = u32::read_xdr(r)?;
+            let b = i == 1;
+            Ok(b)
+        })
     }
 }
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let i = u32::from(*self); // true = 1, false = 0
-        i.write_xdr(w)?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let i = u32::from(*self); // true = 1, false = 0
+            i.write_xdr(w)
+        })
     }
 }
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = u32::read_xdr(r)?;
-        match i {
-            0 => Ok(None),
-            1 => {
-                let t = T::read_xdr(r)?;
-                Ok(Some(t))
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = u32::read_xdr(r)?;
+            match i {
+                0 => Ok(None),
+                1 => {
+                    let t = T::read_xdr(r)?;
+                    Ok(Some(t))
+                }
+                _ => Err(Error::Invalid),
             }
-            _ => Err(Error::Invalid),
-        }
+        })
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        if let Some(t) = self {
-            1u32.write_xdr(w)?;
-            t.write_xdr(w)?;
-        } else {
-            0u32.write_xdr(w)?;
-        }
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            Ok(if let Some(t) = self {
+                1u32.write_xdr(w)?;
+                t.write_xdr(w)?;
+            } else {
+                0u32.write_xdr(w)?;
+            })
+        })
     }
 }
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let t = T::read_xdr(r)?;
-        Ok(Box::new(t))
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        T::write_xdr(self, w)?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let mut arr = [0u8; N];
-        r.read_exact(&mut arr)?;
-
-        let pad = &mut [0u8; 3][..pad_len(N)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
-
-        Ok(arr)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let mut arr = [0u8; N];
+            r.read_exact(&mut arr)?;
+            let pad = &mut [0u8; 3][..pad_len(N)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
+            Ok(arr)
+        })
     }
 }
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        w.write_all(self)?;
-        w.write_all(&[0u8; 3][..pad_len(N)])?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            w.write_all(self)?;
+            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            Ok(())
+        })
     }
 }
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let mut vec = Vec::with_capacity(N);
-        for _ in 0..N {
-            let t = T::read_xdr(r)?;
-            vec.push(t);
-        }
-        let arr: [T; N] = vec.try_into().unwrap_or_else(|_: Vec<T>| unreachable!());
-        Ok(arr)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let mut vec = Vec::with_capacity(N);
+            for _ in 0..N {
+                let t = T::read_xdr(r)?;
+                vec.push(t);
+            }
+            let arr: [T; N] = vec.try_into().unwrap_or_else(|_: Vec<T>| unreachable!());
+            Ok(arr)
+        })
     }
 }
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        for t in self {
-            t.write_xdr(w)?;
-        }
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            for t in self {
+                t.write_xdr(w)?;
+            }
+            Ok(())
+        })
     }
 }
 
@@ -990,68 +1019,76 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(VecM(vec))
+            Ok(VecM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = Vec::with_capacity(len as usize);
-        for _ in 0..len {
-            let t = T::read_xdr(r)?;
-            vec.push(t);
-        }
+            let mut vec = Vec::with_capacity(len as usize);
+            for _ in 0..len {
+                let t = T::read_xdr(r)?;
+                vec.push(t);
+            }
 
-        Ok(VecM(vec))
+            Ok(VecM(vec))
+        })
     }
 }
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        for t in &self.0 {
-            t.write_xdr(w)?;
-        }
+            for t in &self.0 {
+                t.write_xdr(w)?;
+            }
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1380,36 +1417,40 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(BytesM(vec))
+            Ok(BytesM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1759,36 +1800,40 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(StringM(vec))
+            Ok(StringM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1809,7 +1854,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -1832,26 +1877,30 @@ where
 mod tests {
     use std::io::Cursor;
 
+    use crate::{DepthLimitedRead, DepthLimitedWrite};
+
     use super::{Error, ReadXdr, VecM, WriteXdr};
+
+    const DEPTH_LIMIT: u32 = 10;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1860,8 +1909,8 @@ mod tests {
 
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1872,7 +1921,12 @@ mod tests {
     pub fn vec_u8_write_without_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
-        v.write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+
+        v.write_xdr(&mut DepthLimitedWrite::new(
+            Cursor::new(&mut buf),
+            DEPTH_LIMIT,
+        ))
+        .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1880,28 +1934,32 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+        v.write_xdr(&mut DepthLimitedWrite::new(
+            Cursor::new(&mut buf),
+            DEPTH_LIMIT,
+        ))
+        .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
     #[test]
     pub fn arr_u8_read_without_padding() {
-        let mut buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![2, 2, 2, 2]);
+        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
-        let mut buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![2, 0, 0, 0]);
+        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
-        let mut buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![2, 0, 0]);
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1910,8 +1968,8 @@ mod tests {
 
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
-        let mut buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![2, 3, 0, 0]);
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1922,7 +1980,10 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Cursor::new(&mut buf))
+            .write_xdr(&mut DepthLimitedWrite::new(
+                Cursor::new(&mut buf),
+                DEPTH_LIMIT,
+            ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -1930,14 +1991,19 @@ mod tests {
     #[test]
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
-        [2u8].write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+        [2u8]
+            .write_xdr(&mut DepthLimitedWrite::new(
+                Cursor::new(&mut buf),
+                DEPTH_LIMIT,
+            ))
+            .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
 }
 
 #[cfg(all(test, feature = "std"))]
 mod test {
-    use super::VecM;
+    use super::*;
 
     #[test]
     fn into_option_none() {
@@ -1961,6 +2027,36 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = vec![1].try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+
+    #[test]
+    fn depth_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[should_panic]
+    #[test]
+    fn write_over_depth_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 3);
+        a.write_xdr(&mut buf).unwrap();
+    }
+
+    #[should_panic]
+    #[test]
+    fn read_over_depth_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 5);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 3);
+        let _: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
     }
 }
 
@@ -2057,18 +2153,22 @@ impl From<AccountFlags> for i32 {
 
 impl ReadXdr for AccountFlags {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let e = i32::read_xdr(r)?;
-        let v: Self = e.try_into()?;
-        Ok(v)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let e = i32::read_xdr(r)?;
+            let v: Self = e.try_into()?;
+            Ok(v)
+        })
     }
 }
 
 impl WriteXdr for AccountFlags {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let i: i32 = (*self).into();
-        i.write_xdr(w)
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_write(|w| {
+            let i: i32 = (*self).into();
+            i.write_xdr(w)
+        })
     }
 }
 
@@ -2142,21 +2242,24 @@ impl Type {
 
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
+    pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
         match v {
-            TypeVariant::AccountFlags => Ok(Self::AccountFlags(Box::new(AccountFlags::read_xdr(r)?))),
+            TypeVariant::AccountFlags => r.with_limited_depth(|r| Ok(Self::AccountFlags(Box::new(AccountFlags::read_xdr(r)?))))?,
         }
     }
 
     #[cfg(feature = "base64")]
-    pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
-        let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+    pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+        let mut dec = DepthLimitedRead::new(
+          base64::read::DecoderReader::new(r, base64::STANDARD),
+          depth_limit,
+        );
         let t = Self::read_xdr(v, &mut dec)?;
         Ok(t)
     }
 
     #[cfg(feature = "std")]
-    pub fn read_xdr_to_end(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
+    pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let s = Self::read_xdr(v, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -2168,48 +2271,51 @@ impl Type {
     }
 
     #[cfg(feature = "base64")]
-    pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
-        let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+    pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+        let mut dec = DepthLimitedRead::new(
+          base64::read::DecoderReader::new(r, base64::STANDARD),
+          depth_limit,
+        );
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
     }
 
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+    pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit: u32) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(r).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(r, depth_limit).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
     }
 
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+    pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, Frame<AccountFlags>>::new(r).map(|r| r.map(|t| Self::AccountFlags(Box::new(t.0))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, Frame<AccountFlags>>::new(r, depth_limit).map(|r| r.map(|t| Self::AccountFlags(Box::new(t.0))))),
         }
     }
 
     #[cfg(feature = "base64")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+    pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec, depth_limit).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
     }
 
     #[cfg(feature = "std")]
-    pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-        let mut cursor = Cursor::new(bytes.as_ref());
+    pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, depth_limit: u32) -> Result<Self> {
+        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
         let t = Self::read_xdr_to_end(v, &mut cursor)?;
         Ok(t)
     }
 
     #[cfg(feature = "base64")]
-    pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+    pub fn from_xdr_base64(v: TypeVariant, b64: String, depth_limit: u32) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
+        let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), depth_limit);
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
     }

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -51,10 +51,11 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Depth limit for recursive calls in `Read/WriteXdr`. Mimics the stack depth
-/// and its purpose is to avoid the running program from reaching the Rust's
-/// stack size limit (see https://doc.rust-lang.org/std/thread/#stack-size),
-/// which leads to an unrecoverable `SIGABRT`.
+/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+///
+/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+/// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
 pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
@@ -225,11 +226,12 @@ pub trait DepthLimiter {
 }
 
 /// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth` state tracking remaining recursion depth.
+/// recursive read operations. It maintains a `depth_remaining` state tracking
+/// remaining allowed recursion depth.
 #[cfg(feature = "std")]
 pub struct DepthLimitedRead<R: Read> {
     pub inner: R,
-    pub(crate) depth: RefCell<u32>,
+    pub(crate) depth_remaining: RefCell<u32>,
 }
 
 #[cfg(feature = "std")]
@@ -237,11 +239,11 @@ impl<R: Read> DepthLimitedRead<R> {
     /// Constructs a new `DepthLimitedRead`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
-    /// - `depth`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth: u32) -> Self {
+    /// - `depth_limit`: The maximum allowed recursion depth.
+    pub fn new(inner: R, depth_limit: u32) -> Self {
         DepthLimitedRead {
             inner,
-            depth: RefCell::new(depth),
+            depth_remaining: RefCell::new(depth_limit),
         }
     }
 }
@@ -250,21 +252,21 @@ impl<R: Read> DepthLimitedRead<R> {
 impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
     type DepthError = Error;
 
-    /// Decrements the depth. If the depth is already zero, an error is returned indicating
-    /// that the maximum depth limit has been exceeded.
+    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
+    /// returned indicating that the maximum depth limit has been exceeded.
     fn enter(&self) -> core::result::Result<(), Error> {
-        let depth = *self.depth.borrow();
+        let depth = *self.depth_remaining.borrow();
         if depth == 0 {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth.replace(depth - 1);
+        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
     /// Increments the depth, without exceeding the initial depth value.
     fn leave(&self) {
-        let depth = *self.depth.borrow();
-        self.depth.replace(depth.saturating_add(1));
+        let depth = *self.depth_remaining.borrow();
+        self.depth_remaining.replace(depth.saturating_add(1));
     }
 }
 
@@ -277,11 +279,12 @@ impl<R: Read> Read for DepthLimitedRead<R> {
 }
 
 /// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth` state tracking remaining recursion depth.
+/// recursive write operations. It maintains a `depth_remaining` state tracking
+/// remaining allowed recursion depth.
 #[cfg(feature = "std")]
 pub struct DepthLimitedWrite<W: Write> {
     pub inner: W,
-    pub(crate) depth: RefCell<u32>,
+    pub(crate) depth_remaining: RefCell<u32>,
 }
 
 #[cfg(feature = "std")]
@@ -289,11 +292,11 @@ impl<W: Write> DepthLimitedWrite<W> {
     /// Constructs a new `DepthLimitedWrite`.
     ///
     /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth: u32) -> Self {
+    /// - `depth_limit`: The maximum allowed recursion depth.
+    pub fn new(inner: W, depth_limit: u32) -> Self {
         DepthLimitedWrite {
             inner,
-            depth: RefCell::new(depth),
+            depth_remaining: RefCell::new(depth_limit),
         }
     }
 }
@@ -302,21 +305,21 @@ impl<W: Write> DepthLimitedWrite<W> {
 impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
     type DepthError = Error;
 
-    /// Decrements the depth. If the depth is already zero, an error is returned indicating
-    /// that the maximum depth limit has been exceeded.
+    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
+    /// returned indicating that the maximum depth limit has been exceeded.
     fn enter(&self) -> Result<()> {
-        let depth = *self.depth.borrow();
+        let depth = *self.depth_remaining.borrow();
         if depth == 0 {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth.replace(depth - 1);
+        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
     /// Increments the depth, without exceeding the initial depth value.
     fn leave(&self) {
-        let depth = *self.depth.borrow();
-        self.depth.replace(depth.saturating_add(1));
+        let depth = *self.depth_remaining.borrow();
+        self.depth_remaining.replace(depth.saturating_add(1));
     }
 }
 
@@ -341,11 +344,11 @@ pub struct ReadXdrIter<R: Read, S: ReadXdr> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth: u32) -> Self {
+    fn new(r: R, depth_limit: u32) -> Self {
         Self {
             reader: DepthLimitedRead {
                 inner: BufReader::new(r),
-                depth: RefCell::new(depth),
+                depth_remaining: RefCell::new(depth_limit),
             },
             _s: PhantomData,
         }
@@ -417,7 +420,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth.take(),
+            r.depth_remaining.take(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -461,7 +464,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth.take(),
+            r.depth_remaining.take(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -537,7 +540,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth.take())
+        ReadXdrIter::new(&mut r.inner, r.depth_remaining.take())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -547,34 +550,51 @@ where
         r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth.take())
+        ReadXdrIter::new(dec, r.depth_remaining.take())
     }
 
-    /// Construct the type from the XDR bytes.
+    /// Construct the type from the XDR bytes, specifying a depth limit.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
+    #[cfg(feature = "std")]
+    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+        let t = Self::read_xdr_to_end(&mut cursor)?;
+        Ok(t)
+    }
+
+    /// Construct the type from the XDR bytes, using the default depth limit.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
     fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        let mut cursor =
-            DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
-        let t = Self::read_xdr_to_end(&mut cursor)?;
+        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_MAX_DEPTH_LIMIT)
+    }
+
+    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
+    #[cfg(feature = "base64")]
+    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut b64_reader = Cursor::new(b64);
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            depth_limit,
+        );
+        let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes base64 encoded.
+    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            DEFAULT_MAX_DEPTH_LIMIT,
-        );
-        let t = Self::read_xdr_to_end(&mut dec)?;
-        Ok(t)
+        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_MAX_DEPTH_LIMIT)
     }
 }
 
@@ -583,22 +603,32 @@ pub trait WriteXdr {
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), DEFAULT_MAX_DEPTH_LIMIT);
+    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
+    #[cfg(feature = "std")]
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        self.to_xdr_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+    }
+
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
+    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
         let mut enc = DepthLimitedWrite::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            depth_limit,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
+    }
+
+    #[cfg(feature = "base64")]
+    fn to_xdr_base64(&self) -> Result<String> {
+        self.to_xdr_base64_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
     }
 }
 
@@ -2414,7 +2444,7 @@ impl Type {
 
     #[cfg(feature = "base64")]
     pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
+        let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
         let t = Self::read_xdr(v, &mut dec)?;
         Ok(t)
     }
@@ -2433,7 +2463,7 @@ impl Type {
 
     #[cfg(feature = "base64")]
     pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
+        let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
     }
@@ -2442,7 +2472,7 @@ impl Type {
     #[allow(clippy::too_many_lines)]
     pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
     }
 
@@ -2450,7 +2480,7 @@ impl Type {
     #[allow(clippy::too_many_lines)]
     pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, Frame<AccountFlags>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t.0))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, Frame<AccountFlags>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t.0))))),
         }
     }
 
@@ -2459,7 +2489,7 @@ impl Type {
     pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
     }
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -56,7 +56,7 @@ use std::{
 /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
 /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
 /// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
+pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
@@ -570,7 +570,7 @@ where
     /// deserialization.
     #[cfg(feature = "std")]
     fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_MAX_DEPTH_LIMIT)
+        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 
     /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
@@ -594,7 +594,7 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_MAX_DEPTH_LIMIT)
+        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -612,7 +612,7 @@ pub trait WriteXdr {
 
     #[cfg(feature = "std")]
     fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 
     #[cfg(feature = "base64")]
@@ -628,7 +628,7 @@ pub trait WriteXdr {
 
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -2061,29 +2061,32 @@ mod tests {
 
     use super::{
         DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_MAX_DEPTH_LIMIT,
+        DEFAULT_XDR_RW_DEPTH_LIMIT,
     };
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
-            .unwrap();
+        let v =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+                .unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
-            .unwrap();
+        let v =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+                .unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2093,7 +2096,8 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2107,7 +2111,7 @@ mod tests {
 
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
@@ -2119,7 +2123,7 @@ mod tests {
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
@@ -2128,23 +2132,23 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v =
-            <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v =
-            <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2154,7 +2158,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2167,7 +2171,7 @@ mod tests {
         [2u8, 2, 2, 2]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEFAULT_MAX_DEPTH_LIMIT,
+                DEFAULT_XDR_RW_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2179,7 +2183,7 @@ mod tests {
         [2u8]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEFAULT_MAX_DEPTH_LIMIT,
+                DEFAULT_XDR_RW_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2430,7 +2434,7 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.dep
 
             #[cfg(feature = "std")]
             pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
+                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
@@ -2438,7 +2442,7 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.dep
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_MAX_DEPTH_LIMIT);
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -55,7 +55,8 @@ use std::{
 ///
 /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
 /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+/// For more information about Rust's stack size limit, refer to the
+/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
 pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -11,7 +11,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
-use core::{cell::RefCell, marker::PhantomData};
+use core::marker::PhantomData;
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -194,15 +194,18 @@ where
 /// It provides a mechanism to limit recursion depth, and defines the behavior upon
 /// entering and leaving a recursion level.
 pub trait DepthLimiter {
-    /// The error type returned by methods when they fail due to exceeding the depth limit.
-    type DepthError;
+    /// A general error type for any type implementing, or an operation under the guard of
+    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
+    /// which is returned from `enter`.
+    type DepthLimiterError;
 
     /// Defines the behavior for entering a new recursion level.
-    /// A `DepthError` is returned if the new level exceeds the depth limit.
-    fn enter(&self) -> core::result::Result<(), Self::DepthError>;
+    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
+    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
 
     /// Defines the behavior for leaving a recursion level.
-    fn leave(&self);
+    /// A `DepthLimiterError` is returned if an error occurs.
+    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
 
     /// Wraps a given function `f` with depth limiting guards.
     /// It triggers an `enter` before, and a `leave` after the execution of `f`.
@@ -213,16 +216,17 @@ pub trait DepthLimiter {
     ///
     /// # Returns
     ///
-    /// - `Ok` with function result if `f` executes without exceeding depth limits,
-    ///   `Err` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthError>
+    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
+    ///         with an error 3. if error occurs on `leave`.
+    ///   `Ok` otherwise.
+    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
     where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthError>,
+        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
     {
         self.enter()?;
-        let res = f(self)?;
-        self.leave();
-        Ok(res)
+        let res = f(self);
+        self.leave()?;
+        res
     }
 }
 
@@ -232,7 +236,7 @@ pub trait DepthLimiter {
 #[cfg(feature = "std")]
 pub struct DepthLimitedRead<R: Read> {
     pub inner: R,
-    pub(crate) depth_remaining: RefCell<u32>,
+    pub(crate) depth_remaining: u32,
 }
 
 #[cfg(feature = "std")]
@@ -244,30 +248,31 @@ impl<R: Read> DepthLimitedRead<R> {
     pub fn new(inner: R, depth_limit: u32) -> Self {
         DepthLimitedRead {
             inner,
-            depth_remaining: RefCell::new(depth_limit),
+            depth_remaining: depth_limit,
         }
     }
 }
 
 #[cfg(feature = "std")]
 impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthError = Error;
+    type DepthLimiterError = Error;
 
     /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
     /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&self) -> core::result::Result<(), Error> {
-        let depth = *self.depth_remaining.borrow();
-        if depth == 0 {
+    fn enter(&mut self) -> core::result::Result<(), Error> {
+        if let Some(depth) = self.depth_remaining.checked_sub(1) {
+            self.depth_remaining = depth;
+        } else {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
-    /// Increments the depth, without exceeding the initial depth value.
-    fn leave(&self) {
-        let depth = *self.depth_remaining.borrow();
-        self.depth_remaining.replace(depth.saturating_add(1));
+    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
+    /// doesn't exceed the initial depth limit.
+    fn leave(&mut self) -> core::result::Result<(), Error> {
+        self.depth_remaining = self.depth_remaining.saturating_add(1);
+        Ok(())
     }
 }
 
@@ -285,7 +290,7 @@ impl<R: Read> Read for DepthLimitedRead<R> {
 #[cfg(feature = "std")]
 pub struct DepthLimitedWrite<W: Write> {
     pub inner: W,
-    pub(crate) depth_remaining: RefCell<u32>,
+    pub(crate) depth_remaining: u32,
 }
 
 #[cfg(feature = "std")]
@@ -297,30 +302,31 @@ impl<W: Write> DepthLimitedWrite<W> {
     pub fn new(inner: W, depth_limit: u32) -> Self {
         DepthLimitedWrite {
             inner,
-            depth_remaining: RefCell::new(depth_limit),
+            depth_remaining: depth_limit,
         }
     }
 }
 
 #[cfg(feature = "std")]
 impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthError = Error;
+    type DepthLimiterError = Error;
 
     /// Decrements the `depth_remaining`. If the depth is already zero, an error is
     /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&self) -> Result<()> {
-        let depth = *self.depth_remaining.borrow();
-        if depth == 0 {
+    fn enter(&mut self) -> Result<()> {
+        if let Some(depth) = self.depth_remaining.checked_sub(1) {
+            self.depth_remaining = depth;
+        } else {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
-    /// Increments the depth, without exceeding the initial depth value.
-    fn leave(&self) {
-        let depth = *self.depth_remaining.borrow();
-        self.depth_remaining.replace(depth.saturating_add(1));
+    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
+    /// doesn't exceed the initial depth limit.
+    fn leave(&mut self) -> core::result::Result<(), Error> {
+        self.depth_remaining = self.depth_remaining.saturating_add(1);
+        Ok(())
     }
 }
 
@@ -349,7 +355,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
         Self {
             reader: DepthLimitedRead {
                 inner: BufReader::new(r),
-                depth_remaining: RefCell::new(depth_limit),
+                depth_remaining: depth_limit,
             },
             _s: PhantomData,
         }
@@ -421,7 +427,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining.take(),
+            r.depth_remaining,
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -465,7 +471,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining.take(),
+            r.depth_remaining,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -541,7 +547,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining.take())
+        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -551,7 +557,7 @@ where
         r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining.take())
+        ReadXdrIter::new(dec, r.depth_remaining)
     }
 
     /// Construct the type from the XDR bytes, specifying a depth limit.
@@ -2381,7 +2387,7 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2400,7 +2406,7 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2409,8 +2415,8 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
-TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
+                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
+TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
                 }
             }
 
@@ -2418,8 +2424,8 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inn
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, Frame<TestArray>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::TestArray(Box::new(t.0))))),
-TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::TestArray2(Box::new(t.0))))),
+                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, Frame<TestArray>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::TestArray(Box::new(t.0))))),
+TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::TestArray2(Box::new(t.0))))),
                 }
             }
 
@@ -2428,8 +2434,8 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mu
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
-TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
+                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
+TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -11,6 +11,9 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
+use super::depth_limiter::*;
+
+#[cfg(feature = "std")]
 use core::marker::PhantomData;
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
@@ -66,6 +69,7 @@ pub enum Error {
     InvalidHex,
     #[cfg(feature = "std")]
     Io(io::Error),
+    DepthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -109,6 +113,7 @@ impl fmt::Display for Error {
             Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{e}"),
+            Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
         }
     }
 }
@@ -182,15 +187,15 @@ where
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: BufReader<R>,
+    reader: DepthLimitedRead<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R) -> Self {
+    fn new(r: R, depth_limit: u32) -> Self {
         Self {
-            reader: BufReader::new(r),
+            reader: DepthLimitedRead::new(BufReader::new(r), depth_limit),
             _s: PhantomData,
         }
     }
@@ -214,7 +219,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.fill_buf() {
+        match self.reader.inner.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -224,7 +229,8 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
             Ok([..]) => (),
         };
         // Read the buf into the type.
-        match S::read_xdr(&mut self.reader) {
+        let r = self.reader.with_limited_depth(|dlr| S::read_xdr(dlr));
+        match r {
             Ok(s) => Some(Ok(s)),
             Err(e) => Some(Err(e)),
         }
@@ -247,18 +253,21 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     ///
-    /// Use [`ReadXdr::read_xdr_to_end`] when the intent is for all bytes in the
+    /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64(r: &mut impl Read) -> Result<Self> {
-        let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+    fn read_xdr_base64(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(r, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
     }
@@ -282,7 +291,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -298,8 +307,11 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end(r: &mut impl Read) -> Result<Self> {
-        let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+    fn read_xdr_base64_to_end(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(r, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
@@ -316,10 +328,10 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     ///
-    /// Use [`ReadXdr::read_xdr_into_to_end`] when the intent is for all bytes
+    /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -343,7 +355,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end(&mut self, r: &mut impl Read) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -373,8 +385,8 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut R) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(r)
+    fn read_xdr_iter<R: Read>(r: &mut R, depth_limit: u32) -> ReadXdrIter<&mut R, Self> {
+        ReadXdrIter::new(r, depth_limit)
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -382,9 +394,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut R,
+        depth_limit: u32,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
-        ReadXdrIter::new(dec)
+        ReadXdrIter::new(dec, depth_limit)
     }
 
     /// Construct the type from the XDR bytes.
@@ -392,8 +405,8 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        let mut cursor = Cursor::new(bytes.as_ref());
+    fn from_xdr(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
@@ -403,9 +416,12 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
@@ -413,21 +429,24 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        let mut cursor = Cursor::new(vec![]);
+    fn to_xdr(&self, depth_limit: u32) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
         self.write_xdr(&mut cursor)?;
-        let bytes = cursor.into_inner();
+        let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        let mut enc = base64::write::EncoderStringWriter::new(base64::STANDARD);
+    fn to_xdr_base64(&self, depth_limit: u32) -> Result<String> {
+        let mut enc = DepthLimitedWrite::new(
+            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            depth_limit,
+        );
         self.write_xdr(&mut enc)?;
-        let b64 = enc.into_inner();
+        let b64 = enc.inner.into_inner();
         Ok(b64)
     }
 }
@@ -441,229 +460,239 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 4];
-        r.read_exact(&mut b)?;
-        let i = i32::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(i32::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 4];
-        r.read_exact(&mut b)?;
-        let i = u32::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(u32::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 8];
-        r.read_exact(&mut b)?;
-        let i = i64::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(i64::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 8];
-        r.read_exact(&mut b)?;
-        let i = u64::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(u64::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = u32::read_xdr(r)?;
-        let b = i == 1;
-        Ok(b)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = u32::read_xdr(r)?;
+            let b = i == 1;
+            Ok(b)
+        })
     }
 }
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let i = u32::from(*self); // true = 1, false = 0
-        i.write_xdr(w)?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let i = u32::from(*self); // true = 1, false = 0
+            i.write_xdr(w)
+        })
     }
 }
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = u32::read_xdr(r)?;
-        match i {
-            0 => Ok(None),
-            1 => {
-                let t = T::read_xdr(r)?;
-                Ok(Some(t))
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = u32::read_xdr(r)?;
+            match i {
+                0 => Ok(None),
+                1 => {
+                    let t = T::read_xdr(r)?;
+                    Ok(Some(t))
+                }
+                _ => Err(Error::Invalid),
             }
-            _ => Err(Error::Invalid),
-        }
+        })
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        if let Some(t) = self {
-            1u32.write_xdr(w)?;
-            t.write_xdr(w)?;
-        } else {
-            0u32.write_xdr(w)?;
-        }
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            Ok(if let Some(t) = self {
+                1u32.write_xdr(w)?;
+                t.write_xdr(w)?;
+            } else {
+                0u32.write_xdr(w)?;
+            })
+        })
     }
 }
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let t = T::read_xdr(r)?;
-        Ok(Box::new(t))
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        T::write_xdr(self, w)?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let mut arr = [0u8; N];
-        r.read_exact(&mut arr)?;
-
-        let pad = &mut [0u8; 3][..pad_len(N)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
-
-        Ok(arr)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let mut arr = [0u8; N];
+            r.read_exact(&mut arr)?;
+            let pad = &mut [0u8; 3][..pad_len(N)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
+            Ok(arr)
+        })
     }
 }
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        w.write_all(self)?;
-        w.write_all(&[0u8; 3][..pad_len(N)])?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            w.write_all(self)?;
+            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            Ok(())
+        })
     }
 }
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let mut vec = Vec::with_capacity(N);
-        for _ in 0..N {
-            let t = T::read_xdr(r)?;
-            vec.push(t);
-        }
-        let arr: [T; N] = vec.try_into().unwrap_or_else(|_: Vec<T>| unreachable!());
-        Ok(arr)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let mut vec = Vec::with_capacity(N);
+            for _ in 0..N {
+                let t = T::read_xdr(r)?;
+                vec.push(t);
+            }
+            let arr: [T; N] = vec.try_into().unwrap_or_else(|_: Vec<T>| unreachable!());
+            Ok(arr)
+        })
     }
 }
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        for t in self {
-            t.write_xdr(w)?;
-        }
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            for t in self {
+                t.write_xdr(w)?;
+            }
+            Ok(())
+        })
     }
 }
 
@@ -990,68 +1019,76 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(VecM(vec))
+            Ok(VecM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = Vec::with_capacity(len as usize);
-        for _ in 0..len {
-            let t = T::read_xdr(r)?;
-            vec.push(t);
-        }
+            let mut vec = Vec::with_capacity(len as usize);
+            for _ in 0..len {
+                let t = T::read_xdr(r)?;
+                vec.push(t);
+            }
 
-        Ok(VecM(vec))
+            Ok(VecM(vec))
+        })
     }
 }
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        for t in &self.0 {
-            t.write_xdr(w)?;
-        }
+            for t in &self.0 {
+                t.write_xdr(w)?;
+            }
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1380,36 +1417,40 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(BytesM(vec))
+            Ok(BytesM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1759,36 +1800,40 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(StringM(vec))
+            Ok(StringM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1809,7 +1854,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -1832,26 +1877,30 @@ where
 mod tests {
     use std::io::Cursor;
 
+    use crate::{DepthLimitedRead, DepthLimitedWrite};
+
     use super::{Error, ReadXdr, VecM, WriteXdr};
+
+    const DEPTH_LIMIT: u32 = 10;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1860,8 +1909,8 @@ mod tests {
 
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1872,7 +1921,12 @@ mod tests {
     pub fn vec_u8_write_without_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
-        v.write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+
+        v.write_xdr(&mut DepthLimitedWrite::new(
+            Cursor::new(&mut buf),
+            DEPTH_LIMIT,
+        ))
+        .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1880,28 +1934,32 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+        v.write_xdr(&mut DepthLimitedWrite::new(
+            Cursor::new(&mut buf),
+            DEPTH_LIMIT,
+        ))
+        .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
     #[test]
     pub fn arr_u8_read_without_padding() {
-        let mut buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![2, 2, 2, 2]);
+        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
-        let mut buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![2, 0, 0, 0]);
+        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
-        let mut buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![2, 0, 0]);
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1910,8 +1968,8 @@ mod tests {
 
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
-        let mut buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![2, 3, 0, 0]);
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1922,7 +1980,10 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Cursor::new(&mut buf))
+            .write_xdr(&mut DepthLimitedWrite::new(
+                Cursor::new(&mut buf),
+                DEPTH_LIMIT,
+            ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -1930,14 +1991,19 @@ mod tests {
     #[test]
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
-        [2u8].write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+        [2u8]
+            .write_xdr(&mut DepthLimitedWrite::new(
+                Cursor::new(&mut buf),
+                DEPTH_LIMIT,
+            ))
+            .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
 }
 
 #[cfg(all(test, feature = "std"))]
 mod test {
-    use super::VecM;
+    use super::*;
 
     #[test]
     fn into_option_none() {
@@ -1961,6 +2027,36 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = vec![1].try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+
+    #[test]
+    fn depth_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[should_panic]
+    #[test]
+    fn write_over_depth_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 3);
+        a.write_xdr(&mut buf).unwrap();
+    }
+
+    #[should_panic]
+    #[test]
+    fn read_over_depth_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 5);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 3);
+        let _: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
     }
 }
 
@@ -2077,22 +2173,25 @@ TypeVariant::TestArray2, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 match v {
-                    TypeVariant::TestArray => Ok(Self::TestArray(Box::new(TestArray::read_xdr(r)?))),
-TypeVariant::TestArray2 => Ok(Self::TestArray2(Box::new(TestArray2::read_xdr(r)?))),
+                    TypeVariant::TestArray => r.with_limited_depth(|r| Ok(Self::TestArray(Box::new(TestArray::read_xdr(r)?))))?,
+TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new(TestArray2::read_xdr(r)?))))?,
                 }
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
-                let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+            pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(
+                  base64::read::DecoderReader::new(r, base64::STANDARD),
+                  depth_limit,
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2104,51 +2203,54 @@ TypeVariant::TestArray2 => Ok(Self::TestArray2(Box::new(TestArray2::read_xdr(r)?
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
-                let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+            pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(
+                  base64::read::DecoderReader::new(r, base64::STANDARD),
+                  depth_limit,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit: u32) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(r).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
-TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(r).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
+                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(r, depth_limit).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
+TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(r, depth_limit).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, Frame<TestArray>>::new(r).map(|r| r.map(|t| Self::TestArray(Box::new(t.0))))),
-TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(r).map(|r| r.map(|t| Self::TestArray2(Box::new(t.0))))),
+                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, Frame<TestArray>>::new(r, depth_limit).map(|r| r.map(|t| Self::TestArray(Box::new(t.0))))),
+TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(r, depth_limit).map(|r| r.map(|t| Self::TestArray2(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
                 match v {
-                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(dec).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
-TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
+                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(dec, depth_limit).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
+TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, depth_limit).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = Cursor::new(bytes.as_ref());
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, depth_limit: u32) -> Result<Self> {
+                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String, depth_limit: u32) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), depth_limit);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -51,10 +51,11 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Depth limit for recursive calls in `Read/WriteXdr`. Mimics the stack depth
-/// and its purpose is to avoid the running program from reaching the Rust's
-/// stack size limit (see https://doc.rust-lang.org/std/thread/#stack-size),
-/// which leads to an unrecoverable `SIGABRT`.
+/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+///
+/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+/// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
 pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
@@ -225,11 +226,12 @@ pub trait DepthLimiter {
 }
 
 /// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth` state tracking remaining recursion depth.
+/// recursive read operations. It maintains a `depth_remaining` state tracking
+/// remaining allowed recursion depth.
 #[cfg(feature = "std")]
 pub struct DepthLimitedRead<R: Read> {
     pub inner: R,
-    pub(crate) depth: RefCell<u32>,
+    pub(crate) depth_remaining: RefCell<u32>,
 }
 
 #[cfg(feature = "std")]
@@ -237,11 +239,11 @@ impl<R: Read> DepthLimitedRead<R> {
     /// Constructs a new `DepthLimitedRead`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
-    /// - `depth`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth: u32) -> Self {
+    /// - `depth_limit`: The maximum allowed recursion depth.
+    pub fn new(inner: R, depth_limit: u32) -> Self {
         DepthLimitedRead {
             inner,
-            depth: RefCell::new(depth),
+            depth_remaining: RefCell::new(depth_limit),
         }
     }
 }
@@ -250,21 +252,21 @@ impl<R: Read> DepthLimitedRead<R> {
 impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
     type DepthError = Error;
 
-    /// Decrements the depth. If the depth is already zero, an error is returned indicating
-    /// that the maximum depth limit has been exceeded.
+    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
+    /// returned indicating that the maximum depth limit has been exceeded.
     fn enter(&self) -> core::result::Result<(), Error> {
-        let depth = *self.depth.borrow();
+        let depth = *self.depth_remaining.borrow();
         if depth == 0 {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth.replace(depth - 1);
+        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
     /// Increments the depth, without exceeding the initial depth value.
     fn leave(&self) {
-        let depth = *self.depth.borrow();
-        self.depth.replace(depth.saturating_add(1));
+        let depth = *self.depth_remaining.borrow();
+        self.depth_remaining.replace(depth.saturating_add(1));
     }
 }
 
@@ -277,11 +279,12 @@ impl<R: Read> Read for DepthLimitedRead<R> {
 }
 
 /// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth` state tracking remaining recursion depth.
+/// recursive write operations. It maintains a `depth_remaining` state tracking
+/// remaining allowed recursion depth.
 #[cfg(feature = "std")]
 pub struct DepthLimitedWrite<W: Write> {
     pub inner: W,
-    pub(crate) depth: RefCell<u32>,
+    pub(crate) depth_remaining: RefCell<u32>,
 }
 
 #[cfg(feature = "std")]
@@ -289,11 +292,11 @@ impl<W: Write> DepthLimitedWrite<W> {
     /// Constructs a new `DepthLimitedWrite`.
     ///
     /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth: u32) -> Self {
+    /// - `depth_limit`: The maximum allowed recursion depth.
+    pub fn new(inner: W, depth_limit: u32) -> Self {
         DepthLimitedWrite {
             inner,
-            depth: RefCell::new(depth),
+            depth_remaining: RefCell::new(depth_limit),
         }
     }
 }
@@ -302,21 +305,21 @@ impl<W: Write> DepthLimitedWrite<W> {
 impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
     type DepthError = Error;
 
-    /// Decrements the depth. If the depth is already zero, an error is returned indicating
-    /// that the maximum depth limit has been exceeded.
+    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
+    /// returned indicating that the maximum depth limit has been exceeded.
     fn enter(&self) -> Result<()> {
-        let depth = *self.depth.borrow();
+        let depth = *self.depth_remaining.borrow();
         if depth == 0 {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth.replace(depth - 1);
+        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
     /// Increments the depth, without exceeding the initial depth value.
     fn leave(&self) {
-        let depth = *self.depth.borrow();
-        self.depth.replace(depth.saturating_add(1));
+        let depth = *self.depth_remaining.borrow();
+        self.depth_remaining.replace(depth.saturating_add(1));
     }
 }
 
@@ -341,11 +344,11 @@ pub struct ReadXdrIter<R: Read, S: ReadXdr> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth: u32) -> Self {
+    fn new(r: R, depth_limit: u32) -> Self {
         Self {
             reader: DepthLimitedRead {
                 inner: BufReader::new(r),
-                depth: RefCell::new(depth),
+                depth_remaining: RefCell::new(depth_limit),
             },
             _s: PhantomData,
         }
@@ -417,7 +420,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth.take(),
+            r.depth_remaining.take(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -461,7 +464,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth.take(),
+            r.depth_remaining.take(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -537,7 +540,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth.take())
+        ReadXdrIter::new(&mut r.inner, r.depth_remaining.take())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -547,34 +550,51 @@ where
         r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth.take())
+        ReadXdrIter::new(dec, r.depth_remaining.take())
     }
 
-    /// Construct the type from the XDR bytes.
+    /// Construct the type from the XDR bytes, specifying a depth limit.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
+    #[cfg(feature = "std")]
+    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+        let t = Self::read_xdr_to_end(&mut cursor)?;
+        Ok(t)
+    }
+
+    /// Construct the type from the XDR bytes, using the default depth limit.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
     fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        let mut cursor =
-            DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
-        let t = Self::read_xdr_to_end(&mut cursor)?;
+        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_MAX_DEPTH_LIMIT)
+    }
+
+    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
+    #[cfg(feature = "base64")]
+    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut b64_reader = Cursor::new(b64);
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            depth_limit,
+        );
+        let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes base64 encoded.
+    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            DEFAULT_MAX_DEPTH_LIMIT,
-        );
-        let t = Self::read_xdr_to_end(&mut dec)?;
-        Ok(t)
+        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_MAX_DEPTH_LIMIT)
     }
 }
 
@@ -583,22 +603,32 @@ pub trait WriteXdr {
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), DEFAULT_MAX_DEPTH_LIMIT);
+    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
+    #[cfg(feature = "std")]
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        self.to_xdr_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+    }
+
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
+    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
         let mut enc = DepthLimitedWrite::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            depth_limit,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
+    }
+
+    #[cfg(feature = "base64")]
+    fn to_xdr_base64(&self) -> Result<String> {
+        self.to_xdr_base64_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
     }
 }
 
@@ -2346,7 +2376,7 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2365,7 +2395,7 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2374,8 +2404,8 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
-TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
+                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
+TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
                 }
             }
 
@@ -2383,8 +2413,8 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inn
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, Frame<TestArray>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::TestArray(Box::new(t.0))))),
-TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::TestArray2(Box::new(t.0))))),
+                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, Frame<TestArray>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::TestArray(Box::new(t.0))))),
+TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::TestArray2(Box::new(t.0))))),
                 }
             }
 
@@ -2393,8 +2423,8 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mu
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
-TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
+                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
+TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -11,7 +11,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
-use core::{cell::RefCell, marker::PhantomData};
+use core::marker::PhantomData;
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -194,15 +194,18 @@ where
 /// It provides a mechanism to limit recursion depth, and defines the behavior upon
 /// entering and leaving a recursion level.
 pub trait DepthLimiter {
-    /// The error type returned by methods when they fail due to exceeding the depth limit.
-    type DepthError;
+    /// A general error type for any type implementing, or an operation under the guard of
+    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
+    /// which is returned from `enter`.
+    type DepthLimiterError;
 
     /// Defines the behavior for entering a new recursion level.
-    /// A `DepthError` is returned if the new level exceeds the depth limit.
-    fn enter(&self) -> core::result::Result<(), Self::DepthError>;
+    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
+    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
 
     /// Defines the behavior for leaving a recursion level.
-    fn leave(&self);
+    /// A `DepthLimiterError` is returned if an error occurs.
+    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
 
     /// Wraps a given function `f` with depth limiting guards.
     /// It triggers an `enter` before, and a `leave` after the execution of `f`.
@@ -213,16 +216,17 @@ pub trait DepthLimiter {
     ///
     /// # Returns
     ///
-    /// - `Ok` with function result if `f` executes without exceeding depth limits,
-    ///   `Err` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthError>
+    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
+    ///         with an error 3. if error occurs on `leave`.
+    ///   `Ok` otherwise.
+    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
     where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthError>,
+        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
     {
         self.enter()?;
-        let res = f(self)?;
-        self.leave();
-        Ok(res)
+        let res = f(self);
+        self.leave()?;
+        res
     }
 }
 
@@ -232,7 +236,7 @@ pub trait DepthLimiter {
 #[cfg(feature = "std")]
 pub struct DepthLimitedRead<R: Read> {
     pub inner: R,
-    pub(crate) depth_remaining: RefCell<u32>,
+    pub(crate) depth_remaining: u32,
 }
 
 #[cfg(feature = "std")]
@@ -244,30 +248,31 @@ impl<R: Read> DepthLimitedRead<R> {
     pub fn new(inner: R, depth_limit: u32) -> Self {
         DepthLimitedRead {
             inner,
-            depth_remaining: RefCell::new(depth_limit),
+            depth_remaining: depth_limit,
         }
     }
 }
 
 #[cfg(feature = "std")]
 impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthError = Error;
+    type DepthLimiterError = Error;
 
     /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
     /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&self) -> core::result::Result<(), Error> {
-        let depth = *self.depth_remaining.borrow();
-        if depth == 0 {
+    fn enter(&mut self) -> core::result::Result<(), Error> {
+        if let Some(depth) = self.depth_remaining.checked_sub(1) {
+            self.depth_remaining = depth;
+        } else {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
-    /// Increments the depth, without exceeding the initial depth value.
-    fn leave(&self) {
-        let depth = *self.depth_remaining.borrow();
-        self.depth_remaining.replace(depth.saturating_add(1));
+    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
+    /// doesn't exceed the initial depth limit.
+    fn leave(&mut self) -> core::result::Result<(), Error> {
+        self.depth_remaining = self.depth_remaining.saturating_add(1);
+        Ok(())
     }
 }
 
@@ -285,7 +290,7 @@ impl<R: Read> Read for DepthLimitedRead<R> {
 #[cfg(feature = "std")]
 pub struct DepthLimitedWrite<W: Write> {
     pub inner: W,
-    pub(crate) depth_remaining: RefCell<u32>,
+    pub(crate) depth_remaining: u32,
 }
 
 #[cfg(feature = "std")]
@@ -297,30 +302,31 @@ impl<W: Write> DepthLimitedWrite<W> {
     pub fn new(inner: W, depth_limit: u32) -> Self {
         DepthLimitedWrite {
             inner,
-            depth_remaining: RefCell::new(depth_limit),
+            depth_remaining: depth_limit,
         }
     }
 }
 
 #[cfg(feature = "std")]
 impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthError = Error;
+    type DepthLimiterError = Error;
 
     /// Decrements the `depth_remaining`. If the depth is already zero, an error is
     /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&self) -> Result<()> {
-        let depth = *self.depth_remaining.borrow();
-        if depth == 0 {
+    fn enter(&mut self) -> Result<()> {
+        if let Some(depth) = self.depth_remaining.checked_sub(1) {
+            self.depth_remaining = depth;
+        } else {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
-    /// Increments the depth, without exceeding the initial depth value.
-    fn leave(&self) {
-        let depth = *self.depth_remaining.borrow();
-        self.depth_remaining.replace(depth.saturating_add(1));
+    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
+    /// doesn't exceed the initial depth limit.
+    fn leave(&mut self) -> core::result::Result<(), Error> {
+        self.depth_remaining = self.depth_remaining.saturating_add(1);
+        Ok(())
     }
 }
 
@@ -349,7 +355,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
         Self {
             reader: DepthLimitedRead {
                 inner: BufReader::new(r),
-                depth_remaining: RefCell::new(depth_limit),
+                depth_remaining: depth_limit,
             },
             _s: PhantomData,
         }
@@ -421,7 +427,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining.take(),
+            r.depth_remaining,
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -465,7 +471,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining.take(),
+            r.depth_remaining,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -541,7 +547,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining.take())
+        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -551,7 +557,7 @@ where
         r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining.take())
+        ReadXdrIter::new(dec, r.depth_remaining)
     }
 
     /// Construct the type from the XDR bytes, specifying a depth limit.
@@ -2763,7 +2769,7 @@ TypeVariant::Color2 => r.with_limited_depth(|r| Ok(Self::Color2(Box::new(Color2:
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2782,7 +2788,7 @@ TypeVariant::Color2 => r.with_limited_depth(|r| Ok(Self::Color2(Box::new(Color2:
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2791,9 +2797,9 @@ TypeVariant::Color2 => r.with_limited_depth(|r| Ok(Self::Color2(Box::new(Color2:
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
                 }
             }
 
@@ -2801,9 +2807,9 @@ TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(&mut r.inner, r.de
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, Frame<MessageType>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::MessageType(Box::new(t.0))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Frame<Color2>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Color2(Box::new(t.0))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, Frame<MessageType>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MessageType(Box::new(t.0))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Frame<Color2>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Color2(Box::new(t.0))))),
                 }
             }
 
@@ -2812,9 +2818,9 @@ TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Frame<Color2>>::new(&mut r.inne
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -55,7 +55,8 @@ use std::{
 ///
 /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
 /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+/// For more information about Rust's stack size limit, refer to the
+/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
 pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -51,10 +51,11 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Depth limit for recursive calls in `Read/WriteXdr`. Mimics the stack depth
-/// and its purpose is to avoid the running program from reaching the Rust's
-/// stack size limit (see https://doc.rust-lang.org/std/thread/#stack-size),
-/// which leads to an unrecoverable `SIGABRT`.
+/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+///
+/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+/// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
 pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
@@ -225,11 +226,12 @@ pub trait DepthLimiter {
 }
 
 /// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth` state tracking remaining recursion depth.
+/// recursive read operations. It maintains a `depth_remaining` state tracking
+/// remaining allowed recursion depth.
 #[cfg(feature = "std")]
 pub struct DepthLimitedRead<R: Read> {
     pub inner: R,
-    pub(crate) depth: RefCell<u32>,
+    pub(crate) depth_remaining: RefCell<u32>,
 }
 
 #[cfg(feature = "std")]
@@ -237,11 +239,11 @@ impl<R: Read> DepthLimitedRead<R> {
     /// Constructs a new `DepthLimitedRead`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
-    /// - `depth`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth: u32) -> Self {
+    /// - `depth_limit`: The maximum allowed recursion depth.
+    pub fn new(inner: R, depth_limit: u32) -> Self {
         DepthLimitedRead {
             inner,
-            depth: RefCell::new(depth),
+            depth_remaining: RefCell::new(depth_limit),
         }
     }
 }
@@ -250,21 +252,21 @@ impl<R: Read> DepthLimitedRead<R> {
 impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
     type DepthError = Error;
 
-    /// Decrements the depth. If the depth is already zero, an error is returned indicating
-    /// that the maximum depth limit has been exceeded.
+    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
+    /// returned indicating that the maximum depth limit has been exceeded.
     fn enter(&self) -> core::result::Result<(), Error> {
-        let depth = *self.depth.borrow();
+        let depth = *self.depth_remaining.borrow();
         if depth == 0 {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth.replace(depth - 1);
+        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
     /// Increments the depth, without exceeding the initial depth value.
     fn leave(&self) {
-        let depth = *self.depth.borrow();
-        self.depth.replace(depth.saturating_add(1));
+        let depth = *self.depth_remaining.borrow();
+        self.depth_remaining.replace(depth.saturating_add(1));
     }
 }
 
@@ -277,11 +279,12 @@ impl<R: Read> Read for DepthLimitedRead<R> {
 }
 
 /// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth` state tracking remaining recursion depth.
+/// recursive write operations. It maintains a `depth_remaining` state tracking
+/// remaining allowed recursion depth.
 #[cfg(feature = "std")]
 pub struct DepthLimitedWrite<W: Write> {
     pub inner: W,
-    pub(crate) depth: RefCell<u32>,
+    pub(crate) depth_remaining: RefCell<u32>,
 }
 
 #[cfg(feature = "std")]
@@ -289,11 +292,11 @@ impl<W: Write> DepthLimitedWrite<W> {
     /// Constructs a new `DepthLimitedWrite`.
     ///
     /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth: u32) -> Self {
+    /// - `depth_limit`: The maximum allowed recursion depth.
+    pub fn new(inner: W, depth_limit: u32) -> Self {
         DepthLimitedWrite {
             inner,
-            depth: RefCell::new(depth),
+            depth_remaining: RefCell::new(depth_limit),
         }
     }
 }
@@ -302,21 +305,21 @@ impl<W: Write> DepthLimitedWrite<W> {
 impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
     type DepthError = Error;
 
-    /// Decrements the depth. If the depth is already zero, an error is returned indicating
-    /// that the maximum depth limit has been exceeded.
+    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
+    /// returned indicating that the maximum depth limit has been exceeded.
     fn enter(&self) -> Result<()> {
-        let depth = *self.depth.borrow();
+        let depth = *self.depth_remaining.borrow();
         if depth == 0 {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth.replace(depth - 1);
+        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
     /// Increments the depth, without exceeding the initial depth value.
     fn leave(&self) {
-        let depth = *self.depth.borrow();
-        self.depth.replace(depth.saturating_add(1));
+        let depth = *self.depth_remaining.borrow();
+        self.depth_remaining.replace(depth.saturating_add(1));
     }
 }
 
@@ -341,11 +344,11 @@ pub struct ReadXdrIter<R: Read, S: ReadXdr> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth: u32) -> Self {
+    fn new(r: R, depth_limit: u32) -> Self {
         Self {
             reader: DepthLimitedRead {
                 inner: BufReader::new(r),
-                depth: RefCell::new(depth),
+                depth_remaining: RefCell::new(depth_limit),
             },
             _s: PhantomData,
         }
@@ -417,7 +420,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth.take(),
+            r.depth_remaining.take(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -461,7 +464,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth.take(),
+            r.depth_remaining.take(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -537,7 +540,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth.take())
+        ReadXdrIter::new(&mut r.inner, r.depth_remaining.take())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -547,34 +550,51 @@ where
         r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth.take())
+        ReadXdrIter::new(dec, r.depth_remaining.take())
     }
 
-    /// Construct the type from the XDR bytes.
+    /// Construct the type from the XDR bytes, specifying a depth limit.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
+    #[cfg(feature = "std")]
+    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+        let t = Self::read_xdr_to_end(&mut cursor)?;
+        Ok(t)
+    }
+
+    /// Construct the type from the XDR bytes, using the default depth limit.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
     fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        let mut cursor =
-            DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
-        let t = Self::read_xdr_to_end(&mut cursor)?;
+        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_MAX_DEPTH_LIMIT)
+    }
+
+    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
+    #[cfg(feature = "base64")]
+    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut b64_reader = Cursor::new(b64);
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            depth_limit,
+        );
+        let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes base64 encoded.
+    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            DEFAULT_MAX_DEPTH_LIMIT,
-        );
-        let t = Self::read_xdr_to_end(&mut dec)?;
-        Ok(t)
+        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_MAX_DEPTH_LIMIT)
     }
 }
 
@@ -583,22 +603,32 @@ pub trait WriteXdr {
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), DEFAULT_MAX_DEPTH_LIMIT);
+    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
+    #[cfg(feature = "std")]
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        self.to_xdr_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+    }
+
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
+    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
         let mut enc = DepthLimitedWrite::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            depth_limit,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
+    }
+
+    #[cfg(feature = "base64")]
+    fn to_xdr_base64(&self) -> Result<String> {
+        self.to_xdr_base64_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
     }
 }
 
@@ -2728,7 +2758,7 @@ TypeVariant::Color2 => r.with_limited_depth(|r| Ok(Self::Color2(Box::new(Color2:
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2747,7 +2777,7 @@ TypeVariant::Color2 => r.with_limited_depth(|r| Ok(Self::Color2(Box::new(Color2:
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2756,9 +2786,9 @@ TypeVariant::Color2 => r.with_limited_depth(|r| Ok(Self::Color2(Box::new(Color2:
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
                 }
             }
 
@@ -2766,9 +2796,9 @@ TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(&mut r.inner, r.de
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, Frame<MessageType>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::MessageType(Box::new(t.0))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Frame<Color2>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Color2(Box::new(t.0))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, Frame<MessageType>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::MessageType(Box::new(t.0))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Frame<Color2>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Color2(Box::new(t.0))))),
                 }
             }
 
@@ -2777,9 +2807,9 @@ TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Frame<Color2>>::new(&mut r.inne
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -11,6 +11,9 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
+use super::depth_limiter::*;
+
+#[cfg(feature = "std")]
 use core::marker::PhantomData;
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
@@ -66,6 +69,7 @@ pub enum Error {
     InvalidHex,
     #[cfg(feature = "std")]
     Io(io::Error),
+    DepthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -109,6 +113,7 @@ impl fmt::Display for Error {
             Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{e}"),
+            Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
         }
     }
 }
@@ -182,15 +187,15 @@ where
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: BufReader<R>,
+    reader: DepthLimitedRead<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R) -> Self {
+    fn new(r: R, depth_limit: u32) -> Self {
         Self {
-            reader: BufReader::new(r),
+            reader: DepthLimitedRead::new(BufReader::new(r), depth_limit),
             _s: PhantomData,
         }
     }
@@ -214,7 +219,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.fill_buf() {
+        match self.reader.inner.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -224,7 +229,8 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
             Ok([..]) => (),
         };
         // Read the buf into the type.
-        match S::read_xdr(&mut self.reader) {
+        let r = self.reader.with_limited_depth(|dlr| S::read_xdr(dlr));
+        match r {
             Ok(s) => Some(Ok(s)),
             Err(e) => Some(Err(e)),
         }
@@ -247,18 +253,21 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     ///
-    /// Use [`ReadXdr::read_xdr_to_end`] when the intent is for all bytes in the
+    /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64(r: &mut impl Read) -> Result<Self> {
-        let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+    fn read_xdr_base64(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(r, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
     }
@@ -282,7 +291,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -298,8 +307,11 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end(r: &mut impl Read) -> Result<Self> {
-        let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+    fn read_xdr_base64_to_end(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(r, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
@@ -316,10 +328,10 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     ///
-    /// Use [`ReadXdr::read_xdr_into_to_end`] when the intent is for all bytes
+    /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -343,7 +355,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end(&mut self, r: &mut impl Read) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -373,8 +385,8 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut R) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(r)
+    fn read_xdr_iter<R: Read>(r: &mut R, depth_limit: u32) -> ReadXdrIter<&mut R, Self> {
+        ReadXdrIter::new(r, depth_limit)
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -382,9 +394,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut R,
+        depth_limit: u32,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
-        ReadXdrIter::new(dec)
+        ReadXdrIter::new(dec, depth_limit)
     }
 
     /// Construct the type from the XDR bytes.
@@ -392,8 +405,8 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        let mut cursor = Cursor::new(bytes.as_ref());
+    fn from_xdr(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
@@ -403,9 +416,12 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
@@ -413,21 +429,24 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        let mut cursor = Cursor::new(vec![]);
+    fn to_xdr(&self, depth_limit: u32) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
         self.write_xdr(&mut cursor)?;
-        let bytes = cursor.into_inner();
+        let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        let mut enc = base64::write::EncoderStringWriter::new(base64::STANDARD);
+    fn to_xdr_base64(&self, depth_limit: u32) -> Result<String> {
+        let mut enc = DepthLimitedWrite::new(
+            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            depth_limit,
+        );
         self.write_xdr(&mut enc)?;
-        let b64 = enc.into_inner();
+        let b64 = enc.inner.into_inner();
         Ok(b64)
     }
 }
@@ -441,229 +460,239 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 4];
-        r.read_exact(&mut b)?;
-        let i = i32::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(i32::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 4];
-        r.read_exact(&mut b)?;
-        let i = u32::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(u32::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 8];
-        r.read_exact(&mut b)?;
-        let i = i64::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(i64::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 8];
-        r.read_exact(&mut b)?;
-        let i = u64::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(u64::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = u32::read_xdr(r)?;
-        let b = i == 1;
-        Ok(b)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = u32::read_xdr(r)?;
+            let b = i == 1;
+            Ok(b)
+        })
     }
 }
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let i = u32::from(*self); // true = 1, false = 0
-        i.write_xdr(w)?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let i = u32::from(*self); // true = 1, false = 0
+            i.write_xdr(w)
+        })
     }
 }
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = u32::read_xdr(r)?;
-        match i {
-            0 => Ok(None),
-            1 => {
-                let t = T::read_xdr(r)?;
-                Ok(Some(t))
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = u32::read_xdr(r)?;
+            match i {
+                0 => Ok(None),
+                1 => {
+                    let t = T::read_xdr(r)?;
+                    Ok(Some(t))
+                }
+                _ => Err(Error::Invalid),
             }
-            _ => Err(Error::Invalid),
-        }
+        })
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        if let Some(t) = self {
-            1u32.write_xdr(w)?;
-            t.write_xdr(w)?;
-        } else {
-            0u32.write_xdr(w)?;
-        }
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            Ok(if let Some(t) = self {
+                1u32.write_xdr(w)?;
+                t.write_xdr(w)?;
+            } else {
+                0u32.write_xdr(w)?;
+            })
+        })
     }
 }
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let t = T::read_xdr(r)?;
-        Ok(Box::new(t))
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        T::write_xdr(self, w)?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let mut arr = [0u8; N];
-        r.read_exact(&mut arr)?;
-
-        let pad = &mut [0u8; 3][..pad_len(N)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
-
-        Ok(arr)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let mut arr = [0u8; N];
+            r.read_exact(&mut arr)?;
+            let pad = &mut [0u8; 3][..pad_len(N)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
+            Ok(arr)
+        })
     }
 }
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        w.write_all(self)?;
-        w.write_all(&[0u8; 3][..pad_len(N)])?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            w.write_all(self)?;
+            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            Ok(())
+        })
     }
 }
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let mut vec = Vec::with_capacity(N);
-        for _ in 0..N {
-            let t = T::read_xdr(r)?;
-            vec.push(t);
-        }
-        let arr: [T; N] = vec.try_into().unwrap_or_else(|_: Vec<T>| unreachable!());
-        Ok(arr)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let mut vec = Vec::with_capacity(N);
+            for _ in 0..N {
+                let t = T::read_xdr(r)?;
+                vec.push(t);
+            }
+            let arr: [T; N] = vec.try_into().unwrap_or_else(|_: Vec<T>| unreachable!());
+            Ok(arr)
+        })
     }
 }
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        for t in self {
-            t.write_xdr(w)?;
-        }
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            for t in self {
+                t.write_xdr(w)?;
+            }
+            Ok(())
+        })
     }
 }
 
@@ -990,68 +1019,76 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(VecM(vec))
+            Ok(VecM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = Vec::with_capacity(len as usize);
-        for _ in 0..len {
-            let t = T::read_xdr(r)?;
-            vec.push(t);
-        }
+            let mut vec = Vec::with_capacity(len as usize);
+            for _ in 0..len {
+                let t = T::read_xdr(r)?;
+                vec.push(t);
+            }
 
-        Ok(VecM(vec))
+            Ok(VecM(vec))
+        })
     }
 }
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        for t in &self.0 {
-            t.write_xdr(w)?;
-        }
+            for t in &self.0 {
+                t.write_xdr(w)?;
+            }
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1380,36 +1417,40 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(BytesM(vec))
+            Ok(BytesM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1759,36 +1800,40 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(StringM(vec))
+            Ok(StringM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1809,7 +1854,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -1832,26 +1877,30 @@ where
 mod tests {
     use std::io::Cursor;
 
+    use crate::{DepthLimitedRead, DepthLimitedWrite};
+
     use super::{Error, ReadXdr, VecM, WriteXdr};
+
+    const DEPTH_LIMIT: u32 = 10;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1860,8 +1909,8 @@ mod tests {
 
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1872,7 +1921,12 @@ mod tests {
     pub fn vec_u8_write_without_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
-        v.write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+
+        v.write_xdr(&mut DepthLimitedWrite::new(
+            Cursor::new(&mut buf),
+            DEPTH_LIMIT,
+        ))
+        .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1880,28 +1934,32 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+        v.write_xdr(&mut DepthLimitedWrite::new(
+            Cursor::new(&mut buf),
+            DEPTH_LIMIT,
+        ))
+        .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
     #[test]
     pub fn arr_u8_read_without_padding() {
-        let mut buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![2, 2, 2, 2]);
+        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
-        let mut buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![2, 0, 0, 0]);
+        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
-        let mut buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![2, 0, 0]);
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1910,8 +1968,8 @@ mod tests {
 
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
-        let mut buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![2, 3, 0, 0]);
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1922,7 +1980,10 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Cursor::new(&mut buf))
+            .write_xdr(&mut DepthLimitedWrite::new(
+                Cursor::new(&mut buf),
+                DEPTH_LIMIT,
+            ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -1930,14 +1991,19 @@ mod tests {
     #[test]
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
-        [2u8].write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+        [2u8]
+            .write_xdr(&mut DepthLimitedWrite::new(
+                Cursor::new(&mut buf),
+                DEPTH_LIMIT,
+            ))
+            .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
 }
 
 #[cfg(all(test, feature = "std"))]
 mod test {
-    use super::VecM;
+    use super::*;
 
     #[test]
     fn into_option_none() {
@@ -1961,6 +2027,36 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = vec![1].try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+
+    #[test]
+    fn depth_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[should_panic]
+    #[test]
+    fn write_over_depth_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 3);
+        a.write_xdr(&mut buf).unwrap();
+    }
+
+    #[should_panic]
+    #[test]
+    fn read_over_depth_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 5);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 3);
+        let _: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
     }
 }
 
@@ -2141,18 +2237,22 @@ Self::FbaMessage => "FbaMessage",
 
         impl ReadXdr for MessageType {
             #[cfg(feature = "std")]
-            fn read_xdr(r: &mut impl Read) -> Result<Self> {
-                let e = i32::read_xdr(r)?;
-                let v: Self = e.try_into()?;
-                Ok(v)
+            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                r.with_limited_depth(|r| {
+                    let e = i32::read_xdr(r)?;
+                    let v: Self = e.try_into()?;
+                    Ok(v)
+                })
             }
         }
 
         impl WriteXdr for MessageType {
             #[cfg(feature = "std")]
-            fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-                let i: i32 = (*self).into();
-                i.write_xdr(w)
+            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+                w.with_limited_write(|w| {
+                    let i: i32 = (*self).into();
+                    i.write_xdr(w)
+                })
             }
         }
 
@@ -2243,18 +2343,22 @@ Self::Blue => "Blue",
 
         impl ReadXdr for Color {
             #[cfg(feature = "std")]
-            fn read_xdr(r: &mut impl Read) -> Result<Self> {
-                let e = i32::read_xdr(r)?;
-                let v: Self = e.try_into()?;
-                Ok(v)
+            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                r.with_limited_depth(|r| {
+                    let e = i32::read_xdr(r)?;
+                    let v: Self = e.try_into()?;
+                    Ok(v)
+                })
             }
         }
 
         impl WriteXdr for Color {
             #[cfg(feature = "std")]
-            fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-                let i: i32 = (*self).into();
-                i.write_xdr(w)
+            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+                w.with_limited_write(|w| {
+                    let i: i32 = (*self).into();
+                    i.write_xdr(w)
+                })
             }
         }
 
@@ -2345,18 +2449,22 @@ Self::Blue2 => "Blue2",
 
         impl ReadXdr for Color2 {
             #[cfg(feature = "std")]
-            fn read_xdr(r: &mut impl Read) -> Result<Self> {
-                let e = i32::read_xdr(r)?;
-                let v: Self = e.try_into()?;
-                Ok(v)
+            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                r.with_limited_depth(|r| {
+                    let e = i32::read_xdr(r)?;
+                    let v: Self = e.try_into()?;
+                    Ok(v)
+                })
             }
         }
 
         impl WriteXdr for Color2 {
             #[cfg(feature = "std")]
-            fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-                let i: i32 = (*self).into();
-                i.write_xdr(w)
+            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+                w.with_limited_write(|w| {
+                    let i: i32 = (*self).into();
+                    i.write_xdr(w)
+                })
             }
         }
 
@@ -2446,23 +2554,26 @@ TypeVariant::Color2, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 match v {
-                    TypeVariant::MessageType => Ok(Self::MessageType(Box::new(MessageType::read_xdr(r)?))),
-TypeVariant::Color => Ok(Self::Color(Box::new(Color::read_xdr(r)?))),
-TypeVariant::Color2 => Ok(Self::Color2(Box::new(Color2::read_xdr(r)?))),
+                    TypeVariant::MessageType => r.with_limited_depth(|r| Ok(Self::MessageType(Box::new(MessageType::read_xdr(r)?))))?,
+TypeVariant::Color => r.with_limited_depth(|r| Ok(Self::Color(Box::new(Color::read_xdr(r)?))))?,
+TypeVariant::Color2 => r.with_limited_depth(|r| Ok(Self::Color2(Box::new(Color2::read_xdr(r)?))))?,
                 }
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
-                let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+            pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(
+                  base64::read::DecoderReader::new(r, base64::STANDARD),
+                  depth_limit,
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2474,54 +2585,57 @@ TypeVariant::Color2 => Ok(Self::Color2(Box::new(Color2::read_xdr(r)?))),
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
-                let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+            pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(
+                  base64::read::DecoderReader::new(r, base64::STANDARD),
+                  depth_limit,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit: u32) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(r).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(r).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(r).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(r, depth_limit).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(r, depth_limit).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(r, depth_limit).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, Frame<MessageType>>::new(r).map(|r| r.map(|t| Self::MessageType(Box::new(t.0))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(r).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Frame<Color2>>::new(r).map(|r| r.map(|t| Self::Color2(Box::new(t.0))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, Frame<MessageType>>::new(r, depth_limit).map(|r| r.map(|t| Self::MessageType(Box::new(t.0))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(r, depth_limit).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Frame<Color2>>::new(r, depth_limit).map(|r| r.map(|t| Self::Color2(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(dec).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(dec).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(dec, depth_limit).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, depth_limit).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(dec, depth_limit).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = Cursor::new(bytes.as_ref());
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, depth_limit: u32) -> Result<Self> {
+                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String, depth_limit: u32) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), depth_limit);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -56,7 +56,7 @@ use std::{
 /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
 /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
 /// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
+pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
@@ -570,7 +570,7 @@ where
     /// deserialization.
     #[cfg(feature = "std")]
     fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_MAX_DEPTH_LIMIT)
+        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 
     /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
@@ -594,7 +594,7 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_MAX_DEPTH_LIMIT)
+        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -612,7 +612,7 @@ pub trait WriteXdr {
 
     #[cfg(feature = "std")]
     fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 
     #[cfg(feature = "base64")]
@@ -628,7 +628,7 @@ pub trait WriteXdr {
 
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -2061,29 +2061,32 @@ mod tests {
 
     use super::{
         DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_MAX_DEPTH_LIMIT,
+        DEFAULT_XDR_RW_DEPTH_LIMIT,
     };
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
-            .unwrap();
+        let v =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+                .unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
-            .unwrap();
+        let v =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+                .unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2093,7 +2096,8 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2107,7 +2111,7 @@ mod tests {
 
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
@@ -2119,7 +2123,7 @@ mod tests {
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
@@ -2128,23 +2132,23 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v =
-            <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v =
-            <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2154,7 +2158,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2167,7 +2171,7 @@ mod tests {
         [2u8, 2, 2, 2]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEFAULT_MAX_DEPTH_LIMIT,
+                DEFAULT_XDR_RW_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2179,7 +2183,7 @@ mod tests {
         [2u8]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEFAULT_MAX_DEPTH_LIMIT,
+                DEFAULT_XDR_RW_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2815,7 +2819,7 @@ TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(dec, r.depth_remai
 
             #[cfg(feature = "std")]
             pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
+                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
@@ -2823,7 +2827,7 @@ TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(dec, r.depth_remai
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_MAX_DEPTH_LIMIT);
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -11,10 +11,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
-use super::depth_limiter::*;
-
-#[cfg(feature = "std")]
-use core::marker::PhantomData;
+use core::{cell::RefCell, marker::PhantomData};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -53,6 +50,8 @@ use std::{
     error, io,
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
+
+pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
@@ -185,6 +184,112 @@ where
 {
 }
 
+pub trait DepthLimiter {
+    type DepthError;
+
+    fn enter(&self) -> core::result::Result<(), Self::DepthError>;
+
+    fn leave(&self);
+
+    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthError>
+    where
+        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthError>,
+    {
+        self.enter()?;
+        let res = f(self)?;
+        self.leave();
+        Ok(res)
+    }
+}
+
+#[cfg(feature = "std")]
+pub struct DepthLimitedRead<R: Read> {
+    pub inner: R,
+    pub(crate) depth: RefCell<u32>,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> DepthLimitedRead<R> {
+    pub fn new(inner: R, depth: u32) -> Self {
+        DepthLimitedRead {
+            inner,
+            depth: RefCell::new(depth),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
+    type DepthError = Error;
+
+    fn enter(&self) -> core::result::Result<(), Error> {
+        let depth = *self.depth.borrow();
+        if depth == 0 {
+            return Err(Error::DepthLimitExceeded);
+        }
+        self.depth.replace(depth - 1);
+        Ok(())
+    }
+
+    fn leave(&self) {
+        let depth = *self.depth.borrow();
+        self.depth.replace(depth.saturating_add(1));
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for DepthLimitedRead<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+pub struct DepthLimitedWrite<W: Write> {
+    pub inner: W,
+    pub(crate) depth: RefCell<u32>,
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> DepthLimitedWrite<W> {
+    pub fn new(inner: W, depth: u32) -> Self {
+        DepthLimitedWrite {
+            inner,
+            depth: RefCell::new(depth),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
+    type DepthError = Error;
+
+    fn enter(&self) -> Result<()> {
+        let depth = *self.depth.borrow();
+        if depth == 0 {
+            return Err(Error::DepthLimitExceeded);
+        }
+        self.depth.replace(depth - 1);
+        Ok(())
+    }
+
+    fn leave(&self) {
+        let depth = *self.depth.borrow();
+        self.depth.replace(depth.saturating_add(1));
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for DepthLimitedWrite<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
     reader: DepthLimitedRead<BufReader<R>>,
@@ -193,9 +298,12 @@ pub struct ReadXdrIter<R: Read, S: ReadXdr> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth_limit: u32) -> Self {
+    fn new(r: R, depth: u32) -> Self {
         Self {
-            reader: DepthLimitedRead::new(BufReader::new(r), depth_limit),
+            reader: DepthLimitedRead {
+                inner: BufReader::new(r),
+                depth: RefCell::new(depth),
+            },
             _s: PhantomData,
         }
     }
@@ -263,10 +371,10 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
-            base64::read::DecoderReader::new(r, base64::STANDARD),
-            depth_limit,
+            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            r.depth.take(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -307,10 +415,10 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
-            base64::read::DecoderReader::new(r, base64::STANDARD),
-            depth_limit,
+            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            r.depth.take(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -385,19 +493,18 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut R, depth_limit: u32) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(r, depth_limit)
+    fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
+        ReadXdrIter::new(&mut r.inner, r.depth.take())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
     /// values that are read into the implementing type.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
-        r: &mut R,
-        depth_limit: u32,
+        r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
-        ReadXdrIter::new(dec, depth_limit)
+        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        ReadXdrIter::new(dec, r.depth.take())
     }
 
     /// Construct the type from the XDR bytes.
@@ -405,8 +512,9 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
+        let mut cursor =
+            DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
@@ -416,11 +524,11 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            depth_limit,
+            DEFAULT_MAX_DEPTH_LIMIT,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -432,18 +540,18 @@ pub trait WriteXdr {
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, depth_limit: u32) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), DEFAULT_MAX_DEPTH_LIMIT);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, depth_limit: u32) -> Result<String> {
+    fn to_xdr_base64(&self) -> Result<String> {
         let mut enc = DepthLimitedWrite::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            depth_limit,
+            DEFAULT_MAX_DEPTH_LIMIT,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
@@ -604,12 +712,13 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         w.with_limited_depth(|w| {
-            Ok(if let Some(t) = self {
+            if let Some(t) = self {
                 1u32.write_xdr(w)?;
                 t.write_xdr(w)?;
             } else {
                 0u32.write_xdr(w)?;
-            })
+            }
+            Ok(())
         })
     }
 }
@@ -1877,30 +1986,31 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use crate::{DepthLimitedRead, DepthLimitedWrite};
-
-    use super::{Error, ReadXdr, VecM, WriteXdr};
-
-    const DEPTH_LIMIT: u32 = 10;
+    use super::{
+        DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
+        DEFAULT_MAX_DEPTH_LIMIT,
+    };
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1910,7 +2020,7 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1924,7 +2034,7 @@ mod tests {
 
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEPTH_LIMIT,
+            DEFAULT_MAX_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
@@ -1936,7 +2046,7 @@ mod tests {
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEPTH_LIMIT,
+            DEFAULT_MAX_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
@@ -1945,21 +2055,23 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v =
+            <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v =
+            <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1969,7 +2081,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1982,7 +2094,7 @@ mod tests {
         [2u8, 2, 2, 2]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEPTH_LIMIT,
+                DEFAULT_MAX_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -1994,7 +2106,7 @@ mod tests {
         [2u8]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEPTH_LIMIT,
+                DEFAULT_MAX_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2040,23 +2152,32 @@ mod test {
         assert_eq!(a, a_back);
     }
 
-    #[should_panic]
     #[test]
     fn write_over_depth_limit_fail() {
+        let depth_limit = 3;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 3);
-        a.write_xdr(&mut buf).unwrap();
+        let mut buf = DepthLimitedWrite::new(Vec::new(), depth_limit);
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::DepthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
     }
 
-    #[should_panic]
     #[test]
     fn read_over_depth_limit_fail() {
+        let read_depth_limit = 3;
+        let write_depth_limit = 5;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 5);
+        let mut buf = DepthLimitedWrite::new(Vec::new(), write_depth_limit);
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 3);
-        let _: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), read_depth_limit);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::DepthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
     }
 }
 
@@ -2249,7 +2370,7 @@ Self::FbaMessage => "FbaMessage",
         impl WriteXdr for MessageType {
             #[cfg(feature = "std")]
             fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
-                w.with_limited_write(|w| {
+                w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
                 })
@@ -2355,7 +2476,7 @@ Self::Blue => "Blue",
         impl WriteXdr for Color {
             #[cfg(feature = "std")]
             fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
-                w.with_limited_write(|w| {
+                w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
                 })
@@ -2461,7 +2582,7 @@ Self::Blue2 => "Blue2",
         impl WriteXdr for Color2 {
             #[cfg(feature = "std")]
             fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
-                w.with_limited_write(|w| {
+                w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
                 })
@@ -2556,18 +2677,15 @@ TypeVariant::Color2, ];
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 match v {
-                    TypeVariant::MessageType => r.with_limited_depth(|r| Ok(Self::MessageType(Box::new(MessageType::read_xdr(r)?))))?,
-TypeVariant::Color => r.with_limited_depth(|r| Ok(Self::Color(Box::new(Color::read_xdr(r)?))))?,
-TypeVariant::Color2 => r.with_limited_depth(|r| Ok(Self::Color2(Box::new(Color2::read_xdr(r)?))))?,
+                    TypeVariant::MessageType => r.with_limited_depth(|r| Ok(Self::MessageType(Box::new(MessageType::read_xdr(r)?)))),
+TypeVariant::Color => r.with_limited_depth(|r| Ok(Self::Color(Box::new(Color::read_xdr(r)?)))),
+TypeVariant::Color2 => r.with_limited_depth(|r| Ok(Self::Color2(Box::new(Color2::read_xdr(r)?)))),
                 }
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(
-                  base64::read::DecoderReader::new(r, base64::STANDARD),
-                  depth_limit,
-                );
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2585,57 +2703,54 @@ TypeVariant::Color2 => r.with_limited_depth(|r| Ok(Self::Color2(Box::new(Color2:
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(
-                  base64::read::DecoderReader::new(r, base64::STANDARD),
-                  depth_limit,
-                );
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit: u32) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(r, depth_limit).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(r, depth_limit).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(r, depth_limit).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, Frame<MessageType>>::new(r, depth_limit).map(|r| r.map(|t| Self::MessageType(Box::new(t.0))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(r, depth_limit).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Frame<Color2>>::new(r, depth_limit).map(|r| r.map(|t| Self::Color2(Box::new(t.0))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, Frame<MessageType>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::MessageType(Box::new(t.0))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Frame<Color2>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Color2(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(dec, depth_limit).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, depth_limit).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(dec, depth_limit).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, depth_limit: u32) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
+                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String, depth_limit: u32) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), depth_limit);
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_MAX_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -11,6 +11,9 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
+use super::depth_limiter::*;
+
+#[cfg(feature = "std")]
 use core::marker::PhantomData;
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
@@ -66,6 +69,7 @@ pub enum Error {
     InvalidHex,
     #[cfg(feature = "std")]
     Io(io::Error),
+    DepthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -109,6 +113,7 @@ impl fmt::Display for Error {
             Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{e}"),
+            Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
         }
     }
 }
@@ -182,15 +187,15 @@ where
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: BufReader<R>,
+    reader: DepthLimitedRead<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R) -> Self {
+    fn new(r: R, depth_limit: u32) -> Self {
         Self {
-            reader: BufReader::new(r),
+            reader: DepthLimitedRead::new(BufReader::new(r), depth_limit),
             _s: PhantomData,
         }
     }
@@ -214,7 +219,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.fill_buf() {
+        match self.reader.inner.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -224,7 +229,8 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
             Ok([..]) => (),
         };
         // Read the buf into the type.
-        match S::read_xdr(&mut self.reader) {
+        let r = self.reader.with_limited_depth(|dlr| S::read_xdr(dlr));
+        match r {
             Ok(s) => Some(Ok(s)),
             Err(e) => Some(Err(e)),
         }
@@ -247,18 +253,21 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     ///
-    /// Use [`ReadXdr::read_xdr_to_end`] when the intent is for all bytes in the
+    /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64(r: &mut impl Read) -> Result<Self> {
-        let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+    fn read_xdr_base64(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(r, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
     }
@@ -282,7 +291,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -298,8 +307,11 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end(r: &mut impl Read) -> Result<Self> {
-        let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+    fn read_xdr_base64_to_end(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(r, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
@@ -316,10 +328,10 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     ///
-    /// Use [`ReadXdr::read_xdr_into_to_end`] when the intent is for all bytes
+    /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -343,7 +355,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end(&mut self, r: &mut impl Read) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -373,8 +385,8 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut R) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(r)
+    fn read_xdr_iter<R: Read>(r: &mut R, depth_limit: u32) -> ReadXdrIter<&mut R, Self> {
+        ReadXdrIter::new(r, depth_limit)
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -382,9 +394,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut R,
+        depth_limit: u32,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
-        ReadXdrIter::new(dec)
+        ReadXdrIter::new(dec, depth_limit)
     }
 
     /// Construct the type from the XDR bytes.
@@ -392,8 +405,8 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        let mut cursor = Cursor::new(bytes.as_ref());
+    fn from_xdr(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
@@ -403,9 +416,12 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
@@ -413,21 +429,24 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        let mut cursor = Cursor::new(vec![]);
+    fn to_xdr(&self, depth_limit: u32) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
         self.write_xdr(&mut cursor)?;
-        let bytes = cursor.into_inner();
+        let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        let mut enc = base64::write::EncoderStringWriter::new(base64::STANDARD);
+    fn to_xdr_base64(&self, depth_limit: u32) -> Result<String> {
+        let mut enc = DepthLimitedWrite::new(
+            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            depth_limit,
+        );
         self.write_xdr(&mut enc)?;
-        let b64 = enc.into_inner();
+        let b64 = enc.inner.into_inner();
         Ok(b64)
     }
 }
@@ -441,229 +460,239 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 4];
-        r.read_exact(&mut b)?;
-        let i = i32::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(i32::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 4];
-        r.read_exact(&mut b)?;
-        let i = u32::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(u32::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 8];
-        r.read_exact(&mut b)?;
-        let i = i64::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(i64::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 8];
-        r.read_exact(&mut b)?;
-        let i = u64::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(u64::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = u32::read_xdr(r)?;
-        let b = i == 1;
-        Ok(b)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = u32::read_xdr(r)?;
+            let b = i == 1;
+            Ok(b)
+        })
     }
 }
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let i = u32::from(*self); // true = 1, false = 0
-        i.write_xdr(w)?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let i = u32::from(*self); // true = 1, false = 0
+            i.write_xdr(w)
+        })
     }
 }
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = u32::read_xdr(r)?;
-        match i {
-            0 => Ok(None),
-            1 => {
-                let t = T::read_xdr(r)?;
-                Ok(Some(t))
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = u32::read_xdr(r)?;
+            match i {
+                0 => Ok(None),
+                1 => {
+                    let t = T::read_xdr(r)?;
+                    Ok(Some(t))
+                }
+                _ => Err(Error::Invalid),
             }
-            _ => Err(Error::Invalid),
-        }
+        })
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        if let Some(t) = self {
-            1u32.write_xdr(w)?;
-            t.write_xdr(w)?;
-        } else {
-            0u32.write_xdr(w)?;
-        }
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            Ok(if let Some(t) = self {
+                1u32.write_xdr(w)?;
+                t.write_xdr(w)?;
+            } else {
+                0u32.write_xdr(w)?;
+            })
+        })
     }
 }
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let t = T::read_xdr(r)?;
-        Ok(Box::new(t))
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        T::write_xdr(self, w)?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let mut arr = [0u8; N];
-        r.read_exact(&mut arr)?;
-
-        let pad = &mut [0u8; 3][..pad_len(N)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
-
-        Ok(arr)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let mut arr = [0u8; N];
+            r.read_exact(&mut arr)?;
+            let pad = &mut [0u8; 3][..pad_len(N)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
+            Ok(arr)
+        })
     }
 }
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        w.write_all(self)?;
-        w.write_all(&[0u8; 3][..pad_len(N)])?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            w.write_all(self)?;
+            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            Ok(())
+        })
     }
 }
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let mut vec = Vec::with_capacity(N);
-        for _ in 0..N {
-            let t = T::read_xdr(r)?;
-            vec.push(t);
-        }
-        let arr: [T; N] = vec.try_into().unwrap_or_else(|_: Vec<T>| unreachable!());
-        Ok(arr)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let mut vec = Vec::with_capacity(N);
+            for _ in 0..N {
+                let t = T::read_xdr(r)?;
+                vec.push(t);
+            }
+            let arr: [T; N] = vec.try_into().unwrap_or_else(|_: Vec<T>| unreachable!());
+            Ok(arr)
+        })
     }
 }
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        for t in self {
-            t.write_xdr(w)?;
-        }
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            for t in self {
+                t.write_xdr(w)?;
+            }
+            Ok(())
+        })
     }
 }
 
@@ -990,68 +1019,76 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(VecM(vec))
+            Ok(VecM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = Vec::with_capacity(len as usize);
-        for _ in 0..len {
-            let t = T::read_xdr(r)?;
-            vec.push(t);
-        }
+            let mut vec = Vec::with_capacity(len as usize);
+            for _ in 0..len {
+                let t = T::read_xdr(r)?;
+                vec.push(t);
+            }
 
-        Ok(VecM(vec))
+            Ok(VecM(vec))
+        })
     }
 }
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        for t in &self.0 {
-            t.write_xdr(w)?;
-        }
+            for t in &self.0 {
+                t.write_xdr(w)?;
+            }
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1380,36 +1417,40 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(BytesM(vec))
+            Ok(BytesM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1759,36 +1800,40 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(StringM(vec))
+            Ok(StringM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1809,7 +1854,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -1832,26 +1877,30 @@ where
 mod tests {
     use std::io::Cursor;
 
+    use crate::{DepthLimitedRead, DepthLimitedWrite};
+
     use super::{Error, ReadXdr, VecM, WriteXdr};
+
+    const DEPTH_LIMIT: u32 = 10;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1860,8 +1909,8 @@ mod tests {
 
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1872,7 +1921,12 @@ mod tests {
     pub fn vec_u8_write_without_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
-        v.write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+
+        v.write_xdr(&mut DepthLimitedWrite::new(
+            Cursor::new(&mut buf),
+            DEPTH_LIMIT,
+        ))
+        .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1880,28 +1934,32 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+        v.write_xdr(&mut DepthLimitedWrite::new(
+            Cursor::new(&mut buf),
+            DEPTH_LIMIT,
+        ))
+        .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
     #[test]
     pub fn arr_u8_read_without_padding() {
-        let mut buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![2, 2, 2, 2]);
+        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
-        let mut buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![2, 0, 0, 0]);
+        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
-        let mut buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![2, 0, 0]);
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1910,8 +1968,8 @@ mod tests {
 
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
-        let mut buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![2, 3, 0, 0]);
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1922,7 +1980,10 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Cursor::new(&mut buf))
+            .write_xdr(&mut DepthLimitedWrite::new(
+                Cursor::new(&mut buf),
+                DEPTH_LIMIT,
+            ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -1930,14 +1991,19 @@ mod tests {
     #[test]
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
-        [2u8].write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+        [2u8]
+            .write_xdr(&mut DepthLimitedWrite::new(
+                Cursor::new(&mut buf),
+                DEPTH_LIMIT,
+            ))
+            .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
 }
 
 #[cfg(all(test, feature = "std"))]
 mod test {
-    use super::VecM;
+    use super::*;
 
     #[test]
     fn into_option_none() {
@@ -1961,6 +2027,36 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = vec![1].try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+
+    #[test]
+    fn depth_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[should_panic]
+    #[test]
+    fn write_over_depth_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 3);
+        a.write_xdr(&mut buf).unwrap();
+    }
+
+    #[should_panic]
+    #[test]
+    fn read_over_depth_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 5);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 3);
+        let _: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
     }
 }
 
@@ -2068,18 +2164,22 @@ Self::Offer => "Offer",
 
         impl ReadXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn read_xdr(r: &mut impl Read) -> Result<Self> {
-                let e = i32::read_xdr(r)?;
-                let v: Self = e.try_into()?;
-                Ok(v)
+            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                r.with_limited_depth(|r| {
+                    let e = i32::read_xdr(r)?;
+                    let v: Self = e.try_into()?;
+                    Ok(v)
+                })
             }
         }
 
         impl WriteXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-                let i: i32 = (*self).into();
-                i.write_xdr(w)
+            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+                w.with_limited_write(|w| {
+                    let i: i32 = (*self).into();
+                    i.write_xdr(w)
+                })
             }
         }
 
@@ -2105,17 +2205,21 @@ pub struct MyUnionOne {
 impl ReadXdr for MyUnionOne {
     #[cfg(feature = "std")]
     fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        Ok(Self{
-          some_int: i32::read_xdr(r)?,
-        })
+        r.with_limited_depth(|r| {
+            Ok(Self{
+              some_int: i32::read_xdr(r)?,
+            })
+        }
     }
 }
 
 impl WriteXdr for MyUnionOne {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        self.some_int.write_xdr(w)?;
-        Ok(())
+        w.with_limited_depth(|w| {
+            self.some_int.write_xdr(w)?;
+            Ok(())
+        })
     }
 }
 
@@ -2137,19 +2241,23 @@ pub struct MyUnionTwo {
         impl ReadXdr for MyUnionTwo {
             #[cfg(feature = "std")]
             fn read_xdr(r: &mut impl Read) -> Result<Self> {
-                Ok(Self{
-                  some_int: i32::read_xdr(r)?,
+                r.with_limited_depth(|r| {
+                    Ok(Self{
+                      some_int: i32::read_xdr(r)?,
 foo: i32::read_xdr(r)?,
-                })
+                    })
+                }
             }
         }
 
         impl WriteXdr for MyUnionTwo {
             #[cfg(feature = "std")]
             fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-                self.some_int.write_xdr(w)?;
+                w.with_limited_depth(|w| {
+                    self.some_int.write_xdr(w)?;
 self.foo.write_xdr(w)?;
-                Ok(())
+                    Ok(())
+                })
             }
         }
 
@@ -2244,31 +2352,35 @@ Self::Offer => UnionKey::Offer,
 
         impl ReadXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn read_xdr(r: &mut impl Read) -> Result<Self> {
-                let dv: UnionKey = <UnionKey as ReadXdr>::read_xdr(r)?;
-                #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
-                let v = match dv {
-                    UnionKey::One => Self::One(MyUnionOne::read_xdr(r)?),
+            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                r.with_limited_read(|r| {
+                    let dv: UnionKey = <UnionKey as ReadXdr>::read_xdr(r)?;
+                    #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
+                    let v = match dv {
+                        UnionKey::One => Self::One(MyUnionOne::read_xdr(r)?),
 UnionKey::Two => Self::Two(MyUnionTwo::read_xdr(r)?),
 UnionKey::Offer => Self::Offer,
-                    #[allow(unreachable_patterns)]
-                    _ => return Err(Error::Invalid),
-                };
-                Ok(v)
+                        #[allow(unreachable_patterns)]
+                        _ => return Err(Error::Invalid),
+                    };
+                    Ok(v)
+                }
             }
         }
 
         impl WriteXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-                self.discriminant().write_xdr(w)?;
-                #[allow(clippy::match_same_arms)]
-                match self {
-                    Self::One(v) => v.write_xdr(w)?,
+            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite) -> Result<()> {
+                w.with_limited_depth(|w| {
+                    self.discriminant().write_xdr(w)?;
+                    #[allow(clippy::match_same_arms)]
+                    match self {
+                        Self::One(v) => v.write_xdr(w)?,
 Self::Two(v) => v.write_xdr(w)?,
 Self::Offer => ().write_xdr(w)?,
-                };
-                Ok(())
+                    };
+                    Ok(())
+                })
             }
         }
 
@@ -2374,25 +2486,28 @@ TypeVariant::MyUnionTwo, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 match v {
-                    TypeVariant::UnionKey => Ok(Self::UnionKey(Box::new(UnionKey::read_xdr(r)?))),
-TypeVariant::Foo => Ok(Self::Foo(Box::new(Foo::read_xdr(r)?))),
-TypeVariant::MyUnion => Ok(Self::MyUnion(Box::new(MyUnion::read_xdr(r)?))),
-TypeVariant::MyUnionOne => Ok(Self::MyUnionOne(Box::new(MyUnionOne::read_xdr(r)?))),
-TypeVariant::MyUnionTwo => Ok(Self::MyUnionTwo(Box::new(MyUnionTwo::read_xdr(r)?))),
+                    TypeVariant::UnionKey => r.with_limited_depth(|r| Ok(Self::UnionKey(Box::new(UnionKey::read_xdr(r)?))))?,
+TypeVariant::Foo => r.with_limited_depth(|r| Ok(Self::Foo(Box::new(Foo::read_xdr(r)?))))?,
+TypeVariant::MyUnion => r.with_limited_depth(|r| Ok(Self::MyUnion(Box::new(MyUnion::read_xdr(r)?))))?,
+TypeVariant::MyUnionOne => r.with_limited_depth(|r| Ok(Self::MyUnionOne(Box::new(MyUnionOne::read_xdr(r)?))))?,
+TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new(MyUnionTwo::read_xdr(r)?))))?,
                 }
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
-                let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+            pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(
+                  base64::read::DecoderReader::new(r, base64::STANDARD),
+                  depth_limit,
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2404,60 +2519,63 @@ TypeVariant::MyUnionTwo => Ok(Self::MyUnionTwo(Box::new(MyUnionTwo::read_xdr(r)?
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
-                let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+            pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(
+                  base64::read::DecoderReader::new(r, base64::STANDARD),
+                  depth_limit,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit: u32) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(r).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(r).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(r).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(r).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
-TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(r).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
+                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(r, depth_limit).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(r, depth_limit).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(r, depth_limit).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(r, depth_limit).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
+TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(r, depth_limit).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(r).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
-TypeVariant::Foo => Box::new(ReadXdrIter::<_, Frame<Foo>>::new(r).map(|r| r.map(|t| Self::Foo(Box::new(t.0))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(r).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
-TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, Frame<MyUnionOne>>::new(r).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t.0))))),
-TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(r).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t.0))))),
+                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(r, depth_limit).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
+TypeVariant::Foo => Box::new(ReadXdrIter::<_, Frame<Foo>>::new(r, depth_limit).map(|r| r.map(|t| Self::Foo(Box::new(t.0))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(r, depth_limit).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
+TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, Frame<MyUnionOne>>::new(r, depth_limit).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t.0))))),
+TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(r, depth_limit).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
                 match v {
-                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(dec).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(dec).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
-TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
+                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, depth_limit).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(dec, depth_limit).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, depth_limit).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(dec, depth_limit).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
+TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, depth_limit).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = Cursor::new(bytes.as_ref());
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, depth_limit: u32) -> Result<Self> {
+                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String, depth_limit: u32) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), depth_limit);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -55,7 +55,8 @@ use std::{
 ///
 /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
 /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+/// For more information about Rust's stack size limit, refer to the
+/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
 pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -11,10 +11,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
-use super::depth_limiter::*;
-
-#[cfg(feature = "std")]
-use core::marker::PhantomData;
+use core::{cell::RefCell, marker::PhantomData};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -53,6 +50,8 @@ use std::{
     error, io,
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
+
+pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
@@ -185,6 +184,112 @@ where
 {
 }
 
+pub trait DepthLimiter {
+    type DepthError;
+
+    fn enter(&self) -> core::result::Result<(), Self::DepthError>;
+
+    fn leave(&self);
+
+    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthError>
+    where
+        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthError>,
+    {
+        self.enter()?;
+        let res = f(self)?;
+        self.leave();
+        Ok(res)
+    }
+}
+
+#[cfg(feature = "std")]
+pub struct DepthLimitedRead<R: Read> {
+    pub inner: R,
+    pub(crate) depth: RefCell<u32>,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> DepthLimitedRead<R> {
+    pub fn new(inner: R, depth: u32) -> Self {
+        DepthLimitedRead {
+            inner,
+            depth: RefCell::new(depth),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
+    type DepthError = Error;
+
+    fn enter(&self) -> core::result::Result<(), Error> {
+        let depth = *self.depth.borrow();
+        if depth == 0 {
+            return Err(Error::DepthLimitExceeded);
+        }
+        self.depth.replace(depth - 1);
+        Ok(())
+    }
+
+    fn leave(&self) {
+        let depth = *self.depth.borrow();
+        self.depth.replace(depth.saturating_add(1));
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for DepthLimitedRead<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+pub struct DepthLimitedWrite<W: Write> {
+    pub inner: W,
+    pub(crate) depth: RefCell<u32>,
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> DepthLimitedWrite<W> {
+    pub fn new(inner: W, depth: u32) -> Self {
+        DepthLimitedWrite {
+            inner,
+            depth: RefCell::new(depth),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
+    type DepthError = Error;
+
+    fn enter(&self) -> Result<()> {
+        let depth = *self.depth.borrow();
+        if depth == 0 {
+            return Err(Error::DepthLimitExceeded);
+        }
+        self.depth.replace(depth - 1);
+        Ok(())
+    }
+
+    fn leave(&self) {
+        let depth = *self.depth.borrow();
+        self.depth.replace(depth.saturating_add(1));
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for DepthLimitedWrite<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
     reader: DepthLimitedRead<BufReader<R>>,
@@ -193,9 +298,12 @@ pub struct ReadXdrIter<R: Read, S: ReadXdr> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth_limit: u32) -> Self {
+    fn new(r: R, depth: u32) -> Self {
         Self {
-            reader: DepthLimitedRead::new(BufReader::new(r), depth_limit),
+            reader: DepthLimitedRead {
+                inner: BufReader::new(r),
+                depth: RefCell::new(depth),
+            },
             _s: PhantomData,
         }
     }
@@ -263,10 +371,10 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
-            base64::read::DecoderReader::new(r, base64::STANDARD),
-            depth_limit,
+            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            r.depth.take(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -307,10 +415,10 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
-            base64::read::DecoderReader::new(r, base64::STANDARD),
-            depth_limit,
+            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            r.depth.take(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -385,19 +493,18 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut R, depth_limit: u32) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(r, depth_limit)
+    fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
+        ReadXdrIter::new(&mut r.inner, r.depth.take())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
     /// values that are read into the implementing type.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
-        r: &mut R,
-        depth_limit: u32,
+        r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
-        ReadXdrIter::new(dec, depth_limit)
+        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        ReadXdrIter::new(dec, r.depth.take())
     }
 
     /// Construct the type from the XDR bytes.
@@ -405,8 +512,9 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
+        let mut cursor =
+            DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
@@ -416,11 +524,11 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            depth_limit,
+            DEFAULT_MAX_DEPTH_LIMIT,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -432,18 +540,18 @@ pub trait WriteXdr {
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, depth_limit: u32) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), DEFAULT_MAX_DEPTH_LIMIT);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, depth_limit: u32) -> Result<String> {
+    fn to_xdr_base64(&self) -> Result<String> {
         let mut enc = DepthLimitedWrite::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            depth_limit,
+            DEFAULT_MAX_DEPTH_LIMIT,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
@@ -604,12 +712,13 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         w.with_limited_depth(|w| {
-            Ok(if let Some(t) = self {
+            if let Some(t) = self {
                 1u32.write_xdr(w)?;
                 t.write_xdr(w)?;
             } else {
                 0u32.write_xdr(w)?;
-            })
+            }
+            Ok(())
         })
     }
 }
@@ -1877,30 +1986,31 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use crate::{DepthLimitedRead, DepthLimitedWrite};
-
-    use super::{Error, ReadXdr, VecM, WriteXdr};
-
-    const DEPTH_LIMIT: u32 = 10;
+    use super::{
+        DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
+        DEFAULT_MAX_DEPTH_LIMIT,
+    };
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1910,7 +2020,7 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1924,7 +2034,7 @@ mod tests {
 
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEPTH_LIMIT,
+            DEFAULT_MAX_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
@@ -1936,7 +2046,7 @@ mod tests {
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEPTH_LIMIT,
+            DEFAULT_MAX_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
@@ -1945,21 +2055,23 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v =
+            <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v =
+            <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1969,7 +2081,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1982,7 +2094,7 @@ mod tests {
         [2u8, 2, 2, 2]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEPTH_LIMIT,
+                DEFAULT_MAX_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -1994,7 +2106,7 @@ mod tests {
         [2u8]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEPTH_LIMIT,
+                DEFAULT_MAX_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2040,23 +2152,32 @@ mod test {
         assert_eq!(a, a_back);
     }
 
-    #[should_panic]
     #[test]
     fn write_over_depth_limit_fail() {
+        let depth_limit = 3;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 3);
-        a.write_xdr(&mut buf).unwrap();
+        let mut buf = DepthLimitedWrite::new(Vec::new(), depth_limit);
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::DepthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
     }
 
-    #[should_panic]
     #[test]
     fn read_over_depth_limit_fail() {
+        let read_depth_limit = 3;
+        let write_depth_limit = 5;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 5);
+        let mut buf = DepthLimitedWrite::new(Vec::new(), write_depth_limit);
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 3);
-        let _: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), read_depth_limit);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::DepthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
     }
 }
 
@@ -2176,7 +2297,7 @@ Self::Offer => "Offer",
         impl WriteXdr for UnionKey {
             #[cfg(feature = "std")]
             fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
-                w.with_limited_write(|w| {
+                w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
                 })
@@ -2204,18 +2325,18 @@ pub struct MyUnionOne {
 
 impl ReadXdr for MyUnionOne {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             Ok(Self{
               some_int: i32::read_xdr(r)?,
             })
-        }
+        })
     }
 }
 
 impl WriteXdr for MyUnionOne {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             self.some_int.write_xdr(w)?;
             Ok(())
@@ -2240,19 +2361,19 @@ pub struct MyUnionTwo {
 
         impl ReadXdr for MyUnionTwo {
             #[cfg(feature = "std")]
-            fn read_xdr(r: &mut impl Read) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       some_int: i32::read_xdr(r)?,
 foo: i32::read_xdr(r)?,
                     })
-                }
+                })
             }
         }
 
         impl WriteXdr for MyUnionTwo {
             #[cfg(feature = "std")]
-            fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     self.some_int.write_xdr(w)?;
 self.foo.write_xdr(w)?;
@@ -2353,7 +2474,7 @@ Self::Offer => UnionKey::Offer,
         impl ReadXdr for MyUnion {
             #[cfg(feature = "std")]
             fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                r.with_limited_read(|r| {
+                r.with_limited_depth(|r| {
                     let dv: UnionKey = <UnionKey as ReadXdr>::read_xdr(r)?;
                     #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
                     let v = match dv {
@@ -2364,13 +2485,13 @@ UnionKey::Offer => Self::Offer,
                         _ => return Err(Error::Invalid),
                     };
                     Ok(v)
-                }
+                })
             }
         }
 
         impl WriteXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     self.discriminant().write_xdr(w)?;
                     #[allow(clippy::match_same_arms)]
@@ -2488,20 +2609,17 @@ TypeVariant::MyUnionTwo, ];
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 match v {
-                    TypeVariant::UnionKey => r.with_limited_depth(|r| Ok(Self::UnionKey(Box::new(UnionKey::read_xdr(r)?))))?,
-TypeVariant::Foo => r.with_limited_depth(|r| Ok(Self::Foo(Box::new(Foo::read_xdr(r)?))))?,
-TypeVariant::MyUnion => r.with_limited_depth(|r| Ok(Self::MyUnion(Box::new(MyUnion::read_xdr(r)?))))?,
-TypeVariant::MyUnionOne => r.with_limited_depth(|r| Ok(Self::MyUnionOne(Box::new(MyUnionOne::read_xdr(r)?))))?,
-TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new(MyUnionTwo::read_xdr(r)?))))?,
+                    TypeVariant::UnionKey => r.with_limited_depth(|r| Ok(Self::UnionKey(Box::new(UnionKey::read_xdr(r)?)))),
+TypeVariant::Foo => r.with_limited_depth(|r| Ok(Self::Foo(Box::new(Foo::read_xdr(r)?)))),
+TypeVariant::MyUnion => r.with_limited_depth(|r| Ok(Self::MyUnion(Box::new(MyUnion::read_xdr(r)?)))),
+TypeVariant::MyUnionOne => r.with_limited_depth(|r| Ok(Self::MyUnionOne(Box::new(MyUnionOne::read_xdr(r)?)))),
+TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new(MyUnionTwo::read_xdr(r)?)))),
                 }
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(
-                  base64::read::DecoderReader::new(r, base64::STANDARD),
-                  depth_limit,
-                );
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2519,63 +2637,60 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(
-                  base64::read::DecoderReader::new(r, base64::STANDARD),
-                  depth_limit,
-                );
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit: u32) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(r, depth_limit).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(r, depth_limit).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(r, depth_limit).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(r, depth_limit).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
-TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(r, depth_limit).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
+                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
+TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(r, depth_limit).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
-TypeVariant::Foo => Box::new(ReadXdrIter::<_, Frame<Foo>>::new(r, depth_limit).map(|r| r.map(|t| Self::Foo(Box::new(t.0))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(r, depth_limit).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
-TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, Frame<MyUnionOne>>::new(r, depth_limit).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t.0))))),
-TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(r, depth_limit).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t.0))))),
+                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
+TypeVariant::Foo => Box::new(ReadXdrIter::<_, Frame<Foo>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Foo(Box::new(t.0))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
+TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, Frame<MyUnionOne>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t.0))))),
+TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, depth_limit).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(dec, depth_limit).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, depth_limit).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(dec, depth_limit).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
-TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, depth_limit).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
+                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
+TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, depth_limit: u32) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
+                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String, depth_limit: u32) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), depth_limit);
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_MAX_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -56,7 +56,7 @@ use std::{
 /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
 /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
 /// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
+pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
@@ -570,7 +570,7 @@ where
     /// deserialization.
     #[cfg(feature = "std")]
     fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_MAX_DEPTH_LIMIT)
+        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 
     /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
@@ -594,7 +594,7 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_MAX_DEPTH_LIMIT)
+        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -612,7 +612,7 @@ pub trait WriteXdr {
 
     #[cfg(feature = "std")]
     fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 
     #[cfg(feature = "base64")]
@@ -628,7 +628,7 @@ pub trait WriteXdr {
 
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -2061,29 +2061,32 @@ mod tests {
 
     use super::{
         DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_MAX_DEPTH_LIMIT,
+        DEFAULT_XDR_RW_DEPTH_LIMIT,
     };
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
-            .unwrap();
+        let v =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+                .unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
-            .unwrap();
+        let v =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+                .unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2093,7 +2096,8 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2107,7 +2111,7 @@ mod tests {
 
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
@@ -2119,7 +2123,7 @@ mod tests {
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
@@ -2128,23 +2132,23 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v =
-            <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v =
-            <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2154,7 +2158,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2167,7 +2171,7 @@ mod tests {
         [2u8, 2, 2, 2]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEFAULT_MAX_DEPTH_LIMIT,
+                DEFAULT_XDR_RW_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2179,7 +2183,7 @@ mod tests {
         [2u8]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEFAULT_MAX_DEPTH_LIMIT,
+                DEFAULT_XDR_RW_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2755,7 +2759,7 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.dep
 
             #[cfg(feature = "std")]
             pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
+                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
@@ -2763,7 +2767,7 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.dep
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_MAX_DEPTH_LIMIT);
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -11,7 +11,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
-use core::{cell::RefCell, marker::PhantomData};
+use core::marker::PhantomData;
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -194,15 +194,18 @@ where
 /// It provides a mechanism to limit recursion depth, and defines the behavior upon
 /// entering and leaving a recursion level.
 pub trait DepthLimiter {
-    /// The error type returned by methods when they fail due to exceeding the depth limit.
-    type DepthError;
+    /// A general error type for any type implementing, or an operation under the guard of
+    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
+    /// which is returned from `enter`.
+    type DepthLimiterError;
 
     /// Defines the behavior for entering a new recursion level.
-    /// A `DepthError` is returned if the new level exceeds the depth limit.
-    fn enter(&self) -> core::result::Result<(), Self::DepthError>;
+    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
+    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
 
     /// Defines the behavior for leaving a recursion level.
-    fn leave(&self);
+    /// A `DepthLimiterError` is returned if an error occurs.
+    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
 
     /// Wraps a given function `f` with depth limiting guards.
     /// It triggers an `enter` before, and a `leave` after the execution of `f`.
@@ -213,16 +216,17 @@ pub trait DepthLimiter {
     ///
     /// # Returns
     ///
-    /// - `Ok` with function result if `f` executes without exceeding depth limits,
-    ///   `Err` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthError>
+    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
+    ///         with an error 3. if error occurs on `leave`.
+    ///   `Ok` otherwise.
+    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
     where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthError>,
+        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
     {
         self.enter()?;
-        let res = f(self)?;
-        self.leave();
-        Ok(res)
+        let res = f(self);
+        self.leave()?;
+        res
     }
 }
 
@@ -232,7 +236,7 @@ pub trait DepthLimiter {
 #[cfg(feature = "std")]
 pub struct DepthLimitedRead<R: Read> {
     pub inner: R,
-    pub(crate) depth_remaining: RefCell<u32>,
+    pub(crate) depth_remaining: u32,
 }
 
 #[cfg(feature = "std")]
@@ -244,30 +248,31 @@ impl<R: Read> DepthLimitedRead<R> {
     pub fn new(inner: R, depth_limit: u32) -> Self {
         DepthLimitedRead {
             inner,
-            depth_remaining: RefCell::new(depth_limit),
+            depth_remaining: depth_limit,
         }
     }
 }
 
 #[cfg(feature = "std")]
 impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthError = Error;
+    type DepthLimiterError = Error;
 
     /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
     /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&self) -> core::result::Result<(), Error> {
-        let depth = *self.depth_remaining.borrow();
-        if depth == 0 {
+    fn enter(&mut self) -> core::result::Result<(), Error> {
+        if let Some(depth) = self.depth_remaining.checked_sub(1) {
+            self.depth_remaining = depth;
+        } else {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
-    /// Increments the depth, without exceeding the initial depth value.
-    fn leave(&self) {
-        let depth = *self.depth_remaining.borrow();
-        self.depth_remaining.replace(depth.saturating_add(1));
+    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
+    /// doesn't exceed the initial depth limit.
+    fn leave(&mut self) -> core::result::Result<(), Error> {
+        self.depth_remaining = self.depth_remaining.saturating_add(1);
+        Ok(())
     }
 }
 
@@ -285,7 +290,7 @@ impl<R: Read> Read for DepthLimitedRead<R> {
 #[cfg(feature = "std")]
 pub struct DepthLimitedWrite<W: Write> {
     pub inner: W,
-    pub(crate) depth_remaining: RefCell<u32>,
+    pub(crate) depth_remaining: u32,
 }
 
 #[cfg(feature = "std")]
@@ -297,30 +302,31 @@ impl<W: Write> DepthLimitedWrite<W> {
     pub fn new(inner: W, depth_limit: u32) -> Self {
         DepthLimitedWrite {
             inner,
-            depth_remaining: RefCell::new(depth_limit),
+            depth_remaining: depth_limit,
         }
     }
 }
 
 #[cfg(feature = "std")]
 impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthError = Error;
+    type DepthLimiterError = Error;
 
     /// Decrements the `depth_remaining`. If the depth is already zero, an error is
     /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&self) -> Result<()> {
-        let depth = *self.depth_remaining.borrow();
-        if depth == 0 {
+    fn enter(&mut self) -> Result<()> {
+        if let Some(depth) = self.depth_remaining.checked_sub(1) {
+            self.depth_remaining = depth;
+        } else {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
-    /// Increments the depth, without exceeding the initial depth value.
-    fn leave(&self) {
-        let depth = *self.depth_remaining.borrow();
-        self.depth_remaining.replace(depth.saturating_add(1));
+    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
+    /// doesn't exceed the initial depth limit.
+    fn leave(&mut self) -> core::result::Result<(), Error> {
+        self.depth_remaining = self.depth_remaining.saturating_add(1);
+        Ok(())
     }
 }
 
@@ -349,7 +355,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
         Self {
             reader: DepthLimitedRead {
                 inner: BufReader::new(r),
-                depth_remaining: RefCell::new(depth_limit),
+                depth_remaining: depth_limit,
             },
             _s: PhantomData,
         }
@@ -421,7 +427,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining.take(),
+            r.depth_remaining,
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -465,7 +471,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining.take(),
+            r.depth_remaining,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -541,7 +547,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining.take())
+        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -551,7 +557,7 @@ where
         r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining.take())
+        ReadXdrIter::new(dec, r.depth_remaining)
     }
 
     /// Construct the type from the XDR bytes, specifying a depth limit.
@@ -2697,7 +2703,7 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2716,7 +2722,7 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2725,11 +2731,11 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
-TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
+                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
+TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
                 }
             }
 
@@ -2737,11 +2743,11 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(&mut r.inn
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
-TypeVariant::Foo => Box::new(ReadXdrIter::<_, Frame<Foo>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Foo(Box::new(t.0))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
-TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, Frame<MyUnionOne>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t.0))))),
-TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t.0))))),
+                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
+TypeVariant::Foo => Box::new(ReadXdrIter::<_, Frame<Foo>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Foo(Box::new(t.0))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
+TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, Frame<MyUnionOne>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t.0))))),
+TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t.0))))),
                 }
             }
 
@@ -2750,11 +2756,11 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(&mu
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
-TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
+                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
+TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -51,10 +51,11 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Depth limit for recursive calls in `Read/WriteXdr`. Mimics the stack depth
-/// and its purpose is to avoid the running program from reaching the Rust's
-/// stack size limit (see https://doc.rust-lang.org/std/thread/#stack-size),
-/// which leads to an unrecoverable `SIGABRT`.
+/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+///
+/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+/// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
 pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
@@ -225,11 +226,12 @@ pub trait DepthLimiter {
 }
 
 /// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth` state tracking remaining recursion depth.
+/// recursive read operations. It maintains a `depth_remaining` state tracking
+/// remaining allowed recursion depth.
 #[cfg(feature = "std")]
 pub struct DepthLimitedRead<R: Read> {
     pub inner: R,
-    pub(crate) depth: RefCell<u32>,
+    pub(crate) depth_remaining: RefCell<u32>,
 }
 
 #[cfg(feature = "std")]
@@ -237,11 +239,11 @@ impl<R: Read> DepthLimitedRead<R> {
     /// Constructs a new `DepthLimitedRead`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
-    /// - `depth`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth: u32) -> Self {
+    /// - `depth_limit`: The maximum allowed recursion depth.
+    pub fn new(inner: R, depth_limit: u32) -> Self {
         DepthLimitedRead {
             inner,
-            depth: RefCell::new(depth),
+            depth_remaining: RefCell::new(depth_limit),
         }
     }
 }
@@ -250,21 +252,21 @@ impl<R: Read> DepthLimitedRead<R> {
 impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
     type DepthError = Error;
 
-    /// Decrements the depth. If the depth is already zero, an error is returned indicating
-    /// that the maximum depth limit has been exceeded.
+    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
+    /// returned indicating that the maximum depth limit has been exceeded.
     fn enter(&self) -> core::result::Result<(), Error> {
-        let depth = *self.depth.borrow();
+        let depth = *self.depth_remaining.borrow();
         if depth == 0 {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth.replace(depth - 1);
+        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
     /// Increments the depth, without exceeding the initial depth value.
     fn leave(&self) {
-        let depth = *self.depth.borrow();
-        self.depth.replace(depth.saturating_add(1));
+        let depth = *self.depth_remaining.borrow();
+        self.depth_remaining.replace(depth.saturating_add(1));
     }
 }
 
@@ -277,11 +279,12 @@ impl<R: Read> Read for DepthLimitedRead<R> {
 }
 
 /// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth` state tracking remaining recursion depth.
+/// recursive write operations. It maintains a `depth_remaining` state tracking
+/// remaining allowed recursion depth.
 #[cfg(feature = "std")]
 pub struct DepthLimitedWrite<W: Write> {
     pub inner: W,
-    pub(crate) depth: RefCell<u32>,
+    pub(crate) depth_remaining: RefCell<u32>,
 }
 
 #[cfg(feature = "std")]
@@ -289,11 +292,11 @@ impl<W: Write> DepthLimitedWrite<W> {
     /// Constructs a new `DepthLimitedWrite`.
     ///
     /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth: u32) -> Self {
+    /// - `depth_limit`: The maximum allowed recursion depth.
+    pub fn new(inner: W, depth_limit: u32) -> Self {
         DepthLimitedWrite {
             inner,
-            depth: RefCell::new(depth),
+            depth_remaining: RefCell::new(depth_limit),
         }
     }
 }
@@ -302,21 +305,21 @@ impl<W: Write> DepthLimitedWrite<W> {
 impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
     type DepthError = Error;
 
-    /// Decrements the depth. If the depth is already zero, an error is returned indicating
-    /// that the maximum depth limit has been exceeded.
+    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
+    /// returned indicating that the maximum depth limit has been exceeded.
     fn enter(&self) -> Result<()> {
-        let depth = *self.depth.borrow();
+        let depth = *self.depth_remaining.borrow();
         if depth == 0 {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth.replace(depth - 1);
+        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
     /// Increments the depth, without exceeding the initial depth value.
     fn leave(&self) {
-        let depth = *self.depth.borrow();
-        self.depth.replace(depth.saturating_add(1));
+        let depth = *self.depth_remaining.borrow();
+        self.depth_remaining.replace(depth.saturating_add(1));
     }
 }
 
@@ -341,11 +344,11 @@ pub struct ReadXdrIter<R: Read, S: ReadXdr> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth: u32) -> Self {
+    fn new(r: R, depth_limit: u32) -> Self {
         Self {
             reader: DepthLimitedRead {
                 inner: BufReader::new(r),
-                depth: RefCell::new(depth),
+                depth_remaining: RefCell::new(depth_limit),
             },
             _s: PhantomData,
         }
@@ -417,7 +420,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth.take(),
+            r.depth_remaining.take(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -461,7 +464,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth.take(),
+            r.depth_remaining.take(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -537,7 +540,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth.take())
+        ReadXdrIter::new(&mut r.inner, r.depth_remaining.take())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -547,34 +550,51 @@ where
         r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth.take())
+        ReadXdrIter::new(dec, r.depth_remaining.take())
     }
 
-    /// Construct the type from the XDR bytes.
+    /// Construct the type from the XDR bytes, specifying a depth limit.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
+    #[cfg(feature = "std")]
+    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+        let t = Self::read_xdr_to_end(&mut cursor)?;
+        Ok(t)
+    }
+
+    /// Construct the type from the XDR bytes, using the default depth limit.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
     fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        let mut cursor =
-            DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
-        let t = Self::read_xdr_to_end(&mut cursor)?;
+        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_MAX_DEPTH_LIMIT)
+    }
+
+    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
+    #[cfg(feature = "base64")]
+    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut b64_reader = Cursor::new(b64);
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            depth_limit,
+        );
+        let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes base64 encoded.
+    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            DEFAULT_MAX_DEPTH_LIMIT,
-        );
-        let t = Self::read_xdr_to_end(&mut dec)?;
-        Ok(t)
+        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_MAX_DEPTH_LIMIT)
     }
 }
 
@@ -583,22 +603,32 @@ pub trait WriteXdr {
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), DEFAULT_MAX_DEPTH_LIMIT);
+    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
+    #[cfg(feature = "std")]
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        self.to_xdr_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+    }
+
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
+    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
         let mut enc = DepthLimitedWrite::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            depth_limit,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
+    }
+
+    #[cfg(feature = "base64")]
+    fn to_xdr_base64(&self) -> Result<String> {
+        self.to_xdr_base64_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
     }
 }
 
@@ -2377,7 +2407,7 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2396,7 +2426,7 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2405,8 +2435,8 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
                 }
             }
 
@@ -2414,8 +2444,8 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inn
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Frame<Arr>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Arr(Box::new(t.0))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::HasOptions(Box::new(t.0))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Frame<Arr>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Arr(Box::new(t.0))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::HasOptions(Box::new(t.0))))),
                 }
             }
 
@@ -2424,8 +2454,8 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mu
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -11,10 +11,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
-use super::depth_limiter::*;
-
-#[cfg(feature = "std")]
-use core::marker::PhantomData;
+use core::{cell::RefCell, marker::PhantomData};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -53,6 +50,8 @@ use std::{
     error, io,
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
+
+pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
@@ -185,6 +184,112 @@ where
 {
 }
 
+pub trait DepthLimiter {
+    type DepthError;
+
+    fn enter(&self) -> core::result::Result<(), Self::DepthError>;
+
+    fn leave(&self);
+
+    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthError>
+    where
+        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthError>,
+    {
+        self.enter()?;
+        let res = f(self)?;
+        self.leave();
+        Ok(res)
+    }
+}
+
+#[cfg(feature = "std")]
+pub struct DepthLimitedRead<R: Read> {
+    pub inner: R,
+    pub(crate) depth: RefCell<u32>,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> DepthLimitedRead<R> {
+    pub fn new(inner: R, depth: u32) -> Self {
+        DepthLimitedRead {
+            inner,
+            depth: RefCell::new(depth),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
+    type DepthError = Error;
+
+    fn enter(&self) -> core::result::Result<(), Error> {
+        let depth = *self.depth.borrow();
+        if depth == 0 {
+            return Err(Error::DepthLimitExceeded);
+        }
+        self.depth.replace(depth - 1);
+        Ok(())
+    }
+
+    fn leave(&self) {
+        let depth = *self.depth.borrow();
+        self.depth.replace(depth.saturating_add(1));
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for DepthLimitedRead<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+pub struct DepthLimitedWrite<W: Write> {
+    pub inner: W,
+    pub(crate) depth: RefCell<u32>,
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> DepthLimitedWrite<W> {
+    pub fn new(inner: W, depth: u32) -> Self {
+        DepthLimitedWrite {
+            inner,
+            depth: RefCell::new(depth),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
+    type DepthError = Error;
+
+    fn enter(&self) -> Result<()> {
+        let depth = *self.depth.borrow();
+        if depth == 0 {
+            return Err(Error::DepthLimitExceeded);
+        }
+        self.depth.replace(depth - 1);
+        Ok(())
+    }
+
+    fn leave(&self) {
+        let depth = *self.depth.borrow();
+        self.depth.replace(depth.saturating_add(1));
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for DepthLimitedWrite<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
     reader: DepthLimitedRead<BufReader<R>>,
@@ -193,9 +298,12 @@ pub struct ReadXdrIter<R: Read, S: ReadXdr> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth_limit: u32) -> Self {
+    fn new(r: R, depth: u32) -> Self {
         Self {
-            reader: DepthLimitedRead::new(BufReader::new(r), depth_limit),
+            reader: DepthLimitedRead {
+                inner: BufReader::new(r),
+                depth: RefCell::new(depth),
+            },
             _s: PhantomData,
         }
     }
@@ -263,10 +371,10 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
-            base64::read::DecoderReader::new(r, base64::STANDARD),
-            depth_limit,
+            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            r.depth.take(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -307,10 +415,10 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
-            base64::read::DecoderReader::new(r, base64::STANDARD),
-            depth_limit,
+            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            r.depth.take(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -385,19 +493,18 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut R, depth_limit: u32) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(r, depth_limit)
+    fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
+        ReadXdrIter::new(&mut r.inner, r.depth.take())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
     /// values that are read into the implementing type.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
-        r: &mut R,
-        depth_limit: u32,
+        r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
-        ReadXdrIter::new(dec, depth_limit)
+        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        ReadXdrIter::new(dec, r.depth.take())
     }
 
     /// Construct the type from the XDR bytes.
@@ -405,8 +512,9 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
+        let mut cursor =
+            DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
@@ -416,11 +524,11 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            depth_limit,
+            DEFAULT_MAX_DEPTH_LIMIT,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -432,18 +540,18 @@ pub trait WriteXdr {
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, depth_limit: u32) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), DEFAULT_MAX_DEPTH_LIMIT);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, depth_limit: u32) -> Result<String> {
+    fn to_xdr_base64(&self) -> Result<String> {
         let mut enc = DepthLimitedWrite::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            depth_limit,
+            DEFAULT_MAX_DEPTH_LIMIT,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
@@ -604,12 +712,13 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         w.with_limited_depth(|w| {
-            Ok(if let Some(t) = self {
+            if let Some(t) = self {
                 1u32.write_xdr(w)?;
                 t.write_xdr(w)?;
             } else {
                 0u32.write_xdr(w)?;
-            })
+            }
+            Ok(())
         })
     }
 }
@@ -1877,30 +1986,31 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use crate::{DepthLimitedRead, DepthLimitedWrite};
-
-    use super::{Error, ReadXdr, VecM, WriteXdr};
-
-    const DEPTH_LIMIT: u32 = 10;
+    use super::{
+        DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
+        DEFAULT_MAX_DEPTH_LIMIT,
+    };
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1910,7 +2020,7 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1924,7 +2034,7 @@ mod tests {
 
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEPTH_LIMIT,
+            DEFAULT_MAX_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
@@ -1936,7 +2046,7 @@ mod tests {
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEPTH_LIMIT,
+            DEFAULT_MAX_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
@@ -1945,21 +2055,23 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v =
+            <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v =
+            <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1969,7 +2081,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1982,7 +2094,7 @@ mod tests {
         [2u8, 2, 2, 2]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEPTH_LIMIT,
+                DEFAULT_MAX_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -1994,7 +2106,7 @@ mod tests {
         [2u8]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEPTH_LIMIT,
+                DEFAULT_MAX_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2040,23 +2152,32 @@ mod test {
         assert_eq!(a, a_back);
     }
 
-    #[should_panic]
     #[test]
     fn write_over_depth_limit_fail() {
+        let depth_limit = 3;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 3);
-        a.write_xdr(&mut buf).unwrap();
+        let mut buf = DepthLimitedWrite::new(Vec::new(), depth_limit);
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::DepthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
     }
 
-    #[should_panic]
     #[test]
     fn read_over_depth_limit_fail() {
+        let read_depth_limit = 3;
+        let write_depth_limit = 5;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 5);
+        let mut buf = DepthLimitedWrite::new(Vec::new(), write_depth_limit);
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 3);
-        let _: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), read_depth_limit);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::DepthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
     }
 }
 
@@ -2103,20 +2224,20 @@ pub struct HasOptions {
 
         impl ReadXdr for HasOptions {
             #[cfg(feature = "std")]
-            fn read_xdr(r: &mut impl Read) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       first_option: Option::<i32>::read_xdr(r)?,
 second_option: Option::<i32>::read_xdr(r)?,
 third_option: Option::<i32>::read_xdr(r)?,
                     })
-                }
+                })
             }
         }
 
         impl WriteXdr for HasOptions {
             #[cfg(feature = "std")]
-            fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     self.first_option.write_xdr(w)?;
 self.second_option.write_xdr(w)?;
@@ -2206,17 +2327,14 @@ TypeVariant::HasOptions, ];
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 match v {
-                    TypeVariant::Arr => r.with_limited_depth(|r| Ok(Self::Arr(Box::new(Arr::read_xdr(r)?))))?,
-TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new(HasOptions::read_xdr(r)?))))?,
+                    TypeVariant::Arr => r.with_limited_depth(|r| Ok(Self::Arr(Box::new(Arr::read_xdr(r)?)))),
+TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new(HasOptions::read_xdr(r)?)))),
                 }
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(
-                  base64::read::DecoderReader::new(r, base64::STANDARD),
-                  depth_limit,
-                );
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2234,54 +2352,51 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(
-                  base64::read::DecoderReader::new(r, base64::STANDARD),
-                  depth_limit,
-                );
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit: u32) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(r, depth_limit).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(r, depth_limit).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Frame<Arr>>::new(r, depth_limit).map(|r| r.map(|t| Self::Arr(Box::new(t.0))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(r, depth_limit).map(|r| r.map(|t| Self::HasOptions(Box::new(t.0))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Frame<Arr>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Arr(Box::new(t.0))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::HasOptions(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec, depth_limit).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, depth_limit).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, depth_limit: u32) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
+                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String, depth_limit: u32) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), depth_limit);
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_MAX_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -55,7 +55,8 @@ use std::{
 ///
 /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
 /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+/// For more information about Rust's stack size limit, refer to the
+/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
 pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -11,7 +11,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
-use core::{cell::RefCell, marker::PhantomData};
+use core::marker::PhantomData;
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -194,15 +194,18 @@ where
 /// It provides a mechanism to limit recursion depth, and defines the behavior upon
 /// entering and leaving a recursion level.
 pub trait DepthLimiter {
-    /// The error type returned by methods when they fail due to exceeding the depth limit.
-    type DepthError;
+    /// A general error type for any type implementing, or an operation under the guard of
+    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
+    /// which is returned from `enter`.
+    type DepthLimiterError;
 
     /// Defines the behavior for entering a new recursion level.
-    /// A `DepthError` is returned if the new level exceeds the depth limit.
-    fn enter(&self) -> core::result::Result<(), Self::DepthError>;
+    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
+    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
 
     /// Defines the behavior for leaving a recursion level.
-    fn leave(&self);
+    /// A `DepthLimiterError` is returned if an error occurs.
+    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
 
     /// Wraps a given function `f` with depth limiting guards.
     /// It triggers an `enter` before, and a `leave` after the execution of `f`.
@@ -213,16 +216,17 @@ pub trait DepthLimiter {
     ///
     /// # Returns
     ///
-    /// - `Ok` with function result if `f` executes without exceeding depth limits,
-    ///   `Err` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthError>
+    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
+    ///         with an error 3. if error occurs on `leave`.
+    ///   `Ok` otherwise.
+    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
     where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthError>,
+        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
     {
         self.enter()?;
-        let res = f(self)?;
-        self.leave();
-        Ok(res)
+        let res = f(self);
+        self.leave()?;
+        res
     }
 }
 
@@ -232,7 +236,7 @@ pub trait DepthLimiter {
 #[cfg(feature = "std")]
 pub struct DepthLimitedRead<R: Read> {
     pub inner: R,
-    pub(crate) depth_remaining: RefCell<u32>,
+    pub(crate) depth_remaining: u32,
 }
 
 #[cfg(feature = "std")]
@@ -244,30 +248,31 @@ impl<R: Read> DepthLimitedRead<R> {
     pub fn new(inner: R, depth_limit: u32) -> Self {
         DepthLimitedRead {
             inner,
-            depth_remaining: RefCell::new(depth_limit),
+            depth_remaining: depth_limit,
         }
     }
 }
 
 #[cfg(feature = "std")]
 impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthError = Error;
+    type DepthLimiterError = Error;
 
     /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
     /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&self) -> core::result::Result<(), Error> {
-        let depth = *self.depth_remaining.borrow();
-        if depth == 0 {
+    fn enter(&mut self) -> core::result::Result<(), Error> {
+        if let Some(depth) = self.depth_remaining.checked_sub(1) {
+            self.depth_remaining = depth;
+        } else {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
-    /// Increments the depth, without exceeding the initial depth value.
-    fn leave(&self) {
-        let depth = *self.depth_remaining.borrow();
-        self.depth_remaining.replace(depth.saturating_add(1));
+    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
+    /// doesn't exceed the initial depth limit.
+    fn leave(&mut self) -> core::result::Result<(), Error> {
+        self.depth_remaining = self.depth_remaining.saturating_add(1);
+        Ok(())
     }
 }
 
@@ -285,7 +290,7 @@ impl<R: Read> Read for DepthLimitedRead<R> {
 #[cfg(feature = "std")]
 pub struct DepthLimitedWrite<W: Write> {
     pub inner: W,
-    pub(crate) depth_remaining: RefCell<u32>,
+    pub(crate) depth_remaining: u32,
 }
 
 #[cfg(feature = "std")]
@@ -297,30 +302,31 @@ impl<W: Write> DepthLimitedWrite<W> {
     pub fn new(inner: W, depth_limit: u32) -> Self {
         DepthLimitedWrite {
             inner,
-            depth_remaining: RefCell::new(depth_limit),
+            depth_remaining: depth_limit,
         }
     }
 }
 
 #[cfg(feature = "std")]
 impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthError = Error;
+    type DepthLimiterError = Error;
 
     /// Decrements the `depth_remaining`. If the depth is already zero, an error is
     /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&self) -> Result<()> {
-        let depth = *self.depth_remaining.borrow();
-        if depth == 0 {
+    fn enter(&mut self) -> Result<()> {
+        if let Some(depth) = self.depth_remaining.checked_sub(1) {
+            self.depth_remaining = depth;
+        } else {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
-    /// Increments the depth, without exceeding the initial depth value.
-    fn leave(&self) {
-        let depth = *self.depth_remaining.borrow();
-        self.depth_remaining.replace(depth.saturating_add(1));
+    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
+    /// doesn't exceed the initial depth limit.
+    fn leave(&mut self) -> core::result::Result<(), Error> {
+        self.depth_remaining = self.depth_remaining.saturating_add(1);
+        Ok(())
     }
 }
 
@@ -349,7 +355,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
         Self {
             reader: DepthLimitedRead {
                 inner: BufReader::new(r),
-                depth_remaining: RefCell::new(depth_limit),
+                depth_remaining: depth_limit,
             },
             _s: PhantomData,
         }
@@ -421,7 +427,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining.take(),
+            r.depth_remaining,
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -465,7 +471,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining.take(),
+            r.depth_remaining,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -541,7 +547,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining.take())
+        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -551,7 +557,7 @@ where
         r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining.take())
+        ReadXdrIter::new(dec, r.depth_remaining)
     }
 
     /// Construct the type from the XDR bytes, specifying a depth limit.
@@ -2412,7 +2418,7 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2431,7 +2437,7 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2440,8 +2446,8 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
                 }
             }
 
@@ -2449,8 +2455,8 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inn
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Frame<Arr>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Arr(Box::new(t.0))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::HasOptions(Box::new(t.0))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Frame<Arr>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Arr(Box::new(t.0))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::HasOptions(Box::new(t.0))))),
                 }
             }
 
@@ -2459,8 +2465,8 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mu
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -56,7 +56,7 @@ use std::{
 /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
 /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
 /// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
+pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
@@ -570,7 +570,7 @@ where
     /// deserialization.
     #[cfg(feature = "std")]
     fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_MAX_DEPTH_LIMIT)
+        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 
     /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
@@ -594,7 +594,7 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_MAX_DEPTH_LIMIT)
+        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -612,7 +612,7 @@ pub trait WriteXdr {
 
     #[cfg(feature = "std")]
     fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 
     #[cfg(feature = "base64")]
@@ -628,7 +628,7 @@ pub trait WriteXdr {
 
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -2061,29 +2061,32 @@ mod tests {
 
     use super::{
         DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_MAX_DEPTH_LIMIT,
+        DEFAULT_XDR_RW_DEPTH_LIMIT,
     };
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
-            .unwrap();
+        let v =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+                .unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
-            .unwrap();
+        let v =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+                .unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2093,7 +2096,8 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2107,7 +2111,7 @@ mod tests {
 
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
@@ -2119,7 +2123,7 @@ mod tests {
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
@@ -2128,23 +2132,23 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v =
-            <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v =
-            <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2154,7 +2158,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2167,7 +2171,7 @@ mod tests {
         [2u8, 2, 2, 2]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEFAULT_MAX_DEPTH_LIMIT,
+                DEFAULT_XDR_RW_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2179,7 +2183,7 @@ mod tests {
         [2u8]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEFAULT_MAX_DEPTH_LIMIT,
+                DEFAULT_XDR_RW_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2461,7 +2465,7 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.dep
 
             #[cfg(feature = "std")]
             pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
+                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
@@ -2469,7 +2473,7 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.dep
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_MAX_DEPTH_LIMIT);
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -11,6 +11,9 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
+use super::depth_limiter::*;
+
+#[cfg(feature = "std")]
 use core::marker::PhantomData;
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
@@ -66,6 +69,7 @@ pub enum Error {
     InvalidHex,
     #[cfg(feature = "std")]
     Io(io::Error),
+    DepthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -109,6 +113,7 @@ impl fmt::Display for Error {
             Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{e}"),
+            Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
         }
     }
 }
@@ -182,15 +187,15 @@ where
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: BufReader<R>,
+    reader: DepthLimitedRead<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R) -> Self {
+    fn new(r: R, depth_limit: u32) -> Self {
         Self {
-            reader: BufReader::new(r),
+            reader: DepthLimitedRead::new(BufReader::new(r), depth_limit),
             _s: PhantomData,
         }
     }
@@ -214,7 +219,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.fill_buf() {
+        match self.reader.inner.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -224,7 +229,8 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
             Ok([..]) => (),
         };
         // Read the buf into the type.
-        match S::read_xdr(&mut self.reader) {
+        let r = self.reader.with_limited_depth(|dlr| S::read_xdr(dlr));
+        match r {
             Ok(s) => Some(Ok(s)),
             Err(e) => Some(Err(e)),
         }
@@ -247,18 +253,21 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     ///
-    /// Use [`ReadXdr::read_xdr_to_end`] when the intent is for all bytes in the
+    /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64(r: &mut impl Read) -> Result<Self> {
-        let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+    fn read_xdr_base64(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(r, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
     }
@@ -282,7 +291,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -298,8 +307,11 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end(r: &mut impl Read) -> Result<Self> {
-        let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+    fn read_xdr_base64_to_end(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(r, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
@@ -316,10 +328,10 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     ///
-    /// Use [`ReadXdr::read_xdr_into_to_end`] when the intent is for all bytes
+    /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -343,7 +355,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end(&mut self, r: &mut impl Read) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -373,8 +385,8 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut R) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(r)
+    fn read_xdr_iter<R: Read>(r: &mut R, depth_limit: u32) -> ReadXdrIter<&mut R, Self> {
+        ReadXdrIter::new(r, depth_limit)
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -382,9 +394,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut R,
+        depth_limit: u32,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
-        ReadXdrIter::new(dec)
+        ReadXdrIter::new(dec, depth_limit)
     }
 
     /// Construct the type from the XDR bytes.
@@ -392,8 +405,8 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        let mut cursor = Cursor::new(bytes.as_ref());
+    fn from_xdr(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
@@ -403,9 +416,12 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
@@ -413,21 +429,24 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        let mut cursor = Cursor::new(vec![]);
+    fn to_xdr(&self, depth_limit: u32) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
         self.write_xdr(&mut cursor)?;
-        let bytes = cursor.into_inner();
+        let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        let mut enc = base64::write::EncoderStringWriter::new(base64::STANDARD);
+    fn to_xdr_base64(&self, depth_limit: u32) -> Result<String> {
+        let mut enc = DepthLimitedWrite::new(
+            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            depth_limit,
+        );
         self.write_xdr(&mut enc)?;
-        let b64 = enc.into_inner();
+        let b64 = enc.inner.into_inner();
         Ok(b64)
     }
 }
@@ -441,229 +460,239 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 4];
-        r.read_exact(&mut b)?;
-        let i = i32::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(i32::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 4];
-        r.read_exact(&mut b)?;
-        let i = u32::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(u32::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 8];
-        r.read_exact(&mut b)?;
-        let i = i64::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(i64::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 8];
-        r.read_exact(&mut b)?;
-        let i = u64::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(u64::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = u32::read_xdr(r)?;
-        let b = i == 1;
-        Ok(b)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = u32::read_xdr(r)?;
+            let b = i == 1;
+            Ok(b)
+        })
     }
 }
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let i = u32::from(*self); // true = 1, false = 0
-        i.write_xdr(w)?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let i = u32::from(*self); // true = 1, false = 0
+            i.write_xdr(w)
+        })
     }
 }
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = u32::read_xdr(r)?;
-        match i {
-            0 => Ok(None),
-            1 => {
-                let t = T::read_xdr(r)?;
-                Ok(Some(t))
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = u32::read_xdr(r)?;
+            match i {
+                0 => Ok(None),
+                1 => {
+                    let t = T::read_xdr(r)?;
+                    Ok(Some(t))
+                }
+                _ => Err(Error::Invalid),
             }
-            _ => Err(Error::Invalid),
-        }
+        })
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        if let Some(t) = self {
-            1u32.write_xdr(w)?;
-            t.write_xdr(w)?;
-        } else {
-            0u32.write_xdr(w)?;
-        }
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            Ok(if let Some(t) = self {
+                1u32.write_xdr(w)?;
+                t.write_xdr(w)?;
+            } else {
+                0u32.write_xdr(w)?;
+            })
+        })
     }
 }
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let t = T::read_xdr(r)?;
-        Ok(Box::new(t))
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        T::write_xdr(self, w)?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let mut arr = [0u8; N];
-        r.read_exact(&mut arr)?;
-
-        let pad = &mut [0u8; 3][..pad_len(N)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
-
-        Ok(arr)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let mut arr = [0u8; N];
+            r.read_exact(&mut arr)?;
+            let pad = &mut [0u8; 3][..pad_len(N)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
+            Ok(arr)
+        })
     }
 }
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        w.write_all(self)?;
-        w.write_all(&[0u8; 3][..pad_len(N)])?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            w.write_all(self)?;
+            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            Ok(())
+        })
     }
 }
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let mut vec = Vec::with_capacity(N);
-        for _ in 0..N {
-            let t = T::read_xdr(r)?;
-            vec.push(t);
-        }
-        let arr: [T; N] = vec.try_into().unwrap_or_else(|_: Vec<T>| unreachable!());
-        Ok(arr)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let mut vec = Vec::with_capacity(N);
+            for _ in 0..N {
+                let t = T::read_xdr(r)?;
+                vec.push(t);
+            }
+            let arr: [T; N] = vec.try_into().unwrap_or_else(|_: Vec<T>| unreachable!());
+            Ok(arr)
+        })
     }
 }
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        for t in self {
-            t.write_xdr(w)?;
-        }
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            for t in self {
+                t.write_xdr(w)?;
+            }
+            Ok(())
+        })
     }
 }
 
@@ -990,68 +1019,76 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(VecM(vec))
+            Ok(VecM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = Vec::with_capacity(len as usize);
-        for _ in 0..len {
-            let t = T::read_xdr(r)?;
-            vec.push(t);
-        }
+            let mut vec = Vec::with_capacity(len as usize);
+            for _ in 0..len {
+                let t = T::read_xdr(r)?;
+                vec.push(t);
+            }
 
-        Ok(VecM(vec))
+            Ok(VecM(vec))
+        })
     }
 }
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        for t in &self.0 {
-            t.write_xdr(w)?;
-        }
+            for t in &self.0 {
+                t.write_xdr(w)?;
+            }
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1380,36 +1417,40 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(BytesM(vec))
+            Ok(BytesM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1759,36 +1800,40 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(StringM(vec))
+            Ok(StringM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1809,7 +1854,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -1832,26 +1877,30 @@ where
 mod tests {
     use std::io::Cursor;
 
+    use crate::{DepthLimitedRead, DepthLimitedWrite};
+
     use super::{Error, ReadXdr, VecM, WriteXdr};
+
+    const DEPTH_LIMIT: u32 = 10;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1860,8 +1909,8 @@ mod tests {
 
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1872,7 +1921,12 @@ mod tests {
     pub fn vec_u8_write_without_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
-        v.write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+
+        v.write_xdr(&mut DepthLimitedWrite::new(
+            Cursor::new(&mut buf),
+            DEPTH_LIMIT,
+        ))
+        .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1880,28 +1934,32 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+        v.write_xdr(&mut DepthLimitedWrite::new(
+            Cursor::new(&mut buf),
+            DEPTH_LIMIT,
+        ))
+        .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
     #[test]
     pub fn arr_u8_read_without_padding() {
-        let mut buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![2, 2, 2, 2]);
+        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
-        let mut buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![2, 0, 0, 0]);
+        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
-        let mut buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![2, 0, 0]);
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1910,8 +1968,8 @@ mod tests {
 
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
-        let mut buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![2, 3, 0, 0]);
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1922,7 +1980,10 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Cursor::new(&mut buf))
+            .write_xdr(&mut DepthLimitedWrite::new(
+                Cursor::new(&mut buf),
+                DEPTH_LIMIT,
+            ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -1930,14 +1991,19 @@ mod tests {
     #[test]
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
-        [2u8].write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+        [2u8]
+            .write_xdr(&mut DepthLimitedWrite::new(
+                Cursor::new(&mut buf),
+                DEPTH_LIMIT,
+            ))
+            .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
 }
 
 #[cfg(all(test, feature = "std"))]
 mod test {
-    use super::VecM;
+    use super::*;
 
     #[test]
     fn into_option_none() {
@@ -1961,6 +2027,36 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = vec![1].try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+
+    #[test]
+    fn depth_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[should_panic]
+    #[test]
+    fn write_over_depth_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 3);
+        a.write_xdr(&mut buf).unwrap();
+    }
+
+    #[should_panic]
+    #[test]
+    fn read_over_depth_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 5);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 3);
+        let _: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
     }
 }
 
@@ -2008,21 +2104,25 @@ pub struct HasOptions {
         impl ReadXdr for HasOptions {
             #[cfg(feature = "std")]
             fn read_xdr(r: &mut impl Read) -> Result<Self> {
-                Ok(Self{
-                  first_option: Option::<i32>::read_xdr(r)?,
+                r.with_limited_depth(|r| {
+                    Ok(Self{
+                      first_option: Option::<i32>::read_xdr(r)?,
 second_option: Option::<i32>::read_xdr(r)?,
 third_option: Option::<i32>::read_xdr(r)?,
-                })
+                    })
+                }
             }
         }
 
         impl WriteXdr for HasOptions {
             #[cfg(feature = "std")]
             fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-                self.first_option.write_xdr(w)?;
+                w.with_limited_depth(|w| {
+                    self.first_option.write_xdr(w)?;
 self.second_option.write_xdr(w)?;
 self.third_option.write_xdr(w)?;
-                Ok(())
+                    Ok(())
+                })
             }
         }
 
@@ -2104,22 +2204,25 @@ TypeVariant::HasOptions, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 match v {
-                    TypeVariant::Arr => Ok(Self::Arr(Box::new(Arr::read_xdr(r)?))),
-TypeVariant::HasOptions => Ok(Self::HasOptions(Box::new(HasOptions::read_xdr(r)?))),
+                    TypeVariant::Arr => r.with_limited_depth(|r| Ok(Self::Arr(Box::new(Arr::read_xdr(r)?))))?,
+TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new(HasOptions::read_xdr(r)?))))?,
                 }
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
-                let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+            pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(
+                  base64::read::DecoderReader::new(r, base64::STANDARD),
+                  depth_limit,
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2131,51 +2234,54 @@ TypeVariant::HasOptions => Ok(Self::HasOptions(Box::new(HasOptions::read_xdr(r)?
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
-                let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+            pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(
+                  base64::read::DecoderReader::new(r, base64::STANDARD),
+                  depth_limit,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit: u32) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(r).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(r).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(r, depth_limit).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(r, depth_limit).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Frame<Arr>>::new(r).map(|r| r.map(|t| Self::Arr(Box::new(t.0))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(r).map(|r| r.map(|t| Self::HasOptions(Box::new(t.0))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Frame<Arr>>::new(r, depth_limit).map(|r| r.map(|t| Self::Arr(Box::new(t.0))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(r, depth_limit).map(|r| r.map(|t| Self::HasOptions(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec, depth_limit).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, depth_limit).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = Cursor::new(bytes.as_ref());
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, depth_limit: u32) -> Result<Self> {
+                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String, depth_limit: u32) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), depth_limit);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -11,10 +11,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
-use super::depth_limiter::*;
-
-#[cfg(feature = "std")]
-use core::marker::PhantomData;
+use core::{cell::RefCell, marker::PhantomData};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -53,6 +50,8 @@ use std::{
     error, io,
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
+
+pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
@@ -185,6 +184,112 @@ where
 {
 }
 
+pub trait DepthLimiter {
+    type DepthError;
+
+    fn enter(&self) -> core::result::Result<(), Self::DepthError>;
+
+    fn leave(&self);
+
+    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthError>
+    where
+        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthError>,
+    {
+        self.enter()?;
+        let res = f(self)?;
+        self.leave();
+        Ok(res)
+    }
+}
+
+#[cfg(feature = "std")]
+pub struct DepthLimitedRead<R: Read> {
+    pub inner: R,
+    pub(crate) depth: RefCell<u32>,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> DepthLimitedRead<R> {
+    pub fn new(inner: R, depth: u32) -> Self {
+        DepthLimitedRead {
+            inner,
+            depth: RefCell::new(depth),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
+    type DepthError = Error;
+
+    fn enter(&self) -> core::result::Result<(), Error> {
+        let depth = *self.depth.borrow();
+        if depth == 0 {
+            return Err(Error::DepthLimitExceeded);
+        }
+        self.depth.replace(depth - 1);
+        Ok(())
+    }
+
+    fn leave(&self) {
+        let depth = *self.depth.borrow();
+        self.depth.replace(depth.saturating_add(1));
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for DepthLimitedRead<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+pub struct DepthLimitedWrite<W: Write> {
+    pub inner: W,
+    pub(crate) depth: RefCell<u32>,
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> DepthLimitedWrite<W> {
+    pub fn new(inner: W, depth: u32) -> Self {
+        DepthLimitedWrite {
+            inner,
+            depth: RefCell::new(depth),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
+    type DepthError = Error;
+
+    fn enter(&self) -> Result<()> {
+        let depth = *self.depth.borrow();
+        if depth == 0 {
+            return Err(Error::DepthLimitExceeded);
+        }
+        self.depth.replace(depth - 1);
+        Ok(())
+    }
+
+    fn leave(&self) {
+        let depth = *self.depth.borrow();
+        self.depth.replace(depth.saturating_add(1));
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for DepthLimitedWrite<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
     reader: DepthLimitedRead<BufReader<R>>,
@@ -193,9 +298,12 @@ pub struct ReadXdrIter<R: Read, S: ReadXdr> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth_limit: u32) -> Self {
+    fn new(r: R, depth: u32) -> Self {
         Self {
-            reader: DepthLimitedRead::new(BufReader::new(r), depth_limit),
+            reader: DepthLimitedRead {
+                inner: BufReader::new(r),
+                depth: RefCell::new(depth),
+            },
             _s: PhantomData,
         }
     }
@@ -263,10 +371,10 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
-            base64::read::DecoderReader::new(r, base64::STANDARD),
-            depth_limit,
+            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            r.depth.take(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -307,10 +415,10 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
-            base64::read::DecoderReader::new(r, base64::STANDARD),
-            depth_limit,
+            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            r.depth.take(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -385,19 +493,18 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut R, depth_limit: u32) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(r, depth_limit)
+    fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
+        ReadXdrIter::new(&mut r.inner, r.depth.take())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
     /// values that are read into the implementing type.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
-        r: &mut R,
-        depth_limit: u32,
+        r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
-        ReadXdrIter::new(dec, depth_limit)
+        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        ReadXdrIter::new(dec, r.depth.take())
     }
 
     /// Construct the type from the XDR bytes.
@@ -405,8 +512,9 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
+        let mut cursor =
+            DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
@@ -416,11 +524,11 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            depth_limit,
+            DEFAULT_MAX_DEPTH_LIMIT,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -432,18 +540,18 @@ pub trait WriteXdr {
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, depth_limit: u32) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), DEFAULT_MAX_DEPTH_LIMIT);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, depth_limit: u32) -> Result<String> {
+    fn to_xdr_base64(&self) -> Result<String> {
         let mut enc = DepthLimitedWrite::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            depth_limit,
+            DEFAULT_MAX_DEPTH_LIMIT,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
@@ -604,12 +712,13 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         w.with_limited_depth(|w| {
-            Ok(if let Some(t) = self {
+            if let Some(t) = self {
                 1u32.write_xdr(w)?;
                 t.write_xdr(w)?;
             } else {
                 0u32.write_xdr(w)?;
-            })
+            }
+            Ok(())
         })
     }
 }
@@ -1877,30 +1986,31 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use crate::{DepthLimitedRead, DepthLimitedWrite};
-
-    use super::{Error, ReadXdr, VecM, WriteXdr};
-
-    const DEPTH_LIMIT: u32 = 10;
+    use super::{
+        DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
+        DEFAULT_MAX_DEPTH_LIMIT,
+    };
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1910,7 +2020,7 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1924,7 +2034,7 @@ mod tests {
 
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEPTH_LIMIT,
+            DEFAULT_MAX_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
@@ -1936,7 +2046,7 @@ mod tests {
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEPTH_LIMIT,
+            DEFAULT_MAX_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
@@ -1945,21 +2055,23 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v =
+            <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v =
+            <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1969,7 +2081,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1982,7 +2094,7 @@ mod tests {
         [2u8, 2, 2, 2]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEPTH_LIMIT,
+                DEFAULT_MAX_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -1994,7 +2106,7 @@ mod tests {
         [2u8]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEPTH_LIMIT,
+                DEFAULT_MAX_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2040,23 +2152,32 @@ mod test {
         assert_eq!(a, a_back);
     }
 
-    #[should_panic]
     #[test]
     fn write_over_depth_limit_fail() {
+        let depth_limit = 3;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 3);
-        a.write_xdr(&mut buf).unwrap();
+        let mut buf = DepthLimitedWrite::new(Vec::new(), depth_limit);
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::DepthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
     }
 
-    #[should_panic]
     #[test]
     fn read_over_depth_limit_fail() {
+        let read_depth_limit = 3;
+        let write_depth_limit = 5;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 5);
+        let mut buf = DepthLimitedWrite::new(Vec::new(), write_depth_limit);
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 3);
-        let _: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), read_depth_limit);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::DepthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
     }
 }
 
@@ -2107,7 +2228,7 @@ pub struct MyStruct {
 
         impl ReadXdr for MyStruct {
             #[cfg(feature = "std")]
-            fn read_xdr(r: &mut impl Read) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       some_int: i32::read_xdr(r)?,
@@ -2116,13 +2237,13 @@ some_opaque: <[u8; 10]>::read_xdr(r)?,
 some_string: StringM::read_xdr(r)?,
 max_string: StringM::<100>::read_xdr(r)?,
                     })
-                }
+                })
             }
         }
 
         impl WriteXdr for MyStruct {
             #[cfg(feature = "std")]
-            fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     self.some_int.write_xdr(w)?;
 self.a_big_int.write_xdr(w)?;
@@ -2214,17 +2335,14 @@ TypeVariant::MyStruct, ];
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 match v {
-                    TypeVariant::Int64 => r.with_limited_depth(|r| Ok(Self::Int64(Box::new(Int64::read_xdr(r)?))))?,
-TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyStruct::read_xdr(r)?))))?,
+                    TypeVariant::Int64 => r.with_limited_depth(|r| Ok(Self::Int64(Box::new(Int64::read_xdr(r)?)))),
+TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyStruct::read_xdr(r)?)))),
                 }
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(
-                  base64::read::DecoderReader::new(r, base64::STANDARD),
-                  depth_limit,
-                );
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2242,54 +2360,51 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(
-                  base64::read::DecoderReader::new(r, base64::STANDARD),
-                  depth_limit,
-                );
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit: u32) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(r, depth_limit).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(r, depth_limit).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Frame<Int64>>::new(r, depth_limit).map(|r| r.map(|t| Self::Int64(Box::new(t.0))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(r, depth_limit).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
+                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Frame<Int64>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Int64(Box::new(t.0))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(dec, depth_limit).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, depth_limit).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, depth_limit: u32) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
+                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String, depth_limit: u32) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), depth_limit);
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_MAX_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -56,7 +56,7 @@ use std::{
 /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
 /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
 /// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
+pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
@@ -570,7 +570,7 @@ where
     /// deserialization.
     #[cfg(feature = "std")]
     fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_MAX_DEPTH_LIMIT)
+        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 
     /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
@@ -594,7 +594,7 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_MAX_DEPTH_LIMIT)
+        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -612,7 +612,7 @@ pub trait WriteXdr {
 
     #[cfg(feature = "std")]
     fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 
     #[cfg(feature = "base64")]
@@ -628,7 +628,7 @@ pub trait WriteXdr {
 
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -2061,29 +2061,32 @@ mod tests {
 
     use super::{
         DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_MAX_DEPTH_LIMIT,
+        DEFAULT_XDR_RW_DEPTH_LIMIT,
     };
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
-            .unwrap();
+        let v =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+                .unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
-            .unwrap();
+        let v =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+                .unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2093,7 +2096,8 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2107,7 +2111,7 @@ mod tests {
 
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
@@ -2119,7 +2123,7 @@ mod tests {
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
@@ -2128,23 +2132,23 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v =
-            <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v =
-            <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2154,7 +2158,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2167,7 +2171,7 @@ mod tests {
         [2u8, 2, 2, 2]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEFAULT_MAX_DEPTH_LIMIT,
+                DEFAULT_XDR_RW_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2179,7 +2183,7 @@ mod tests {
         [2u8]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEFAULT_MAX_DEPTH_LIMIT,
+                DEFAULT_XDR_RW_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2469,7 +2473,7 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.depth_r
 
             #[cfg(feature = "std")]
             pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
+                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
@@ -2477,7 +2481,7 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.depth_r
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_MAX_DEPTH_LIMIT);
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -11,7 +11,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
-use core::{cell::RefCell, marker::PhantomData};
+use core::marker::PhantomData;
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -194,15 +194,18 @@ where
 /// It provides a mechanism to limit recursion depth, and defines the behavior upon
 /// entering and leaving a recursion level.
 pub trait DepthLimiter {
-    /// The error type returned by methods when they fail due to exceeding the depth limit.
-    type DepthError;
+    /// A general error type for any type implementing, or an operation under the guard of
+    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
+    /// which is returned from `enter`.
+    type DepthLimiterError;
 
     /// Defines the behavior for entering a new recursion level.
-    /// A `DepthError` is returned if the new level exceeds the depth limit.
-    fn enter(&self) -> core::result::Result<(), Self::DepthError>;
+    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
+    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
 
     /// Defines the behavior for leaving a recursion level.
-    fn leave(&self);
+    /// A `DepthLimiterError` is returned if an error occurs.
+    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
 
     /// Wraps a given function `f` with depth limiting guards.
     /// It triggers an `enter` before, and a `leave` after the execution of `f`.
@@ -213,16 +216,17 @@ pub trait DepthLimiter {
     ///
     /// # Returns
     ///
-    /// - `Ok` with function result if `f` executes without exceeding depth limits,
-    ///   `Err` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthError>
+    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
+    ///         with an error 3. if error occurs on `leave`.
+    ///   `Ok` otherwise.
+    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
     where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthError>,
+        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
     {
         self.enter()?;
-        let res = f(self)?;
-        self.leave();
-        Ok(res)
+        let res = f(self);
+        self.leave()?;
+        res
     }
 }
 
@@ -232,7 +236,7 @@ pub trait DepthLimiter {
 #[cfg(feature = "std")]
 pub struct DepthLimitedRead<R: Read> {
     pub inner: R,
-    pub(crate) depth_remaining: RefCell<u32>,
+    pub(crate) depth_remaining: u32,
 }
 
 #[cfg(feature = "std")]
@@ -244,30 +248,31 @@ impl<R: Read> DepthLimitedRead<R> {
     pub fn new(inner: R, depth_limit: u32) -> Self {
         DepthLimitedRead {
             inner,
-            depth_remaining: RefCell::new(depth_limit),
+            depth_remaining: depth_limit,
         }
     }
 }
 
 #[cfg(feature = "std")]
 impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthError = Error;
+    type DepthLimiterError = Error;
 
     /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
     /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&self) -> core::result::Result<(), Error> {
-        let depth = *self.depth_remaining.borrow();
-        if depth == 0 {
+    fn enter(&mut self) -> core::result::Result<(), Error> {
+        if let Some(depth) = self.depth_remaining.checked_sub(1) {
+            self.depth_remaining = depth;
+        } else {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
-    /// Increments the depth, without exceeding the initial depth value.
-    fn leave(&self) {
-        let depth = *self.depth_remaining.borrow();
-        self.depth_remaining.replace(depth.saturating_add(1));
+    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
+    /// doesn't exceed the initial depth limit.
+    fn leave(&mut self) -> core::result::Result<(), Error> {
+        self.depth_remaining = self.depth_remaining.saturating_add(1);
+        Ok(())
     }
 }
 
@@ -285,7 +290,7 @@ impl<R: Read> Read for DepthLimitedRead<R> {
 #[cfg(feature = "std")]
 pub struct DepthLimitedWrite<W: Write> {
     pub inner: W,
-    pub(crate) depth_remaining: RefCell<u32>,
+    pub(crate) depth_remaining: u32,
 }
 
 #[cfg(feature = "std")]
@@ -297,30 +302,31 @@ impl<W: Write> DepthLimitedWrite<W> {
     pub fn new(inner: W, depth_limit: u32) -> Self {
         DepthLimitedWrite {
             inner,
-            depth_remaining: RefCell::new(depth_limit),
+            depth_remaining: depth_limit,
         }
     }
 }
 
 #[cfg(feature = "std")]
 impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthError = Error;
+    type DepthLimiterError = Error;
 
     /// Decrements the `depth_remaining`. If the depth is already zero, an error is
     /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&self) -> Result<()> {
-        let depth = *self.depth_remaining.borrow();
-        if depth == 0 {
+    fn enter(&mut self) -> Result<()> {
+        if let Some(depth) = self.depth_remaining.checked_sub(1) {
+            self.depth_remaining = depth;
+        } else {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
-    /// Increments the depth, without exceeding the initial depth value.
-    fn leave(&self) {
-        let depth = *self.depth_remaining.borrow();
-        self.depth_remaining.replace(depth.saturating_add(1));
+    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
+    /// doesn't exceed the initial depth limit.
+    fn leave(&mut self) -> core::result::Result<(), Error> {
+        self.depth_remaining = self.depth_remaining.saturating_add(1);
+        Ok(())
     }
 }
 
@@ -349,7 +355,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
         Self {
             reader: DepthLimitedRead {
                 inner: BufReader::new(r),
-                depth_remaining: RefCell::new(depth_limit),
+                depth_remaining: depth_limit,
             },
             _s: PhantomData,
         }
@@ -421,7 +427,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining.take(),
+            r.depth_remaining,
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -465,7 +471,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining.take(),
+            r.depth_remaining,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -541,7 +547,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining.take())
+        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -551,7 +557,7 @@ where
         r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining.take())
+        ReadXdrIter::new(dec, r.depth_remaining)
     }
 
     /// Construct the type from the XDR bytes, specifying a depth limit.
@@ -2420,7 +2426,7 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2439,7 +2445,7 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2448,8 +2454,8 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
                 }
             }
 
@@ -2457,8 +2463,8 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, 
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Frame<Int64>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Int64(Box::new(t.0))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
+                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Frame<Int64>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Int64(Box::new(t.0))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
                 }
             }
 
@@ -2467,8 +2473,8 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -55,7 +55,8 @@ use std::{
 ///
 /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
 /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+/// For more information about Rust's stack size limit, refer to the
+/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
 pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -51,10 +51,11 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Depth limit for recursive calls in `Read/WriteXdr`. Mimics the stack depth
-/// and its purpose is to avoid the running program from reaching the Rust's
-/// stack size limit (see https://doc.rust-lang.org/std/thread/#stack-size),
-/// which leads to an unrecoverable `SIGABRT`.
+/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+///
+/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+/// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
 pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
@@ -225,11 +226,12 @@ pub trait DepthLimiter {
 }
 
 /// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth` state tracking remaining recursion depth.
+/// recursive read operations. It maintains a `depth_remaining` state tracking
+/// remaining allowed recursion depth.
 #[cfg(feature = "std")]
 pub struct DepthLimitedRead<R: Read> {
     pub inner: R,
-    pub(crate) depth: RefCell<u32>,
+    pub(crate) depth_remaining: RefCell<u32>,
 }
 
 #[cfg(feature = "std")]
@@ -237,11 +239,11 @@ impl<R: Read> DepthLimitedRead<R> {
     /// Constructs a new `DepthLimitedRead`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
-    /// - `depth`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth: u32) -> Self {
+    /// - `depth_limit`: The maximum allowed recursion depth.
+    pub fn new(inner: R, depth_limit: u32) -> Self {
         DepthLimitedRead {
             inner,
-            depth: RefCell::new(depth),
+            depth_remaining: RefCell::new(depth_limit),
         }
     }
 }
@@ -250,21 +252,21 @@ impl<R: Read> DepthLimitedRead<R> {
 impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
     type DepthError = Error;
 
-    /// Decrements the depth. If the depth is already zero, an error is returned indicating
-    /// that the maximum depth limit has been exceeded.
+    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
+    /// returned indicating that the maximum depth limit has been exceeded.
     fn enter(&self) -> core::result::Result<(), Error> {
-        let depth = *self.depth.borrow();
+        let depth = *self.depth_remaining.borrow();
         if depth == 0 {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth.replace(depth - 1);
+        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
     /// Increments the depth, without exceeding the initial depth value.
     fn leave(&self) {
-        let depth = *self.depth.borrow();
-        self.depth.replace(depth.saturating_add(1));
+        let depth = *self.depth_remaining.borrow();
+        self.depth_remaining.replace(depth.saturating_add(1));
     }
 }
 
@@ -277,11 +279,12 @@ impl<R: Read> Read for DepthLimitedRead<R> {
 }
 
 /// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth` state tracking remaining recursion depth.
+/// recursive write operations. It maintains a `depth_remaining` state tracking
+/// remaining allowed recursion depth.
 #[cfg(feature = "std")]
 pub struct DepthLimitedWrite<W: Write> {
     pub inner: W,
-    pub(crate) depth: RefCell<u32>,
+    pub(crate) depth_remaining: RefCell<u32>,
 }
 
 #[cfg(feature = "std")]
@@ -289,11 +292,11 @@ impl<W: Write> DepthLimitedWrite<W> {
     /// Constructs a new `DepthLimitedWrite`.
     ///
     /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth: u32) -> Self {
+    /// - `depth_limit`: The maximum allowed recursion depth.
+    pub fn new(inner: W, depth_limit: u32) -> Self {
         DepthLimitedWrite {
             inner,
-            depth: RefCell::new(depth),
+            depth_remaining: RefCell::new(depth_limit),
         }
     }
 }
@@ -302,21 +305,21 @@ impl<W: Write> DepthLimitedWrite<W> {
 impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
     type DepthError = Error;
 
-    /// Decrements the depth. If the depth is already zero, an error is returned indicating
-    /// that the maximum depth limit has been exceeded.
+    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
+    /// returned indicating that the maximum depth limit has been exceeded.
     fn enter(&self) -> Result<()> {
-        let depth = *self.depth.borrow();
+        let depth = *self.depth_remaining.borrow();
         if depth == 0 {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth.replace(depth - 1);
+        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
     /// Increments the depth, without exceeding the initial depth value.
     fn leave(&self) {
-        let depth = *self.depth.borrow();
-        self.depth.replace(depth.saturating_add(1));
+        let depth = *self.depth_remaining.borrow();
+        self.depth_remaining.replace(depth.saturating_add(1));
     }
 }
 
@@ -341,11 +344,11 @@ pub struct ReadXdrIter<R: Read, S: ReadXdr> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth: u32) -> Self {
+    fn new(r: R, depth_limit: u32) -> Self {
         Self {
             reader: DepthLimitedRead {
                 inner: BufReader::new(r),
-                depth: RefCell::new(depth),
+                depth_remaining: RefCell::new(depth_limit),
             },
             _s: PhantomData,
         }
@@ -417,7 +420,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth.take(),
+            r.depth_remaining.take(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -461,7 +464,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth.take(),
+            r.depth_remaining.take(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -537,7 +540,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth.take())
+        ReadXdrIter::new(&mut r.inner, r.depth_remaining.take())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -547,34 +550,51 @@ where
         r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth.take())
+        ReadXdrIter::new(dec, r.depth_remaining.take())
     }
 
-    /// Construct the type from the XDR bytes.
+    /// Construct the type from the XDR bytes, specifying a depth limit.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
+    #[cfg(feature = "std")]
+    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+        let t = Self::read_xdr_to_end(&mut cursor)?;
+        Ok(t)
+    }
+
+    /// Construct the type from the XDR bytes, using the default depth limit.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
     fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        let mut cursor =
-            DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
-        let t = Self::read_xdr_to_end(&mut cursor)?;
+        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_MAX_DEPTH_LIMIT)
+    }
+
+    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
+    #[cfg(feature = "base64")]
+    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut b64_reader = Cursor::new(b64);
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            depth_limit,
+        );
+        let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes base64 encoded.
+    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            DEFAULT_MAX_DEPTH_LIMIT,
-        );
-        let t = Self::read_xdr_to_end(&mut dec)?;
-        Ok(t)
+        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_MAX_DEPTH_LIMIT)
     }
 }
 
@@ -583,22 +603,32 @@ pub trait WriteXdr {
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), DEFAULT_MAX_DEPTH_LIMIT);
+    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
+    #[cfg(feature = "std")]
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        self.to_xdr_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+    }
+
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
+    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
         let mut enc = DepthLimitedWrite::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            depth_limit,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
+    }
+
+    #[cfg(feature = "base64")]
+    fn to_xdr_base64(&self) -> Result<String> {
+        self.to_xdr_base64_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
     }
 }
 
@@ -2385,7 +2415,7 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2404,7 +2434,7 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2413,8 +2443,8 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
                 }
             }
 
@@ -2422,8 +2452,8 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, 
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Frame<Int64>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Int64(Box::new(t.0))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
+                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Frame<Int64>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Int64(Box::new(t.0))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
                 }
             }
 
@@ -2432,8 +2462,8 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -11,6 +11,9 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
+use super::depth_limiter::*;
+
+#[cfg(feature = "std")]
 use core::marker::PhantomData;
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
@@ -66,6 +69,7 @@ pub enum Error {
     InvalidHex,
     #[cfg(feature = "std")]
     Io(io::Error),
+    DepthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -109,6 +113,7 @@ impl fmt::Display for Error {
             Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{e}"),
+            Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
         }
     }
 }
@@ -182,15 +187,15 @@ where
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: BufReader<R>,
+    reader: DepthLimitedRead<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R) -> Self {
+    fn new(r: R, depth_limit: u32) -> Self {
         Self {
-            reader: BufReader::new(r),
+            reader: DepthLimitedRead::new(BufReader::new(r), depth_limit),
             _s: PhantomData,
         }
     }
@@ -214,7 +219,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.fill_buf() {
+        match self.reader.inner.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -224,7 +229,8 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
             Ok([..]) => (),
         };
         // Read the buf into the type.
-        match S::read_xdr(&mut self.reader) {
+        let r = self.reader.with_limited_depth(|dlr| S::read_xdr(dlr));
+        match r {
             Ok(s) => Some(Ok(s)),
             Err(e) => Some(Err(e)),
         }
@@ -247,18 +253,21 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     ///
-    /// Use [`ReadXdr::read_xdr_to_end`] when the intent is for all bytes in the
+    /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64(r: &mut impl Read) -> Result<Self> {
-        let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+    fn read_xdr_base64(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(r, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
     }
@@ -282,7 +291,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -298,8 +307,11 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end(r: &mut impl Read) -> Result<Self> {
-        let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+    fn read_xdr_base64_to_end(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(r, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
@@ -316,10 +328,10 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     ///
-    /// Use [`ReadXdr::read_xdr_into_to_end`] when the intent is for all bytes
+    /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -343,7 +355,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end(&mut self, r: &mut impl Read) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -373,8 +385,8 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut R) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(r)
+    fn read_xdr_iter<R: Read>(r: &mut R, depth_limit: u32) -> ReadXdrIter<&mut R, Self> {
+        ReadXdrIter::new(r, depth_limit)
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -382,9 +394,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut R,
+        depth_limit: u32,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
-        ReadXdrIter::new(dec)
+        ReadXdrIter::new(dec, depth_limit)
     }
 
     /// Construct the type from the XDR bytes.
@@ -392,8 +405,8 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        let mut cursor = Cursor::new(bytes.as_ref());
+    fn from_xdr(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
@@ -403,9 +416,12 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
@@ -413,21 +429,24 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        let mut cursor = Cursor::new(vec![]);
+    fn to_xdr(&self, depth_limit: u32) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
         self.write_xdr(&mut cursor)?;
-        let bytes = cursor.into_inner();
+        let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        let mut enc = base64::write::EncoderStringWriter::new(base64::STANDARD);
+    fn to_xdr_base64(&self, depth_limit: u32) -> Result<String> {
+        let mut enc = DepthLimitedWrite::new(
+            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            depth_limit,
+        );
         self.write_xdr(&mut enc)?;
-        let b64 = enc.into_inner();
+        let b64 = enc.inner.into_inner();
         Ok(b64)
     }
 }
@@ -441,229 +460,239 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 4];
-        r.read_exact(&mut b)?;
-        let i = i32::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(i32::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 4];
-        r.read_exact(&mut b)?;
-        let i = u32::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(u32::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 8];
-        r.read_exact(&mut b)?;
-        let i = i64::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(i64::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 8];
-        r.read_exact(&mut b)?;
-        let i = u64::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(u64::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = u32::read_xdr(r)?;
-        let b = i == 1;
-        Ok(b)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = u32::read_xdr(r)?;
+            let b = i == 1;
+            Ok(b)
+        })
     }
 }
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let i = u32::from(*self); // true = 1, false = 0
-        i.write_xdr(w)?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let i = u32::from(*self); // true = 1, false = 0
+            i.write_xdr(w)
+        })
     }
 }
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = u32::read_xdr(r)?;
-        match i {
-            0 => Ok(None),
-            1 => {
-                let t = T::read_xdr(r)?;
-                Ok(Some(t))
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = u32::read_xdr(r)?;
+            match i {
+                0 => Ok(None),
+                1 => {
+                    let t = T::read_xdr(r)?;
+                    Ok(Some(t))
+                }
+                _ => Err(Error::Invalid),
             }
-            _ => Err(Error::Invalid),
-        }
+        })
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        if let Some(t) = self {
-            1u32.write_xdr(w)?;
-            t.write_xdr(w)?;
-        } else {
-            0u32.write_xdr(w)?;
-        }
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            Ok(if let Some(t) = self {
+                1u32.write_xdr(w)?;
+                t.write_xdr(w)?;
+            } else {
+                0u32.write_xdr(w)?;
+            })
+        })
     }
 }
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let t = T::read_xdr(r)?;
-        Ok(Box::new(t))
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        T::write_xdr(self, w)?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let mut arr = [0u8; N];
-        r.read_exact(&mut arr)?;
-
-        let pad = &mut [0u8; 3][..pad_len(N)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
-
-        Ok(arr)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let mut arr = [0u8; N];
+            r.read_exact(&mut arr)?;
+            let pad = &mut [0u8; 3][..pad_len(N)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
+            Ok(arr)
+        })
     }
 }
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        w.write_all(self)?;
-        w.write_all(&[0u8; 3][..pad_len(N)])?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            w.write_all(self)?;
+            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            Ok(())
+        })
     }
 }
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let mut vec = Vec::with_capacity(N);
-        for _ in 0..N {
-            let t = T::read_xdr(r)?;
-            vec.push(t);
-        }
-        let arr: [T; N] = vec.try_into().unwrap_or_else(|_: Vec<T>| unreachable!());
-        Ok(arr)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let mut vec = Vec::with_capacity(N);
+            for _ in 0..N {
+                let t = T::read_xdr(r)?;
+                vec.push(t);
+            }
+            let arr: [T; N] = vec.try_into().unwrap_or_else(|_: Vec<T>| unreachable!());
+            Ok(arr)
+        })
     }
 }
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        for t in self {
-            t.write_xdr(w)?;
-        }
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            for t in self {
+                t.write_xdr(w)?;
+            }
+            Ok(())
+        })
     }
 }
 
@@ -990,68 +1019,76 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(VecM(vec))
+            Ok(VecM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = Vec::with_capacity(len as usize);
-        for _ in 0..len {
-            let t = T::read_xdr(r)?;
-            vec.push(t);
-        }
+            let mut vec = Vec::with_capacity(len as usize);
+            for _ in 0..len {
+                let t = T::read_xdr(r)?;
+                vec.push(t);
+            }
 
-        Ok(VecM(vec))
+            Ok(VecM(vec))
+        })
     }
 }
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        for t in &self.0 {
-            t.write_xdr(w)?;
-        }
+            for t in &self.0 {
+                t.write_xdr(w)?;
+            }
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1380,36 +1417,40 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(BytesM(vec))
+            Ok(BytesM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1759,36 +1800,40 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(StringM(vec))
+            Ok(StringM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1809,7 +1854,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -1832,26 +1877,30 @@ where
 mod tests {
     use std::io::Cursor;
 
+    use crate::{DepthLimitedRead, DepthLimitedWrite};
+
     use super::{Error, ReadXdr, VecM, WriteXdr};
+
+    const DEPTH_LIMIT: u32 = 10;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1860,8 +1909,8 @@ mod tests {
 
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1872,7 +1921,12 @@ mod tests {
     pub fn vec_u8_write_without_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
-        v.write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+
+        v.write_xdr(&mut DepthLimitedWrite::new(
+            Cursor::new(&mut buf),
+            DEPTH_LIMIT,
+        ))
+        .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1880,28 +1934,32 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+        v.write_xdr(&mut DepthLimitedWrite::new(
+            Cursor::new(&mut buf),
+            DEPTH_LIMIT,
+        ))
+        .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
     #[test]
     pub fn arr_u8_read_without_padding() {
-        let mut buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![2, 2, 2, 2]);
+        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
-        let mut buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![2, 0, 0, 0]);
+        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
-        let mut buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![2, 0, 0]);
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1910,8 +1968,8 @@ mod tests {
 
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
-        let mut buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![2, 3, 0, 0]);
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1922,7 +1980,10 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Cursor::new(&mut buf))
+            .write_xdr(&mut DepthLimitedWrite::new(
+                Cursor::new(&mut buf),
+                DEPTH_LIMIT,
+            ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -1930,14 +1991,19 @@ mod tests {
     #[test]
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
-        [2u8].write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+        [2u8]
+            .write_xdr(&mut DepthLimitedWrite::new(
+                Cursor::new(&mut buf),
+                DEPTH_LIMIT,
+            ))
+            .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
 }
 
 #[cfg(all(test, feature = "std"))]
 mod test {
-    use super::VecM;
+    use super::*;
 
     #[test]
     fn into_option_none() {
@@ -1961,6 +2027,36 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = vec![1].try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+
+    #[test]
+    fn depth_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[should_panic]
+    #[test]
+    fn write_over_depth_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 3);
+        a.write_xdr(&mut buf).unwrap();
+    }
+
+    #[should_panic]
+    #[test]
+    fn read_over_depth_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 5);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 3);
+        let _: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
     }
 }
 
@@ -2042,17 +2138,19 @@ impl AsRef<[u8; 64]> for Uint512 {
 
 impl ReadXdr for Uint512 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = <[u8; 64]>::read_xdr(r)?;
-        let v = Uint512(i);
-        Ok(v)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = <[u8; 64]>::read_xdr(r)?;
+            let v = Uint512(i);
+            Ok(v)})
+        })
     }
 }
 
 impl WriteXdr for Uint512 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        self.0.write_xdr(w)
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
 
@@ -2127,17 +2225,19 @@ impl AsRef<BytesM::<64>> for Uint513 {
 
 impl ReadXdr for Uint513 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = BytesM::<64>::read_xdr(r)?;
-        let v = Uint513(i);
-        Ok(v)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = BytesM::<64>::read_xdr(r)?;
+            let v = Uint513(i);
+            Ok(v)})
+        })
     }
 }
 
 impl WriteXdr for Uint513 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        self.0.write_xdr(w)
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
 
@@ -2224,17 +2324,19 @@ impl AsRef<BytesM> for Uint514 {
 
 impl ReadXdr for Uint514 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = BytesM::read_xdr(r)?;
-        let v = Uint514(i);
-        Ok(v)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = BytesM::read_xdr(r)?;
+            let v = Uint514(i);
+            Ok(v)})
+        })
     }
 }
 
 impl WriteXdr for Uint514 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        self.0.write_xdr(w)
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
 
@@ -2321,17 +2423,19 @@ impl AsRef<StringM::<64>> for Str {
 
 impl ReadXdr for Str {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = StringM::<64>::read_xdr(r)?;
-        let v = Str(i);
-        Ok(v)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = StringM::<64>::read_xdr(r)?;
+            let v = Str(i);
+            Ok(v)})
+        })
     }
 }
 
 impl WriteXdr for Str {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        self.0.write_xdr(w)
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
 
@@ -2418,17 +2522,19 @@ impl AsRef<StringM> for Str2 {
 
 impl ReadXdr for Str2 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = StringM::read_xdr(r)?;
-        let v = Str2(i);
-        Ok(v)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = StringM::read_xdr(r)?;
+            let v = Str2(i);
+            Ok(v)})
+        })
     }
 }
 
 impl WriteXdr for Str2 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        self.0.write_xdr(w)
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
 
@@ -2542,17 +2648,19 @@ impl AsRef<[u8; 32]> for Hash {
 
 impl ReadXdr for Hash {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = <[u8; 32]>::read_xdr(r)?;
-        let v = Hash(i);
-        Ok(v)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = <[u8; 32]>::read_xdr(r)?;
+            let v = Hash(i);
+            Ok(v)})
+        })
     }
 }
 
 impl WriteXdr for Hash {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        self.0.write_xdr(w)
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
 
@@ -2626,17 +2734,19 @@ impl AsRef<[Hash; 12]> for Hashes1 {
 
 impl ReadXdr for Hashes1 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = <[Hash; 12]>::read_xdr(r)?;
-        let v = Hashes1(i);
-        Ok(v)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = <[Hash; 12]>::read_xdr(r)?;
+            let v = Hashes1(i);
+            Ok(v)})
+        })
     }
 }
 
 impl WriteXdr for Hashes1 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        self.0.write_xdr(w)
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
 
@@ -2711,17 +2821,19 @@ impl AsRef<VecM::<Hash, 12>> for Hashes2 {
 
 impl ReadXdr for Hashes2 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = VecM::<Hash, 12>::read_xdr(r)?;
-        let v = Hashes2(i);
-        Ok(v)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = VecM::<Hash, 12>::read_xdr(r)?;
+            let v = Hashes2(i);
+            Ok(v)})
+        })
     }
 }
 
 impl WriteXdr for Hashes2 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        self.0.write_xdr(w)
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
 
@@ -2808,17 +2920,19 @@ impl AsRef<VecM::<Hash>> for Hashes3 {
 
 impl ReadXdr for Hashes3 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = VecM::<Hash>::read_xdr(r)?;
-        let v = Hashes3(i);
-        Ok(v)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = VecM::<Hash>::read_xdr(r)?;
+            let v = Hashes3(i);
+            Ok(v)})
+        })
     }
 }
 
 impl WriteXdr for Hashes3 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        self.0.write_xdr(w)
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
 
@@ -2904,17 +3018,19 @@ impl AsRef<Option<Hash>> for OptHash1 {
 
 impl ReadXdr for OptHash1 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = Option::<Hash>::read_xdr(r)?;
-        let v = OptHash1(i);
-        Ok(v)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = Option::<Hash>::read_xdr(r)?;
+            let v = OptHash1(i);
+            Ok(v)})
+        })
     }
 }
 
 impl WriteXdr for OptHash1 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        self.0.write_xdr(w)
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
 
@@ -2951,17 +3067,19 @@ impl AsRef<Option<Hash>> for OptHash2 {
 
 impl ReadXdr for OptHash2 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = Option::<Hash>::read_xdr(r)?;
-        let v = OptHash2(i);
-        Ok(v)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = Option::<Hash>::read_xdr(r)?;
+            let v = OptHash2(i);
+            Ok(v)})
+        })
     }
 }
 
 impl WriteXdr for OptHash2 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        self.0.write_xdr(w)
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
 
@@ -3018,29 +3136,33 @@ pub struct MyStruct {
         impl ReadXdr for MyStruct {
             #[cfg(feature = "std")]
             fn read_xdr(r: &mut impl Read) -> Result<Self> {
-                Ok(Self{
-                  field1: Uint512::read_xdr(r)?,
+                r.with_limited_depth(|r| {
+                    Ok(Self{
+                      field1: Uint512::read_xdr(r)?,
 field2: OptHash1::read_xdr(r)?,
 field3: i32::read_xdr(r)?,
 field4: u32::read_xdr(r)?,
 field5: f32::read_xdr(r)?,
 field6: f64::read_xdr(r)?,
 field7: bool::read_xdr(r)?,
-                })
+                    })
+                }
             }
         }
 
         impl WriteXdr for MyStruct {
             #[cfg(feature = "std")]
             fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-                self.field1.write_xdr(w)?;
+                w.with_limited_depth(|w| {
+                    self.field1.write_xdr(w)?;
 self.field2.write_xdr(w)?;
 self.field3.write_xdr(w)?;
 self.field4.write_xdr(w)?;
 self.field5.write_xdr(w)?;
 self.field6.write_xdr(w)?;
 self.field7.write_xdr(w)?;
-                Ok(())
+                    Ok(())
+                })
             }
         }
 
@@ -3061,17 +3183,21 @@ pub struct LotsOfMyStructs {
 impl ReadXdr for LotsOfMyStructs {
     #[cfg(feature = "std")]
     fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        Ok(Self{
-          members: VecM::<MyStruct>::read_xdr(r)?,
-        })
+        r.with_limited_depth(|r| {
+            Ok(Self{
+              members: VecM::<MyStruct>::read_xdr(r)?,
+            })
+        }
     }
 }
 
 impl WriteXdr for LotsOfMyStructs {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        self.members.write_xdr(w)?;
-        Ok(())
+        w.with_limited_depth(|w| {
+            self.members.write_xdr(w)?;
+            Ok(())
+        })
     }
 }
 
@@ -3092,17 +3218,21 @@ pub struct HasStuff {
 impl ReadXdr for HasStuff {
     #[cfg(feature = "std")]
     fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        Ok(Self{
-          data: LotsOfMyStructs::read_xdr(r)?,
-        })
+        r.with_limited_depth(|r| {
+            Ok(Self{
+              data: LotsOfMyStructs::read_xdr(r)?,
+            })
+        }
     }
 }
 
 impl WriteXdr for HasStuff {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        self.data.write_xdr(w)?;
-        Ok(())
+        w.with_limited_depth(|w| {
+            self.data.write_xdr(w)?;
+            Ok(())
+        })
     }
 }
 
@@ -3193,18 +3323,22 @@ Self::Green => "Green",
 
         impl ReadXdr for Color {
             #[cfg(feature = "std")]
-            fn read_xdr(r: &mut impl Read) -> Result<Self> {
-                let e = i32::read_xdr(r)?;
-                let v: Self = e.try_into()?;
-                Ok(v)
+            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                r.with_limited_depth(|r| {
+                    let e = i32::read_xdr(r)?;
+                    let v: Self = e.try_into()?;
+                    Ok(v)
+                })
             }
         }
 
         impl WriteXdr for Color {
             #[cfg(feature = "std")]
-            fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-                let i: i32 = (*self).into();
-                i.write_xdr(w)
+            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+                w.with_limited_write(|w| {
+                    let i: i32 = (*self).into();
+                    i.write_xdr(w)
+                })
             }
         }
 
@@ -3301,18 +3435,22 @@ Self::2 => "2",
 
         impl ReadXdr for NesterNestedEnum {
             #[cfg(feature = "std")]
-            fn read_xdr(r: &mut impl Read) -> Result<Self> {
-                let e = i32::read_xdr(r)?;
-                let v: Self = e.try_into()?;
-                Ok(v)
+            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                r.with_limited_depth(|r| {
+                    let e = i32::read_xdr(r)?;
+                    let v: Self = e.try_into()?;
+                    Ok(v)
+                })
             }
         }
 
         impl WriteXdr for NesterNestedEnum {
             #[cfg(feature = "std")]
-            fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-                let i: i32 = (*self).into();
-                i.write_xdr(w)
+            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+                w.with_limited_write(|w| {
+                    let i: i32 = (*self).into();
+                    i.write_xdr(w)
+                })
             }
         }
 
@@ -3332,17 +3470,21 @@ pub struct NesterNestedStruct {
 impl ReadXdr for NesterNestedStruct {
     #[cfg(feature = "std")]
     fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        Ok(Self{
-          blah: i32::read_xdr(r)?,
-        })
+        r.with_limited_depth(|r| {
+            Ok(Self{
+              blah: i32::read_xdr(r)?,
+            })
+        }
     }
 }
 
 impl WriteXdr for NesterNestedStruct {
     #[cfg(feature = "std")]
     fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        self.blah.write_xdr(w)?;
-        Ok(())
+        w.with_limited_depth(|w| {
+            self.blah.write_xdr(w)?;
+            Ok(())
+        })
     }
 }
 
@@ -3417,27 +3559,31 @@ impl Union<Color> for NesterNestedUnion {}
 
 impl ReadXdr for NesterNestedUnion {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let dv: Color = <Color as ReadXdr>::read_xdr(r)?;
-        #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
-        let v = match dv {
-            Color::Red => Self::Red,
-            #[allow(unreachable_patterns)]
-            _ => return Err(Error::Invalid),
-        };
-        Ok(v)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_read(|r| {
+            let dv: Color = <Color as ReadXdr>::read_xdr(r)?;
+            #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
+            let v = match dv {
+                Color::Red => Self::Red,
+                #[allow(unreachable_patterns)]
+                _ => return Err(Error::Invalid),
+            };
+            Ok(v)
+        }
     }
 }
 
 impl WriteXdr for NesterNestedUnion {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        self.discriminant().write_xdr(w)?;
-        #[allow(clippy::match_same_arms)]
-        match self {
-            Self::Red => ().write_xdr(w)?,
-        };
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite) -> Result<()> {
+        w.with_limited_depth(|w| {
+            self.discriminant().write_xdr(w)?;
+            #[allow(clippy::match_same_arms)]
+            match self {
+                Self::Red => ().write_xdr(w)?,
+            };
+            Ok(())
+        })
     }
 }
 
@@ -3476,21 +3622,25 @@ pub struct Nester {
         impl ReadXdr for Nester {
             #[cfg(feature = "std")]
             fn read_xdr(r: &mut impl Read) -> Result<Self> {
-                Ok(Self{
-                  nested_enum: NesterNestedEnum::read_xdr(r)?,
+                r.with_limited_depth(|r| {
+                    Ok(Self{
+                      nested_enum: NesterNestedEnum::read_xdr(r)?,
 nested_struct: NesterNestedStruct::read_xdr(r)?,
 nested_union: NesterNestedUnion::read_xdr(r)?,
-                })
+                    })
+                }
             }
         }
 
         impl WriteXdr for Nester {
             #[cfg(feature = "std")]
             fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-                self.nested_enum.write_xdr(w)?;
+                w.with_limited_depth(|w| {
+                    self.nested_enum.write_xdr(w)?;
 self.nested_struct.write_xdr(w)?;
 self.nested_union.write_xdr(w)?;
-                Ok(())
+                    Ok(())
+                })
             }
         }
 
@@ -3740,43 +3890,46 @@ TypeVariant::NesterNestedUnion, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 match v {
-                    TypeVariant::Uint512 => Ok(Self::Uint512(Box::new(Uint512::read_xdr(r)?))),
-TypeVariant::Uint513 => Ok(Self::Uint513(Box::new(Uint513::read_xdr(r)?))),
-TypeVariant::Uint514 => Ok(Self::Uint514(Box::new(Uint514::read_xdr(r)?))),
-TypeVariant::Str => Ok(Self::Str(Box::new(Str::read_xdr(r)?))),
-TypeVariant::Str2 => Ok(Self::Str2(Box::new(Str2::read_xdr(r)?))),
-TypeVariant::Hash => Ok(Self::Hash(Box::new(Hash::read_xdr(r)?))),
-TypeVariant::Hashes1 => Ok(Self::Hashes1(Box::new(Hashes1::read_xdr(r)?))),
-TypeVariant::Hashes2 => Ok(Self::Hashes2(Box::new(Hashes2::read_xdr(r)?))),
-TypeVariant::Hashes3 => Ok(Self::Hashes3(Box::new(Hashes3::read_xdr(r)?))),
-TypeVariant::OptHash1 => Ok(Self::OptHash1(Box::new(OptHash1::read_xdr(r)?))),
-TypeVariant::OptHash2 => Ok(Self::OptHash2(Box::new(OptHash2::read_xdr(r)?))),
-TypeVariant::Int1 => Ok(Self::Int1(Box::new(Int1::read_xdr(r)?))),
-TypeVariant::Int2 => Ok(Self::Int2(Box::new(Int2::read_xdr(r)?))),
-TypeVariant::Int3 => Ok(Self::Int3(Box::new(Int3::read_xdr(r)?))),
-TypeVariant::Int4 => Ok(Self::Int4(Box::new(Int4::read_xdr(r)?))),
-TypeVariant::MyStruct => Ok(Self::MyStruct(Box::new(MyStruct::read_xdr(r)?))),
-TypeVariant::LotsOfMyStructs => Ok(Self::LotsOfMyStructs(Box::new(LotsOfMyStructs::read_xdr(r)?))),
-TypeVariant::HasStuff => Ok(Self::HasStuff(Box::new(HasStuff::read_xdr(r)?))),
-TypeVariant::Color => Ok(Self::Color(Box::new(Color::read_xdr(r)?))),
-TypeVariant::Nester => Ok(Self::Nester(Box::new(Nester::read_xdr(r)?))),
-TypeVariant::NesterNestedEnum => Ok(Self::NesterNestedEnum(Box::new(NesterNestedEnum::read_xdr(r)?))),
-TypeVariant::NesterNestedStruct => Ok(Self::NesterNestedStruct(Box::new(NesterNestedStruct::read_xdr(r)?))),
-TypeVariant::NesterNestedUnion => Ok(Self::NesterNestedUnion(Box::new(NesterNestedUnion::read_xdr(r)?))),
+                    TypeVariant::Uint512 => r.with_limited_depth(|r| Ok(Self::Uint512(Box::new(Uint512::read_xdr(r)?))))?,
+TypeVariant::Uint513 => r.with_limited_depth(|r| Ok(Self::Uint513(Box::new(Uint513::read_xdr(r)?))))?,
+TypeVariant::Uint514 => r.with_limited_depth(|r| Ok(Self::Uint514(Box::new(Uint514::read_xdr(r)?))))?,
+TypeVariant::Str => r.with_limited_depth(|r| Ok(Self::Str(Box::new(Str::read_xdr(r)?))))?,
+TypeVariant::Str2 => r.with_limited_depth(|r| Ok(Self::Str2(Box::new(Str2::read_xdr(r)?))))?,
+TypeVariant::Hash => r.with_limited_depth(|r| Ok(Self::Hash(Box::new(Hash::read_xdr(r)?))))?,
+TypeVariant::Hashes1 => r.with_limited_depth(|r| Ok(Self::Hashes1(Box::new(Hashes1::read_xdr(r)?))))?,
+TypeVariant::Hashes2 => r.with_limited_depth(|r| Ok(Self::Hashes2(Box::new(Hashes2::read_xdr(r)?))))?,
+TypeVariant::Hashes3 => r.with_limited_depth(|r| Ok(Self::Hashes3(Box::new(Hashes3::read_xdr(r)?))))?,
+TypeVariant::OptHash1 => r.with_limited_depth(|r| Ok(Self::OptHash1(Box::new(OptHash1::read_xdr(r)?))))?,
+TypeVariant::OptHash2 => r.with_limited_depth(|r| Ok(Self::OptHash2(Box::new(OptHash2::read_xdr(r)?))))?,
+TypeVariant::Int1 => r.with_limited_depth(|r| Ok(Self::Int1(Box::new(Int1::read_xdr(r)?))))?,
+TypeVariant::Int2 => r.with_limited_depth(|r| Ok(Self::Int2(Box::new(Int2::read_xdr(r)?))))?,
+TypeVariant::Int3 => r.with_limited_depth(|r| Ok(Self::Int3(Box::new(Int3::read_xdr(r)?))))?,
+TypeVariant::Int4 => r.with_limited_depth(|r| Ok(Self::Int4(Box::new(Int4::read_xdr(r)?))))?,
+TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyStruct::read_xdr(r)?))))?,
+TypeVariant::LotsOfMyStructs => r.with_limited_depth(|r| Ok(Self::LotsOfMyStructs(Box::new(LotsOfMyStructs::read_xdr(r)?))))?,
+TypeVariant::HasStuff => r.with_limited_depth(|r| Ok(Self::HasStuff(Box::new(HasStuff::read_xdr(r)?))))?,
+TypeVariant::Color => r.with_limited_depth(|r| Ok(Self::Color(Box::new(Color::read_xdr(r)?))))?,
+TypeVariant::Nester => r.with_limited_depth(|r| Ok(Self::Nester(Box::new(Nester::read_xdr(r)?))))?,
+TypeVariant::NesterNestedEnum => r.with_limited_depth(|r| Ok(Self::NesterNestedEnum(Box::new(NesterNestedEnum::read_xdr(r)?))))?,
+TypeVariant::NesterNestedStruct => r.with_limited_depth(|r| Ok(Self::NesterNestedStruct(Box::new(NesterNestedStruct::read_xdr(r)?))))?,
+TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNestedUnion(Box::new(NesterNestedUnion::read_xdr(r)?))))?,
                 }
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
-                let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+            pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(
+                  base64::read::DecoderReader::new(r, base64::STANDARD),
+                  depth_limit,
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -3788,114 +3941,117 @@ TypeVariant::NesterNestedUnion => Ok(Self::NesterNestedUnion(Box::new(NesterNest
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
-                let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+            pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(
+                  base64::read::DecoderReader::new(r, base64::STANDARD),
+                  depth_limit,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit: u32) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(r).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
-TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Uint513>::new(r).map(|r| r.map(|t| Self::Uint513(Box::new(t))))),
-TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Uint514>::new(r).map(|r| r.map(|t| Self::Uint514(Box::new(t))))),
-TypeVariant::Str => Box::new(ReadXdrIter::<_, Str>::new(r).map(|r| r.map(|t| Self::Str(Box::new(t))))),
-TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Str2>::new(r).map(|r| r.map(|t| Self::Str2(Box::new(t))))),
-TypeVariant::Hash => Box::new(ReadXdrIter::<_, Hash>::new(r).map(|r| r.map(|t| Self::Hash(Box::new(t))))),
-TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Hashes1>::new(r).map(|r| r.map(|t| Self::Hashes1(Box::new(t))))),
-TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Hashes2>::new(r).map(|r| r.map(|t| Self::Hashes2(Box::new(t))))),
-TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Hashes3>::new(r).map(|r| r.map(|t| Self::Hashes3(Box::new(t))))),
-TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, OptHash1>::new(r).map(|r| r.map(|t| Self::OptHash1(Box::new(t))))),
-TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, OptHash2>::new(r).map(|r| r.map(|t| Self::OptHash2(Box::new(t))))),
-TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Int1>::new(r).map(|r| r.map(|t| Self::Int1(Box::new(t))))),
-TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Int2>::new(r).map(|r| r.map(|t| Self::Int2(Box::new(t))))),
-TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Int3>::new(r).map(|r| r.map(|t| Self::Int3(Box::new(t))))),
-TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Int4>::new(r).map(|r| r.map(|t| Self::Int4(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(r).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
-TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, LotsOfMyStructs>::new(r).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t))))),
-TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, HasStuff>::new(r).map(|r| r.map(|t| Self::HasStuff(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(r).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Nester => Box::new(ReadXdrIter::<_, Nester>::new(r).map(|r| r.map(|t| Self::Nester(Box::new(t))))),
-TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, NesterNestedEnum>::new(r).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t))))),
-TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, NesterNestedStruct>::new(r).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t))))),
-TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::new(r).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t))))),
+                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(r, depth_limit).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
+TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Uint513>::new(r, depth_limit).map(|r| r.map(|t| Self::Uint513(Box::new(t))))),
+TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Uint514>::new(r, depth_limit).map(|r| r.map(|t| Self::Uint514(Box::new(t))))),
+TypeVariant::Str => Box::new(ReadXdrIter::<_, Str>::new(r, depth_limit).map(|r| r.map(|t| Self::Str(Box::new(t))))),
+TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Str2>::new(r, depth_limit).map(|r| r.map(|t| Self::Str2(Box::new(t))))),
+TypeVariant::Hash => Box::new(ReadXdrIter::<_, Hash>::new(r, depth_limit).map(|r| r.map(|t| Self::Hash(Box::new(t))))),
+TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Hashes1>::new(r, depth_limit).map(|r| r.map(|t| Self::Hashes1(Box::new(t))))),
+TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Hashes2>::new(r, depth_limit).map(|r| r.map(|t| Self::Hashes2(Box::new(t))))),
+TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Hashes3>::new(r, depth_limit).map(|r| r.map(|t| Self::Hashes3(Box::new(t))))),
+TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, OptHash1>::new(r, depth_limit).map(|r| r.map(|t| Self::OptHash1(Box::new(t))))),
+TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, OptHash2>::new(r, depth_limit).map(|r| r.map(|t| Self::OptHash2(Box::new(t))))),
+TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Int1>::new(r, depth_limit).map(|r| r.map(|t| Self::Int1(Box::new(t))))),
+TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Int2>::new(r, depth_limit).map(|r| r.map(|t| Self::Int2(Box::new(t))))),
+TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Int3>::new(r, depth_limit).map(|r| r.map(|t| Self::Int3(Box::new(t))))),
+TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Int4>::new(r, depth_limit).map(|r| r.map(|t| Self::Int4(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(r, depth_limit).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, LotsOfMyStructs>::new(r, depth_limit).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t))))),
+TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, HasStuff>::new(r, depth_limit).map(|r| r.map(|t| Self::HasStuff(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(r, depth_limit).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Nester => Box::new(ReadXdrIter::<_, Nester>::new(r, depth_limit).map(|r| r.map(|t| Self::Nester(Box::new(t))))),
+TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, NesterNestedEnum>::new(r, depth_limit).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t))))),
+TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, NesterNestedStruct>::new(r, depth_limit).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t))))),
+TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::new(r, depth_limit).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Frame<Uint512>>::new(r).map(|r| r.map(|t| Self::Uint512(Box::new(t.0))))),
-TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Frame<Uint513>>::new(r).map(|r| r.map(|t| Self::Uint513(Box::new(t.0))))),
-TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Frame<Uint514>>::new(r).map(|r| r.map(|t| Self::Uint514(Box::new(t.0))))),
-TypeVariant::Str => Box::new(ReadXdrIter::<_, Frame<Str>>::new(r).map(|r| r.map(|t| Self::Str(Box::new(t.0))))),
-TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Frame<Str2>>::new(r).map(|r| r.map(|t| Self::Str2(Box::new(t.0))))),
-TypeVariant::Hash => Box::new(ReadXdrIter::<_, Frame<Hash>>::new(r).map(|r| r.map(|t| Self::Hash(Box::new(t.0))))),
-TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Frame<Hashes1>>::new(r).map(|r| r.map(|t| Self::Hashes1(Box::new(t.0))))),
-TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Frame<Hashes2>>::new(r).map(|r| r.map(|t| Self::Hashes2(Box::new(t.0))))),
-TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Frame<Hashes3>>::new(r).map(|r| r.map(|t| Self::Hashes3(Box::new(t.0))))),
-TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, Frame<OptHash1>>::new(r).map(|r| r.map(|t| Self::OptHash1(Box::new(t.0))))),
-TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, Frame<OptHash2>>::new(r).map(|r| r.map(|t| Self::OptHash2(Box::new(t.0))))),
-TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Frame<Int1>>::new(r).map(|r| r.map(|t| Self::Int1(Box::new(t.0))))),
-TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Frame<Int2>>::new(r).map(|r| r.map(|t| Self::Int2(Box::new(t.0))))),
-TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Frame<Int3>>::new(r).map(|r| r.map(|t| Self::Int3(Box::new(t.0))))),
-TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Frame<Int4>>::new(r).map(|r| r.map(|t| Self::Int4(Box::new(t.0))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(r).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
-TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, Frame<LotsOfMyStructs>>::new(r).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t.0))))),
-TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, Frame<HasStuff>>::new(r).map(|r| r.map(|t| Self::HasStuff(Box::new(t.0))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(r).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
-TypeVariant::Nester => Box::new(ReadXdrIter::<_, Frame<Nester>>::new(r).map(|r| r.map(|t| Self::Nester(Box::new(t.0))))),
-TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, Frame<NesterNestedEnum>>::new(r).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t.0))))),
-TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, Frame<NesterNestedStruct>>::new(r).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t.0))))),
-TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, Frame<NesterNestedUnion>>::new(r).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t.0))))),
+                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Frame<Uint512>>::new(r, depth_limit).map(|r| r.map(|t| Self::Uint512(Box::new(t.0))))),
+TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Frame<Uint513>>::new(r, depth_limit).map(|r| r.map(|t| Self::Uint513(Box::new(t.0))))),
+TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Frame<Uint514>>::new(r, depth_limit).map(|r| r.map(|t| Self::Uint514(Box::new(t.0))))),
+TypeVariant::Str => Box::new(ReadXdrIter::<_, Frame<Str>>::new(r, depth_limit).map(|r| r.map(|t| Self::Str(Box::new(t.0))))),
+TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Frame<Str2>>::new(r, depth_limit).map(|r| r.map(|t| Self::Str2(Box::new(t.0))))),
+TypeVariant::Hash => Box::new(ReadXdrIter::<_, Frame<Hash>>::new(r, depth_limit).map(|r| r.map(|t| Self::Hash(Box::new(t.0))))),
+TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Frame<Hashes1>>::new(r, depth_limit).map(|r| r.map(|t| Self::Hashes1(Box::new(t.0))))),
+TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Frame<Hashes2>>::new(r, depth_limit).map(|r| r.map(|t| Self::Hashes2(Box::new(t.0))))),
+TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Frame<Hashes3>>::new(r, depth_limit).map(|r| r.map(|t| Self::Hashes3(Box::new(t.0))))),
+TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, Frame<OptHash1>>::new(r, depth_limit).map(|r| r.map(|t| Self::OptHash1(Box::new(t.0))))),
+TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, Frame<OptHash2>>::new(r, depth_limit).map(|r| r.map(|t| Self::OptHash2(Box::new(t.0))))),
+TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Frame<Int1>>::new(r, depth_limit).map(|r| r.map(|t| Self::Int1(Box::new(t.0))))),
+TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Frame<Int2>>::new(r, depth_limit).map(|r| r.map(|t| Self::Int2(Box::new(t.0))))),
+TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Frame<Int3>>::new(r, depth_limit).map(|r| r.map(|t| Self::Int3(Box::new(t.0))))),
+TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Frame<Int4>>::new(r, depth_limit).map(|r| r.map(|t| Self::Int4(Box::new(t.0))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(r, depth_limit).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
+TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, Frame<LotsOfMyStructs>>::new(r, depth_limit).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t.0))))),
+TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, Frame<HasStuff>>::new(r, depth_limit).map(|r| r.map(|t| Self::HasStuff(Box::new(t.0))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(r, depth_limit).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
+TypeVariant::Nester => Box::new(ReadXdrIter::<_, Frame<Nester>>::new(r, depth_limit).map(|r| r.map(|t| Self::Nester(Box::new(t.0))))),
+TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, Frame<NesterNestedEnum>>::new(r, depth_limit).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t.0))))),
+TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, Frame<NesterNestedStruct>>::new(r, depth_limit).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t.0))))),
+TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, Frame<NesterNestedUnion>>::new(r, depth_limit).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
                 match v {
-                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(dec).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
-TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Uint513>::new(dec).map(|r| r.map(|t| Self::Uint513(Box::new(t))))),
-TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Uint514>::new(dec).map(|r| r.map(|t| Self::Uint514(Box::new(t))))),
-TypeVariant::Str => Box::new(ReadXdrIter::<_, Str>::new(dec).map(|r| r.map(|t| Self::Str(Box::new(t))))),
-TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Str2>::new(dec).map(|r| r.map(|t| Self::Str2(Box::new(t))))),
-TypeVariant::Hash => Box::new(ReadXdrIter::<_, Hash>::new(dec).map(|r| r.map(|t| Self::Hash(Box::new(t))))),
-TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Hashes1>::new(dec).map(|r| r.map(|t| Self::Hashes1(Box::new(t))))),
-TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Hashes2>::new(dec).map(|r| r.map(|t| Self::Hashes2(Box::new(t))))),
-TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Hashes3>::new(dec).map(|r| r.map(|t| Self::Hashes3(Box::new(t))))),
-TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, OptHash1>::new(dec).map(|r| r.map(|t| Self::OptHash1(Box::new(t))))),
-TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, OptHash2>::new(dec).map(|r| r.map(|t| Self::OptHash2(Box::new(t))))),
-TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Int1>::new(dec).map(|r| r.map(|t| Self::Int1(Box::new(t))))),
-TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Int2>::new(dec).map(|r| r.map(|t| Self::Int2(Box::new(t))))),
-TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Int3>::new(dec).map(|r| r.map(|t| Self::Int3(Box::new(t))))),
-TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Int4>::new(dec).map(|r| r.map(|t| Self::Int4(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
-TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, LotsOfMyStructs>::new(dec).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t))))),
-TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, HasStuff>::new(dec).map(|r| r.map(|t| Self::HasStuff(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Nester => Box::new(ReadXdrIter::<_, Nester>::new(dec).map(|r| r.map(|t| Self::Nester(Box::new(t))))),
-TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, NesterNestedEnum>::new(dec).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t))))),
-TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, NesterNestedStruct>::new(dec).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t))))),
-TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::new(dec).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t))))),
+                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(dec, depth_limit).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
+TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Uint513>::new(dec, depth_limit).map(|r| r.map(|t| Self::Uint513(Box::new(t))))),
+TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Uint514>::new(dec, depth_limit).map(|r| r.map(|t| Self::Uint514(Box::new(t))))),
+TypeVariant::Str => Box::new(ReadXdrIter::<_, Str>::new(dec, depth_limit).map(|r| r.map(|t| Self::Str(Box::new(t))))),
+TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Str2>::new(dec, depth_limit).map(|r| r.map(|t| Self::Str2(Box::new(t))))),
+TypeVariant::Hash => Box::new(ReadXdrIter::<_, Hash>::new(dec, depth_limit).map(|r| r.map(|t| Self::Hash(Box::new(t))))),
+TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Hashes1>::new(dec, depth_limit).map(|r| r.map(|t| Self::Hashes1(Box::new(t))))),
+TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Hashes2>::new(dec, depth_limit).map(|r| r.map(|t| Self::Hashes2(Box::new(t))))),
+TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Hashes3>::new(dec, depth_limit).map(|r| r.map(|t| Self::Hashes3(Box::new(t))))),
+TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, OptHash1>::new(dec, depth_limit).map(|r| r.map(|t| Self::OptHash1(Box::new(t))))),
+TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, OptHash2>::new(dec, depth_limit).map(|r| r.map(|t| Self::OptHash2(Box::new(t))))),
+TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Int1>::new(dec, depth_limit).map(|r| r.map(|t| Self::Int1(Box::new(t))))),
+TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Int2>::new(dec, depth_limit).map(|r| r.map(|t| Self::Int2(Box::new(t))))),
+TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Int3>::new(dec, depth_limit).map(|r| r.map(|t| Self::Int3(Box::new(t))))),
+TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Int4>::new(dec, depth_limit).map(|r| r.map(|t| Self::Int4(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, depth_limit).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, LotsOfMyStructs>::new(dec, depth_limit).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t))))),
+TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, HasStuff>::new(dec, depth_limit).map(|r| r.map(|t| Self::HasStuff(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, depth_limit).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Nester => Box::new(ReadXdrIter::<_, Nester>::new(dec, depth_limit).map(|r| r.map(|t| Self::Nester(Box::new(t))))),
+TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, NesterNestedEnum>::new(dec, depth_limit).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t))))),
+TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, NesterNestedStruct>::new(dec, depth_limit).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t))))),
+TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::new(dec, depth_limit).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = Cursor::new(bytes.as_ref());
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, depth_limit: u32) -> Result<Self> {
+                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String, depth_limit: u32) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), depth_limit);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -55,7 +55,8 @@ use std::{
 ///
 /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
 /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+/// For more information about Rust's stack size limit, refer to the
+/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
 pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -51,10 +51,11 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Depth limit for recursive calls in `Read/WriteXdr`. Mimics the stack depth
-/// and its purpose is to avoid the running program from reaching the Rust's
-/// stack size limit (see https://doc.rust-lang.org/std/thread/#stack-size),
-/// which leads to an unrecoverable `SIGABRT`.
+/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+///
+/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+/// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
 pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
@@ -225,11 +226,12 @@ pub trait DepthLimiter {
 }
 
 /// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth` state tracking remaining recursion depth.
+/// recursive read operations. It maintains a `depth_remaining` state tracking
+/// remaining allowed recursion depth.
 #[cfg(feature = "std")]
 pub struct DepthLimitedRead<R: Read> {
     pub inner: R,
-    pub(crate) depth: RefCell<u32>,
+    pub(crate) depth_remaining: RefCell<u32>,
 }
 
 #[cfg(feature = "std")]
@@ -237,11 +239,11 @@ impl<R: Read> DepthLimitedRead<R> {
     /// Constructs a new `DepthLimitedRead`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
-    /// - `depth`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth: u32) -> Self {
+    /// - `depth_limit`: The maximum allowed recursion depth.
+    pub fn new(inner: R, depth_limit: u32) -> Self {
         DepthLimitedRead {
             inner,
-            depth: RefCell::new(depth),
+            depth_remaining: RefCell::new(depth_limit),
         }
     }
 }
@@ -250,21 +252,21 @@ impl<R: Read> DepthLimitedRead<R> {
 impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
     type DepthError = Error;
 
-    /// Decrements the depth. If the depth is already zero, an error is returned indicating
-    /// that the maximum depth limit has been exceeded.
+    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
+    /// returned indicating that the maximum depth limit has been exceeded.
     fn enter(&self) -> core::result::Result<(), Error> {
-        let depth = *self.depth.borrow();
+        let depth = *self.depth_remaining.borrow();
         if depth == 0 {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth.replace(depth - 1);
+        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
     /// Increments the depth, without exceeding the initial depth value.
     fn leave(&self) {
-        let depth = *self.depth.borrow();
-        self.depth.replace(depth.saturating_add(1));
+        let depth = *self.depth_remaining.borrow();
+        self.depth_remaining.replace(depth.saturating_add(1));
     }
 }
 
@@ -277,11 +279,12 @@ impl<R: Read> Read for DepthLimitedRead<R> {
 }
 
 /// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth` state tracking remaining recursion depth.
+/// recursive write operations. It maintains a `depth_remaining` state tracking
+/// remaining allowed recursion depth.
 #[cfg(feature = "std")]
 pub struct DepthLimitedWrite<W: Write> {
     pub inner: W,
-    pub(crate) depth: RefCell<u32>,
+    pub(crate) depth_remaining: RefCell<u32>,
 }
 
 #[cfg(feature = "std")]
@@ -289,11 +292,11 @@ impl<W: Write> DepthLimitedWrite<W> {
     /// Constructs a new `DepthLimitedWrite`.
     ///
     /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth: u32) -> Self {
+    /// - `depth_limit`: The maximum allowed recursion depth.
+    pub fn new(inner: W, depth_limit: u32) -> Self {
         DepthLimitedWrite {
             inner,
-            depth: RefCell::new(depth),
+            depth_remaining: RefCell::new(depth_limit),
         }
     }
 }
@@ -302,21 +305,21 @@ impl<W: Write> DepthLimitedWrite<W> {
 impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
     type DepthError = Error;
 
-    /// Decrements the depth. If the depth is already zero, an error is returned indicating
-    /// that the maximum depth limit has been exceeded.
+    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
+    /// returned indicating that the maximum depth limit has been exceeded.
     fn enter(&self) -> Result<()> {
-        let depth = *self.depth.borrow();
+        let depth = *self.depth_remaining.borrow();
         if depth == 0 {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth.replace(depth - 1);
+        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
     /// Increments the depth, without exceeding the initial depth value.
     fn leave(&self) {
-        let depth = *self.depth.borrow();
-        self.depth.replace(depth.saturating_add(1));
+        let depth = *self.depth_remaining.borrow();
+        self.depth_remaining.replace(depth.saturating_add(1));
     }
 }
 
@@ -341,11 +344,11 @@ pub struct ReadXdrIter<R: Read, S: ReadXdr> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth: u32) -> Self {
+    fn new(r: R, depth_limit: u32) -> Self {
         Self {
             reader: DepthLimitedRead {
                 inner: BufReader::new(r),
-                depth: RefCell::new(depth),
+                depth_remaining: RefCell::new(depth_limit),
             },
             _s: PhantomData,
         }
@@ -417,7 +420,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth.take(),
+            r.depth_remaining.take(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -461,7 +464,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth.take(),
+            r.depth_remaining.take(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -537,7 +540,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth.take())
+        ReadXdrIter::new(&mut r.inner, r.depth_remaining.take())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -547,34 +550,51 @@ where
         r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth.take())
+        ReadXdrIter::new(dec, r.depth_remaining.take())
     }
 
-    /// Construct the type from the XDR bytes.
+    /// Construct the type from the XDR bytes, specifying a depth limit.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
+    #[cfg(feature = "std")]
+    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+        let t = Self::read_xdr_to_end(&mut cursor)?;
+        Ok(t)
+    }
+
+    /// Construct the type from the XDR bytes, using the default depth limit.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
     fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        let mut cursor =
-            DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
-        let t = Self::read_xdr_to_end(&mut cursor)?;
+        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_MAX_DEPTH_LIMIT)
+    }
+
+    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
+    #[cfg(feature = "base64")]
+    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut b64_reader = Cursor::new(b64);
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            depth_limit,
+        );
+        let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes base64 encoded.
+    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            DEFAULT_MAX_DEPTH_LIMIT,
-        );
-        let t = Self::read_xdr_to_end(&mut dec)?;
-        Ok(t)
+        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_MAX_DEPTH_LIMIT)
     }
 }
 
@@ -583,22 +603,32 @@ pub trait WriteXdr {
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), DEFAULT_MAX_DEPTH_LIMIT);
+    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
+    #[cfg(feature = "std")]
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        self.to_xdr_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+    }
+
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
+    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
         let mut enc = DepthLimitedWrite::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            depth_limit,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
+    }
+
+    #[cfg(feature = "base64")]
+    fn to_xdr_base64(&self) -> Result<String> {
+        self.to_xdr_base64_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
     }
 }
 
@@ -4084,7 +4114,7 @@ TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNested
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -4103,7 +4133,7 @@ TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNested
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -4112,29 +4142,29 @@ TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNested
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
-TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Uint513>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Uint513(Box::new(t))))),
-TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Uint514>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Uint514(Box::new(t))))),
-TypeVariant::Str => Box::new(ReadXdrIter::<_, Str>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Str(Box::new(t))))),
-TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Str2>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Str2(Box::new(t))))),
-TypeVariant::Hash => Box::new(ReadXdrIter::<_, Hash>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Hash(Box::new(t))))),
-TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Hashes1>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Hashes1(Box::new(t))))),
-TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Hashes2>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Hashes2(Box::new(t))))),
-TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Hashes3>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Hashes3(Box::new(t))))),
-TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, OptHash1>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::OptHash1(Box::new(t))))),
-TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, OptHash2>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::OptHash2(Box::new(t))))),
-TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Int1>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Int1(Box::new(t))))),
-TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Int2>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Int2(Box::new(t))))),
-TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Int3>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Int3(Box::new(t))))),
-TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Int4>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Int4(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
-TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, LotsOfMyStructs>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t))))),
-TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, HasStuff>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::HasStuff(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Nester => Box::new(ReadXdrIter::<_, Nester>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Nester(Box::new(t))))),
-TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, NesterNestedEnum>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t))))),
-TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, NesterNestedStruct>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t))))),
-TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t))))),
+                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
+TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Uint513>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Uint513(Box::new(t))))),
+TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Uint514>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Uint514(Box::new(t))))),
+TypeVariant::Str => Box::new(ReadXdrIter::<_, Str>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Str(Box::new(t))))),
+TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Str2>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Str2(Box::new(t))))),
+TypeVariant::Hash => Box::new(ReadXdrIter::<_, Hash>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Hash(Box::new(t))))),
+TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Hashes1>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Hashes1(Box::new(t))))),
+TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Hashes2>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Hashes2(Box::new(t))))),
+TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Hashes3>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Hashes3(Box::new(t))))),
+TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, OptHash1>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::OptHash1(Box::new(t))))),
+TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, OptHash2>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::OptHash2(Box::new(t))))),
+TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Int1>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Int1(Box::new(t))))),
+TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Int2>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Int2(Box::new(t))))),
+TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Int3>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Int3(Box::new(t))))),
+TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Int4>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Int4(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, LotsOfMyStructs>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t))))),
+TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, HasStuff>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::HasStuff(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Nester => Box::new(ReadXdrIter::<_, Nester>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Nester(Box::new(t))))),
+TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, NesterNestedEnum>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t))))),
+TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, NesterNestedStruct>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t))))),
+TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t))))),
                 }
             }
 
@@ -4142,29 +4172,29 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Frame<Uint512>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Uint512(Box::new(t.0))))),
-TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Frame<Uint513>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Uint513(Box::new(t.0))))),
-TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Frame<Uint514>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Uint514(Box::new(t.0))))),
-TypeVariant::Str => Box::new(ReadXdrIter::<_, Frame<Str>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Str(Box::new(t.0))))),
-TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Frame<Str2>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Str2(Box::new(t.0))))),
-TypeVariant::Hash => Box::new(ReadXdrIter::<_, Frame<Hash>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Hash(Box::new(t.0))))),
-TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Frame<Hashes1>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Hashes1(Box::new(t.0))))),
-TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Frame<Hashes2>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Hashes2(Box::new(t.0))))),
-TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Frame<Hashes3>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Hashes3(Box::new(t.0))))),
-TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, Frame<OptHash1>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::OptHash1(Box::new(t.0))))),
-TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, Frame<OptHash2>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::OptHash2(Box::new(t.0))))),
-TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Frame<Int1>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Int1(Box::new(t.0))))),
-TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Frame<Int2>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Int2(Box::new(t.0))))),
-TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Frame<Int3>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Int3(Box::new(t.0))))),
-TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Frame<Int4>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Int4(Box::new(t.0))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
-TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, Frame<LotsOfMyStructs>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t.0))))),
-TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, Frame<HasStuff>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::HasStuff(Box::new(t.0))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
-TypeVariant::Nester => Box::new(ReadXdrIter::<_, Frame<Nester>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Nester(Box::new(t.0))))),
-TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, Frame<NesterNestedEnum>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t.0))))),
-TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, Frame<NesterNestedStruct>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t.0))))),
-TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, Frame<NesterNestedUnion>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t.0))))),
+                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Frame<Uint512>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Uint512(Box::new(t.0))))),
+TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Frame<Uint513>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Uint513(Box::new(t.0))))),
+TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Frame<Uint514>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Uint514(Box::new(t.0))))),
+TypeVariant::Str => Box::new(ReadXdrIter::<_, Frame<Str>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Str(Box::new(t.0))))),
+TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Frame<Str2>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Str2(Box::new(t.0))))),
+TypeVariant::Hash => Box::new(ReadXdrIter::<_, Frame<Hash>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Hash(Box::new(t.0))))),
+TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Frame<Hashes1>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Hashes1(Box::new(t.0))))),
+TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Frame<Hashes2>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Hashes2(Box::new(t.0))))),
+TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Frame<Hashes3>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Hashes3(Box::new(t.0))))),
+TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, Frame<OptHash1>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::OptHash1(Box::new(t.0))))),
+TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, Frame<OptHash2>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::OptHash2(Box::new(t.0))))),
+TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Frame<Int1>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Int1(Box::new(t.0))))),
+TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Frame<Int2>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Int2(Box::new(t.0))))),
+TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Frame<Int3>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Int3(Box::new(t.0))))),
+TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Frame<Int4>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Int4(Box::new(t.0))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
+TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, Frame<LotsOfMyStructs>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t.0))))),
+TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, Frame<HasStuff>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::HasStuff(Box::new(t.0))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
+TypeVariant::Nester => Box::new(ReadXdrIter::<_, Frame<Nester>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Nester(Box::new(t.0))))),
+TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, Frame<NesterNestedEnum>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t.0))))),
+TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, Frame<NesterNestedStruct>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t.0))))),
+TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, Frame<NesterNestedUnion>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t.0))))),
                 }
             }
 
@@ -4173,29 +4203,29 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, Frame<NesterNestedUn
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
-TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Uint513>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Uint513(Box::new(t))))),
-TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Uint514>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Uint514(Box::new(t))))),
-TypeVariant::Str => Box::new(ReadXdrIter::<_, Str>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Str(Box::new(t))))),
-TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Str2>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Str2(Box::new(t))))),
-TypeVariant::Hash => Box::new(ReadXdrIter::<_, Hash>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Hash(Box::new(t))))),
-TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Hashes1>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Hashes1(Box::new(t))))),
-TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Hashes2>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Hashes2(Box::new(t))))),
-TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Hashes3>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Hashes3(Box::new(t))))),
-TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, OptHash1>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::OptHash1(Box::new(t))))),
-TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, OptHash2>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::OptHash2(Box::new(t))))),
-TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Int1>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Int1(Box::new(t))))),
-TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Int2>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Int2(Box::new(t))))),
-TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Int3>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Int3(Box::new(t))))),
-TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Int4>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Int4(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
-TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, LotsOfMyStructs>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t))))),
-TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, HasStuff>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::HasStuff(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Nester => Box::new(ReadXdrIter::<_, Nester>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Nester(Box::new(t))))),
-TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, NesterNestedEnum>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t))))),
-TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, NesterNestedStruct>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t))))),
-TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t))))),
+                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
+TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Uint513>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Uint513(Box::new(t))))),
+TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Uint514>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Uint514(Box::new(t))))),
+TypeVariant::Str => Box::new(ReadXdrIter::<_, Str>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Str(Box::new(t))))),
+TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Str2>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Str2(Box::new(t))))),
+TypeVariant::Hash => Box::new(ReadXdrIter::<_, Hash>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Hash(Box::new(t))))),
+TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Hashes1>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Hashes1(Box::new(t))))),
+TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Hashes2>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Hashes2(Box::new(t))))),
+TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Hashes3>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Hashes3(Box::new(t))))),
+TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, OptHash1>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::OptHash1(Box::new(t))))),
+TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, OptHash2>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::OptHash2(Box::new(t))))),
+TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Int1>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Int1(Box::new(t))))),
+TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Int2>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Int2(Box::new(t))))),
+TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Int3>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Int3(Box::new(t))))),
+TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Int4>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Int4(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, LotsOfMyStructs>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t))))),
+TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, HasStuff>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::HasStuff(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Nester => Box::new(ReadXdrIter::<_, Nester>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Nester(Box::new(t))))),
+TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, NesterNestedEnum>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t))))),
+TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, NesterNestedStruct>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t))))),
+TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -11,6 +11,9 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
+use super::depth_limiter::*;
+
+#[cfg(feature = "std")]
 use core::marker::PhantomData;
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
@@ -66,6 +69,7 @@ pub enum Error {
     InvalidHex,
     #[cfg(feature = "std")]
     Io(io::Error),
+    DepthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -109,6 +113,7 @@ impl fmt::Display for Error {
             Error::InvalidHex => write!(f, "hex invalid"),
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{e}"),
+            Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
         }
     }
 }
@@ -182,15 +187,15 @@ where
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: BufReader<R>,
+    reader: DepthLimitedRead<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R) -> Self {
+    fn new(r: R, depth_limit: u32) -> Self {
         Self {
-            reader: BufReader::new(r),
+            reader: DepthLimitedRead::new(BufReader::new(r), depth_limit),
             _s: PhantomData,
         }
     }
@@ -214,7 +219,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.fill_buf() {
+        match self.reader.inner.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -224,7 +229,8 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
             Ok([..]) => (),
         };
         // Read the buf into the type.
-        match S::read_xdr(&mut self.reader) {
+        let r = self.reader.with_limited_depth(|dlr| S::read_xdr(dlr));
+        match r {
             Ok(s) => Some(Ok(s)),
             Err(e) => Some(Err(e)),
         }
@@ -247,18 +253,21 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     ///
-    /// Use [`ReadXdr::read_xdr_to_end`] when the intent is for all bytes in the
+    /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64(r: &mut impl Read) -> Result<Self> {
-        let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+    fn read_xdr_base64(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(r, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
     }
@@ -282,7 +291,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -298,8 +307,11 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end(r: &mut impl Read) -> Result<Self> {
-        let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+    fn read_xdr_base64_to_end(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(r, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
@@ -316,10 +328,10 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     ///
-    /// Use [`ReadXdr::read_xdr_into_to_end`] when the intent is for all bytes
+    /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into(&mut self, r: &mut impl Read) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -343,7 +355,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end(&mut self, r: &mut impl Read) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -373,8 +385,8 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut R) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(r)
+    fn read_xdr_iter<R: Read>(r: &mut R, depth_limit: u32) -> ReadXdrIter<&mut R, Self> {
+        ReadXdrIter::new(r, depth_limit)
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -382,9 +394,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut R,
+        depth_limit: u32,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
-        ReadXdrIter::new(dec)
+        ReadXdrIter::new(dec, depth_limit)
     }
 
     /// Construct the type from the XDR bytes.
@@ -392,8 +405,8 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        let mut cursor = Cursor::new(bytes.as_ref());
+    fn from_xdr(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
@@ -403,9 +416,12 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            depth_limit,
+        );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
@@ -413,21 +429,24 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        let mut cursor = Cursor::new(vec![]);
+    fn to_xdr(&self, depth_limit: u32) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
         self.write_xdr(&mut cursor)?;
-        let bytes = cursor.into_inner();
+        let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        let mut enc = base64::write::EncoderStringWriter::new(base64::STANDARD);
+    fn to_xdr_base64(&self, depth_limit: u32) -> Result<String> {
+        let mut enc = DepthLimitedWrite::new(
+            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            depth_limit,
+        );
         self.write_xdr(&mut enc)?;
-        let b64 = enc.into_inner();
+        let b64 = enc.inner.into_inner();
         Ok(b64)
     }
 }
@@ -441,229 +460,239 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 4];
-        r.read_exact(&mut b)?;
-        let i = i32::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(i32::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 4];
-        r.read_exact(&mut b)?;
-        let i = u32::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(u32::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 8];
-        r.read_exact(&mut b)?;
-        let i = i64::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(i64::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut b = [0u8; 8];
-        r.read_exact(&mut b)?;
-        let i = u64::from_be_bytes(b);
-        Ok(i)
+        r.with_limited_depth(|r| {
+            r.read_exact(&mut b)?;
+            Ok(u64::from_be_bytes(b))
+        })
     }
 }
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.write_all(&b)?;
-        Ok(())
+        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
 }
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = u32::read_xdr(r)?;
-        let b = i == 1;
-        Ok(b)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = u32::read_xdr(r)?;
+            let b = i == 1;
+            Ok(b)
+        })
     }
 }
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let i = u32::from(*self); // true = 1, false = 0
-        i.write_xdr(w)?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let i = u32::from(*self); // true = 1, false = 0
+            i.write_xdr(w)
+        })
     }
 }
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = u32::read_xdr(r)?;
-        match i {
-            0 => Ok(None),
-            1 => {
-                let t = T::read_xdr(r)?;
-                Ok(Some(t))
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = u32::read_xdr(r)?;
+            match i {
+                0 => Ok(None),
+                1 => {
+                    let t = T::read_xdr(r)?;
+                    Ok(Some(t))
+                }
+                _ => Err(Error::Invalid),
             }
-            _ => Err(Error::Invalid),
-        }
+        })
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        if let Some(t) = self {
-            1u32.write_xdr(w)?;
-            t.write_xdr(w)?;
-        } else {
-            0u32.write_xdr(w)?;
-        }
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            Ok(if let Some(t) = self {
+                1u32.write_xdr(w)?;
+                t.write_xdr(w)?;
+            } else {
+                0u32.write_xdr(w)?;
+            })
+        })
     }
 }
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let t = T::read_xdr(r)?;
-        Ok(Box::new(t))
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        T::write_xdr(self, w)?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr(_r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, _w: &mut impl Write) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let mut arr = [0u8; N];
-        r.read_exact(&mut arr)?;
-
-        let pad = &mut [0u8; 3][..pad_len(N)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
-
-        Ok(arr)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let mut arr = [0u8; N];
+            r.read_exact(&mut arr)?;
+            let pad = &mut [0u8; 3][..pad_len(N)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
+            Ok(arr)
+        })
     }
 }
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        w.write_all(self)?;
-        w.write_all(&[0u8; 3][..pad_len(N)])?;
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            w.write_all(self)?;
+            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            Ok(())
+        })
     }
 }
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let mut vec = Vec::with_capacity(N);
-        for _ in 0..N {
-            let t = T::read_xdr(r)?;
-            vec.push(t);
-        }
-        let arr: [T; N] = vec.try_into().unwrap_or_else(|_: Vec<T>| unreachable!());
-        Ok(arr)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let mut vec = Vec::with_capacity(N);
+            for _ in 0..N {
+                let t = T::read_xdr(r)?;
+                vec.push(t);
+            }
+            let arr: [T; N] = vec.try_into().unwrap_or_else(|_: Vec<T>| unreachable!());
+            Ok(arr)
+        })
     }
 }
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        for t in self {
-            t.write_xdr(w)?;
-        }
-        Ok(())
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            for t in self {
+                t.write_xdr(w)?;
+            }
+            Ok(())
+        })
     }
 }
 
@@ -990,68 +1019,76 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(VecM(vec))
+            Ok(VecM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = Vec::with_capacity(len as usize);
-        for _ in 0..len {
-            let t = T::read_xdr(r)?;
-            vec.push(t);
-        }
+            let mut vec = Vec::with_capacity(len as usize);
+            for _ in 0..len {
+                let t = T::read_xdr(r)?;
+                vec.push(t);
+            }
 
-        Ok(VecM(vec))
+            Ok(VecM(vec))
+        })
     }
 }
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        for t in &self.0 {
-            t.write_xdr(w)?;
-        }
+            for t in &self.0 {
+                t.write_xdr(w)?;
+            }
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1380,36 +1417,40 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(BytesM(vec))
+            Ok(BytesM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1759,36 +1800,40 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let len: u32 = u32::read_xdr(r)?;
-        if len > MAX {
-            return Err(Error::LengthExceedsMax);
-        }
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let len: u32 = u32::read_xdr(r)?;
+            if len > MAX {
+                return Err(Error::LengthExceedsMax);
+            }
 
-        let mut vec = vec![0u8; len as usize];
-        r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; len as usize];
+            r.read_exact(&mut vec)?;
 
-        let pad = &mut [0u8; 3][..pad_len(len as usize)];
-        r.read_exact(pad)?;
-        if pad.iter().any(|b| *b != 0) {
-            return Err(Error::NonZeroPadding);
-        }
+            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            r.read_exact(pad)?;
+            if pad.iter().any(|b| *b != 0) {
+                return Err(Error::NonZeroPadding);
+            }
 
-        Ok(StringM(vec))
+            Ok(StringM(vec))
+        })
     }
 }
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
-        len.write_xdr(w)?;
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w| {
+            let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
+            len.write_xdr(w)?;
 
-        w.write_all(&self.0)?;
+            w.write_all(&self.0)?;
 
-        w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
 
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -1809,7 +1854,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -1832,26 +1877,30 @@ where
 mod tests {
     use std::io::Cursor;
 
+    use crate::{DepthLimitedRead, DepthLimitedWrite};
+
     use super::{Error, ReadXdr, VecM, WriteXdr};
+
+    const DEPTH_LIMIT: u32 = 10;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1860,8 +1909,8 @@ mod tests {
 
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
-        let mut buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1872,7 +1921,12 @@ mod tests {
     pub fn vec_u8_write_without_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
-        v.write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+
+        v.write_xdr(&mut DepthLimitedWrite::new(
+            Cursor::new(&mut buf),
+            DEPTH_LIMIT,
+        ))
+        .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1880,28 +1934,32 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+        v.write_xdr(&mut DepthLimitedWrite::new(
+            Cursor::new(&mut buf),
+            DEPTH_LIMIT,
+        ))
+        .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
     #[test]
     pub fn arr_u8_read_without_padding() {
-        let mut buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![2, 2, 2, 2]);
+        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
-        let mut buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut buf).unwrap();
+        let buf = Cursor::new(vec![2, 0, 0, 0]);
+        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
-        let mut buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![2, 0, 0]);
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1910,8 +1968,8 @@ mod tests {
 
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
-        let mut buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut buf);
+        let buf = Cursor::new(vec![2, 3, 0, 0]);
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1922,7 +1980,10 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Cursor::new(&mut buf))
+            .write_xdr(&mut DepthLimitedWrite::new(
+                Cursor::new(&mut buf),
+                DEPTH_LIMIT,
+            ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -1930,14 +1991,19 @@ mod tests {
     #[test]
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
-        [2u8].write_xdr(&mut Cursor::new(&mut buf)).unwrap();
+        [2u8]
+            .write_xdr(&mut DepthLimitedWrite::new(
+                Cursor::new(&mut buf),
+                DEPTH_LIMIT,
+            ))
+            .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
 }
 
 #[cfg(all(test, feature = "std"))]
 mod test {
-    use super::VecM;
+    use super::*;
 
     #[test]
     fn into_option_none() {
@@ -1961,6 +2027,36 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = vec![1].try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+
+    #[test]
+    fn depth_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[should_panic]
+    #[test]
+    fn write_over_depth_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 3);
+        a.write_xdr(&mut buf).unwrap();
+    }
+
+    #[should_panic]
+    #[test]
+    fn read_over_depth_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = DepthLimitedWrite::new(Vec::new(), 5);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 3);
+        let _: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
     }
 }
 
@@ -2074,18 +2170,22 @@ Self::Multi => "Multi",
 
         impl ReadXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn read_xdr(r: &mut impl Read) -> Result<Self> {
-                let e = i32::read_xdr(r)?;
-                let v: Self = e.try_into()?;
-                Ok(v)
+            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                r.with_limited_depth(|r| {
+                    let e = i32::read_xdr(r)?;
+                    let v: Self = e.try_into()?;
+                    Ok(v)
+                })
             }
         }
 
         impl WriteXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-                let i: i32 = (*self).into();
-                i.write_xdr(w)
+            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+                w.with_limited_write(|w| {
+                    let i: i32 = (*self).into();
+                    i.write_xdr(w)
+                })
             }
         }
 
@@ -2168,29 +2268,33 @@ Self::Multi(_) => UnionKey::Multi,
 
         impl ReadXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn read_xdr(r: &mut impl Read) -> Result<Self> {
-                let dv: UnionKey = <UnionKey as ReadXdr>::read_xdr(r)?;
-                #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
-                let v = match dv {
-                    UnionKey::Error => Self::Error(i32::read_xdr(r)?),
+            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                r.with_limited_read(|r| {
+                    let dv: UnionKey = <UnionKey as ReadXdr>::read_xdr(r)?;
+                    #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
+                    let v = match dv {
+                        UnionKey::Error => Self::Error(i32::read_xdr(r)?),
 UnionKey::Multi => Self::Multi(VecM::<i32>::read_xdr(r)?),
-                    #[allow(unreachable_patterns)]
-                    _ => return Err(Error::Invalid),
-                };
-                Ok(v)
+                        #[allow(unreachable_patterns)]
+                        _ => return Err(Error::Invalid),
+                    };
+                    Ok(v)
+                }
             }
         }
 
         impl WriteXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-                self.discriminant().write_xdr(w)?;
-                #[allow(clippy::match_same_arms)]
-                match self {
-                    Self::Error(v) => v.write_xdr(w)?,
+            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite) -> Result<()> {
+                w.with_limited_depth(|w| {
+                    self.discriminant().write_xdr(w)?;
+                    #[allow(clippy::match_same_arms)]
+                    match self {
+                        Self::Error(v) => v.write_xdr(w)?,
 Self::Multi(v) => v.write_xdr(w)?,
-                };
-                Ok(())
+                    };
+                    Ok(())
+                })
             }
         }
 
@@ -2272,29 +2376,33 @@ Self::V1(_) => 1,
 
         impl ReadXdr for IntUnion {
             #[cfg(feature = "std")]
-            fn read_xdr(r: &mut impl Read) -> Result<Self> {
-                let dv: i32 = <i32 as ReadXdr>::read_xdr(r)?;
-                #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
-                let v = match dv {
-                    0 => Self::V0(i32::read_xdr(r)?),
+            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                r.with_limited_read(|r| {
+                    let dv: i32 = <i32 as ReadXdr>::read_xdr(r)?;
+                    #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
+                    let v = match dv {
+                        0 => Self::V0(i32::read_xdr(r)?),
 1 => Self::V1(VecM::<i32>::read_xdr(r)?),
-                    #[allow(unreachable_patterns)]
-                    _ => return Err(Error::Invalid),
-                };
-                Ok(v)
+                        #[allow(unreachable_patterns)]
+                        _ => return Err(Error::Invalid),
+                    };
+                    Ok(v)
+                }
             }
         }
 
         impl WriteXdr for IntUnion {
             #[cfg(feature = "std")]
-            fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-                self.discriminant().write_xdr(w)?;
-                #[allow(clippy::match_same_arms)]
-                match self {
-                    Self::V0(v) => v.write_xdr(w)?,
+            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite) -> Result<()> {
+                w.with_limited_depth(|w| {
+                    self.discriminant().write_xdr(w)?;
+                    #[allow(clippy::match_same_arms)]
+                    match self {
+                        Self::V0(v) => v.write_xdr(w)?,
 Self::V1(v) => v.write_xdr(w)?,
-                };
-                Ok(())
+                    };
+                    Ok(())
+                })
             }
         }
 
@@ -2331,17 +2439,19 @@ impl AsRef<IntUnion> for IntUnion2 {
 
 impl ReadXdr for IntUnion2 {
     #[cfg(feature = "std")]
-    fn read_xdr(r: &mut impl Read) -> Result<Self> {
-        let i = IntUnion::read_xdr(r)?;
-        let v = IntUnion2(i);
-        Ok(v)
+    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+        r.with_limited_depth(|r| {
+            let i = IntUnion::read_xdr(r)?;
+            let v = IntUnion2(i);
+            Ok(v)})
+        })
     }
 }
 
 impl WriteXdr for IntUnion2 {
     #[cfg(feature = "std")]
-    fn write_xdr(&self, w: &mut impl Write) -> Result<()> {
-        self.0.write_xdr(w)
+    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+        w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
 
@@ -2455,26 +2565,29 @@ TypeVariant::IntUnion2, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 match v {
-                    TypeVariant::SError => Ok(Self::SError(Box::new(SError::read_xdr(r)?))),
-TypeVariant::Multi => Ok(Self::Multi(Box::new(Multi::read_xdr(r)?))),
-TypeVariant::UnionKey => Ok(Self::UnionKey(Box::new(UnionKey::read_xdr(r)?))),
-TypeVariant::MyUnion => Ok(Self::MyUnion(Box::new(MyUnion::read_xdr(r)?))),
-TypeVariant::IntUnion => Ok(Self::IntUnion(Box::new(IntUnion::read_xdr(r)?))),
-TypeVariant::IntUnion2 => Ok(Self::IntUnion2(Box::new(IntUnion2::read_xdr(r)?))),
+                    TypeVariant::SError => r.with_limited_depth(|r| Ok(Self::SError(Box::new(SError::read_xdr(r)?))))?,
+TypeVariant::Multi => r.with_limited_depth(|r| Ok(Self::Multi(Box::new(Multi::read_xdr(r)?))))?,
+TypeVariant::UnionKey => r.with_limited_depth(|r| Ok(Self::UnionKey(Box::new(UnionKey::read_xdr(r)?))))?,
+TypeVariant::MyUnion => r.with_limited_depth(|r| Ok(Self::MyUnion(Box::new(MyUnion::read_xdr(r)?))))?,
+TypeVariant::IntUnion => r.with_limited_depth(|r| Ok(Self::IntUnion(Box::new(IntUnion::read_xdr(r)?))))?,
+TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(IntUnion2::read_xdr(r)?))))?,
                 }
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
-                let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+            pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(
+                  base64::read::DecoderReader::new(r, base64::STANDARD),
+                  depth_limit,
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2486,63 +2599,66 @@ TypeVariant::IntUnion2 => Ok(Self::IntUnion2(Box::new(IntUnion2::read_xdr(r)?)))
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read) -> Result<Self> {
-                let mut dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+            pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(
+                  base64::read::DecoderReader::new(r, base64::STANDARD),
+                  depth_limit,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit: u32) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(r).map(|r| r.map(|t| Self::SError(Box::new(t))))),
-TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(r).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
-TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(r).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(r).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(r).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
-TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(r).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
+                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(r, depth_limit).map(|r| r.map(|t| Self::SError(Box::new(t))))),
+TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(r, depth_limit).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
+TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(r, depth_limit).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(r, depth_limit).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(r, depth_limit).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
+TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(r, depth_limit).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::SError => Box::new(ReadXdrIter::<_, Frame<SError>>::new(r).map(|r| r.map(|t| Self::SError(Box::new(t.0))))),
-TypeVariant::Multi => Box::new(ReadXdrIter::<_, Frame<Multi>>::new(r).map(|r| r.map(|t| Self::Multi(Box::new(t.0))))),
-TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(r).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(r).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
-TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, Frame<IntUnion>>::new(r).map(|r| r.map(|t| Self::IntUnion(Box::new(t.0))))),
-TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, Frame<IntUnion2>>::new(r).map(|r| r.map(|t| Self::IntUnion2(Box::new(t.0))))),
+                    TypeVariant::SError => Box::new(ReadXdrIter::<_, Frame<SError>>::new(r, depth_limit).map(|r| r.map(|t| Self::SError(Box::new(t.0))))),
+TypeVariant::Multi => Box::new(ReadXdrIter::<_, Frame<Multi>>::new(r, depth_limit).map(|r| r.map(|t| Self::Multi(Box::new(t.0))))),
+TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(r, depth_limit).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(r, depth_limit).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
+TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, Frame<IntUnion>>::new(r, depth_limit).map(|r| r.map(|t| Self::IntUnion(Box::new(t.0))))),
+TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, Frame<IntUnion2>>::new(r, depth_limit).map(|r| r.map(|t| Self::IntUnion2(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
                 match v {
-                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(dec).map(|r| r.map(|t| Self::SError(Box::new(t))))),
-TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(dec).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
-TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(dec).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
-TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
+                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(dec, depth_limit).map(|r| r.map(|t| Self::SError(Box::new(t))))),
+TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(dec, depth_limit).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
+TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, depth_limit).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, depth_limit).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(dec, depth_limit).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
+TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, depth_limit).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = Cursor::new(bytes.as_ref());
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, depth_limit: u32) -> Result<Self> {
+                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String, depth_limit: u32) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD);
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), depth_limit);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -56,7 +56,7 @@ use std::{
 /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
 /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
 /// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
+pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
@@ -570,7 +570,7 @@ where
     /// deserialization.
     #[cfg(feature = "std")]
     fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_MAX_DEPTH_LIMIT)
+        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 
     /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
@@ -594,7 +594,7 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_MAX_DEPTH_LIMIT)
+        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -612,7 +612,7 @@ pub trait WriteXdr {
 
     #[cfg(feature = "std")]
     fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 
     #[cfg(feature = "base64")]
@@ -628,7 +628,7 @@ pub trait WriteXdr {
 
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -2061,29 +2061,32 @@ mod tests {
 
     use super::{
         DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_MAX_DEPTH_LIMIT,
+        DEFAULT_XDR_RW_DEPTH_LIMIT,
     };
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
-            .unwrap();
+        let v =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+                .unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
-            .unwrap();
+        let v =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+                .unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2093,7 +2096,8 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res =
+            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2107,7 +2111,7 @@ mod tests {
 
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
@@ -2119,7 +2123,7 @@ mod tests {
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
@@ -2128,23 +2132,23 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v =
-            <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v =
-            <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2154,7 +2158,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2167,7 +2171,7 @@ mod tests {
         [2u8, 2, 2, 2]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEFAULT_MAX_DEPTH_LIMIT,
+                DEFAULT_XDR_RW_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2179,7 +2183,7 @@ mod tests {
         [2u8]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEFAULT_MAX_DEPTH_LIMIT,
+                DEFAULT_XDR_RW_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2838,7 +2842,7 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.depth
 
             #[cfg(feature = "std")]
             pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
+                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
@@ -2846,7 +2850,7 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.depth
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_MAX_DEPTH_LIMIT);
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -51,10 +51,11 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Depth limit for recursive calls in `Read/WriteXdr`. Mimics the stack depth
-/// and its purpose is to avoid the running program from reaching the Rust's
-/// stack size limit (see https://doc.rust-lang.org/std/thread/#stack-size),
-/// which leads to an unrecoverable `SIGABRT`.
+/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+///
+/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+/// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
 pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
@@ -225,11 +226,12 @@ pub trait DepthLimiter {
 }
 
 /// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth` state tracking remaining recursion depth.
+/// recursive read operations. It maintains a `depth_remaining` state tracking
+/// remaining allowed recursion depth.
 #[cfg(feature = "std")]
 pub struct DepthLimitedRead<R: Read> {
     pub inner: R,
-    pub(crate) depth: RefCell<u32>,
+    pub(crate) depth_remaining: RefCell<u32>,
 }
 
 #[cfg(feature = "std")]
@@ -237,11 +239,11 @@ impl<R: Read> DepthLimitedRead<R> {
     /// Constructs a new `DepthLimitedRead`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
-    /// - `depth`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth: u32) -> Self {
+    /// - `depth_limit`: The maximum allowed recursion depth.
+    pub fn new(inner: R, depth_limit: u32) -> Self {
         DepthLimitedRead {
             inner,
-            depth: RefCell::new(depth),
+            depth_remaining: RefCell::new(depth_limit),
         }
     }
 }
@@ -250,21 +252,21 @@ impl<R: Read> DepthLimitedRead<R> {
 impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
     type DepthError = Error;
 
-    /// Decrements the depth. If the depth is already zero, an error is returned indicating
-    /// that the maximum depth limit has been exceeded.
+    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
+    /// returned indicating that the maximum depth limit has been exceeded.
     fn enter(&self) -> core::result::Result<(), Error> {
-        let depth = *self.depth.borrow();
+        let depth = *self.depth_remaining.borrow();
         if depth == 0 {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth.replace(depth - 1);
+        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
     /// Increments the depth, without exceeding the initial depth value.
     fn leave(&self) {
-        let depth = *self.depth.borrow();
-        self.depth.replace(depth.saturating_add(1));
+        let depth = *self.depth_remaining.borrow();
+        self.depth_remaining.replace(depth.saturating_add(1));
     }
 }
 
@@ -277,11 +279,12 @@ impl<R: Read> Read for DepthLimitedRead<R> {
 }
 
 /// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth` state tracking remaining recursion depth.
+/// recursive write operations. It maintains a `depth_remaining` state tracking
+/// remaining allowed recursion depth.
 #[cfg(feature = "std")]
 pub struct DepthLimitedWrite<W: Write> {
     pub inner: W,
-    pub(crate) depth: RefCell<u32>,
+    pub(crate) depth_remaining: RefCell<u32>,
 }
 
 #[cfg(feature = "std")]
@@ -289,11 +292,11 @@ impl<W: Write> DepthLimitedWrite<W> {
     /// Constructs a new `DepthLimitedWrite`.
     ///
     /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth: u32) -> Self {
+    /// - `depth_limit`: The maximum allowed recursion depth.
+    pub fn new(inner: W, depth_limit: u32) -> Self {
         DepthLimitedWrite {
             inner,
-            depth: RefCell::new(depth),
+            depth_remaining: RefCell::new(depth_limit),
         }
     }
 }
@@ -302,21 +305,21 @@ impl<W: Write> DepthLimitedWrite<W> {
 impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
     type DepthError = Error;
 
-    /// Decrements the depth. If the depth is already zero, an error is returned indicating
-    /// that the maximum depth limit has been exceeded.
+    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
+    /// returned indicating that the maximum depth limit has been exceeded.
     fn enter(&self) -> Result<()> {
-        let depth = *self.depth.borrow();
+        let depth = *self.depth_remaining.borrow();
         if depth == 0 {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth.replace(depth - 1);
+        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
     /// Increments the depth, without exceeding the initial depth value.
     fn leave(&self) {
-        let depth = *self.depth.borrow();
-        self.depth.replace(depth.saturating_add(1));
+        let depth = *self.depth_remaining.borrow();
+        self.depth_remaining.replace(depth.saturating_add(1));
     }
 }
 
@@ -341,11 +344,11 @@ pub struct ReadXdrIter<R: Read, S: ReadXdr> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth: u32) -> Self {
+    fn new(r: R, depth_limit: u32) -> Self {
         Self {
             reader: DepthLimitedRead {
                 inner: BufReader::new(r),
-                depth: RefCell::new(depth),
+                depth_remaining: RefCell::new(depth_limit),
             },
             _s: PhantomData,
         }
@@ -417,7 +420,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth.take(),
+            r.depth_remaining.take(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -461,7 +464,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth.take(),
+            r.depth_remaining.take(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -537,7 +540,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth.take())
+        ReadXdrIter::new(&mut r.inner, r.depth_remaining.take())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -547,34 +550,51 @@ where
         r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth.take())
+        ReadXdrIter::new(dec, r.depth_remaining.take())
     }
 
-    /// Construct the type from the XDR bytes.
+    /// Construct the type from the XDR bytes, specifying a depth limit.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
+    #[cfg(feature = "std")]
+    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+        let t = Self::read_xdr_to_end(&mut cursor)?;
+        Ok(t)
+    }
+
+    /// Construct the type from the XDR bytes, using the default depth limit.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
     fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        let mut cursor =
-            DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
-        let t = Self::read_xdr_to_end(&mut cursor)?;
+        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_MAX_DEPTH_LIMIT)
+    }
+
+    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    ///
+    /// An error is returned if the bytes are not completely consumed by the
+    /// deserialization.
+    #[cfg(feature = "base64")]
+    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+        let mut b64_reader = Cursor::new(b64);
+        let mut dec = DepthLimitedRead::new(
+            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            depth_limit,
+        );
+        let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes base64 encoded.
+    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            DEFAULT_MAX_DEPTH_LIMIT,
-        );
-        let t = Self::read_xdr_to_end(&mut dec)?;
-        Ok(t)
+        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_MAX_DEPTH_LIMIT)
     }
 }
 
@@ -583,22 +603,32 @@ pub trait WriteXdr {
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), DEFAULT_MAX_DEPTH_LIMIT);
+    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
+    #[cfg(feature = "std")]
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        self.to_xdr_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
+    }
+
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
+    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
         let mut enc = DepthLimitedWrite::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            DEFAULT_MAX_DEPTH_LIMIT,
+            depth_limit,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
+    }
+
+    #[cfg(feature = "base64")]
+    fn to_xdr_base64(&self) -> Result<String> {
+        self.to_xdr_base64_with_depth_limit(DEFAULT_MAX_DEPTH_LIMIT)
     }
 }
 
@@ -2742,7 +2772,7 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2761,7 +2791,7 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2770,12 +2800,12 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::SError(Box::new(t))))),
-TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
-TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
-TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
+                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::SError(Box::new(t))))),
+TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
+TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
+TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
                 }
             }
 
@@ -2783,12 +2813,12 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(&mut r.inner
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::SError => Box::new(ReadXdrIter::<_, Frame<SError>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::SError(Box::new(t.0))))),
-TypeVariant::Multi => Box::new(ReadXdrIter::<_, Frame<Multi>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Multi(Box::new(t.0))))),
-TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
-TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, Frame<IntUnion>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::IntUnion(Box::new(t.0))))),
-TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, Frame<IntUnion2>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::IntUnion2(Box::new(t.0))))),
+                    TypeVariant::SError => Box::new(ReadXdrIter::<_, Frame<SError>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::SError(Box::new(t.0))))),
+TypeVariant::Multi => Box::new(ReadXdrIter::<_, Frame<Multi>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Multi(Box::new(t.0))))),
+TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
+TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, Frame<IntUnion>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::IntUnion(Box::new(t.0))))),
+TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, Frame<IntUnion2>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::IntUnion2(Box::new(t.0))))),
                 }
             }
 
@@ -2797,12 +2827,12 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, Frame<IntUnion2>>::new(&mut 
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::SError(Box::new(t))))),
-TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
-TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
-TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
+                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::SError(Box::new(t))))),
+TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
+TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
+TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -55,7 +55,8 @@ use std::{
 ///
 /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
 /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+/// For more information about Rust's stack size limit, refer to the
+/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
 pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -11,10 +11,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
-use super::depth_limiter::*;
-
-#[cfg(feature = "std")]
-use core::marker::PhantomData;
+use core::{cell::RefCell, marker::PhantomData};
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -53,6 +50,8 @@ use std::{
     error, io,
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
+
+pub const DEFAULT_MAX_DEPTH_LIMIT: u32 = 500;
 
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
@@ -185,6 +184,112 @@ where
 {
 }
 
+pub trait DepthLimiter {
+    type DepthError;
+
+    fn enter(&self) -> core::result::Result<(), Self::DepthError>;
+
+    fn leave(&self);
+
+    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthError>
+    where
+        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthError>,
+    {
+        self.enter()?;
+        let res = f(self)?;
+        self.leave();
+        Ok(res)
+    }
+}
+
+#[cfg(feature = "std")]
+pub struct DepthLimitedRead<R: Read> {
+    pub inner: R,
+    pub(crate) depth: RefCell<u32>,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> DepthLimitedRead<R> {
+    pub fn new(inner: R, depth: u32) -> Self {
+        DepthLimitedRead {
+            inner,
+            depth: RefCell::new(depth),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
+    type DepthError = Error;
+
+    fn enter(&self) -> core::result::Result<(), Error> {
+        let depth = *self.depth.borrow();
+        if depth == 0 {
+            return Err(Error::DepthLimitExceeded);
+        }
+        self.depth.replace(depth - 1);
+        Ok(())
+    }
+
+    fn leave(&self) {
+        let depth = *self.depth.borrow();
+        self.depth.replace(depth.saturating_add(1));
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for DepthLimitedRead<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+pub struct DepthLimitedWrite<W: Write> {
+    pub inner: W,
+    pub(crate) depth: RefCell<u32>,
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> DepthLimitedWrite<W> {
+    pub fn new(inner: W, depth: u32) -> Self {
+        DepthLimitedWrite {
+            inner,
+            depth: RefCell::new(depth),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
+    type DepthError = Error;
+
+    fn enter(&self) -> Result<()> {
+        let depth = *self.depth.borrow();
+        if depth == 0 {
+            return Err(Error::DepthLimitExceeded);
+        }
+        self.depth.replace(depth - 1);
+        Ok(())
+    }
+
+    fn leave(&self) {
+        let depth = *self.depth.borrow();
+        self.depth.replace(depth.saturating_add(1));
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for DepthLimitedWrite<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
     reader: DepthLimitedRead<BufReader<R>>,
@@ -193,9 +298,12 @@ pub struct ReadXdrIter<R: Read, S: ReadXdr> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth_limit: u32) -> Self {
+    fn new(r: R, depth: u32) -> Self {
         Self {
-            reader: DepthLimitedRead::new(BufReader::new(r), depth_limit),
+            reader: DepthLimitedRead {
+                inner: BufReader::new(r),
+                depth: RefCell::new(depth),
+            },
             _s: PhantomData,
         }
     }
@@ -263,10 +371,10 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
-            base64::read::DecoderReader::new(r, base64::STANDARD),
-            depth_limit,
+            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            r.depth.take(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -307,10 +415,10 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end(r: &mut impl Read, depth_limit: u32) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
-            base64::read::DecoderReader::new(r, base64::STANDARD),
-            depth_limit,
+            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            r.depth.take(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -385,19 +493,18 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut R, depth_limit: u32) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(r, depth_limit)
+    fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
+        ReadXdrIter::new(&mut r.inner, r.depth.take())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
     /// values that are read into the implementing type.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
-        r: &mut R,
-        depth_limit: u32,
+        r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
-        ReadXdrIter::new(dec, depth_limit)
+        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        ReadXdrIter::new(dec, r.depth.take())
     }
 
     /// Construct the type from the XDR bytes.
@@ -405,8 +512,9 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
+        let mut cursor =
+            DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
@@ -416,11 +524,11 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            depth_limit,
+            DEFAULT_MAX_DEPTH_LIMIT,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -432,18 +540,18 @@ pub trait WriteXdr {
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, depth_limit: u32) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
+    fn to_xdr(&self) -> Result<Vec<u8>> {
+        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), DEFAULT_MAX_DEPTH_LIMIT);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, depth_limit: u32) -> Result<String> {
+    fn to_xdr_base64(&self) -> Result<String> {
         let mut enc = DepthLimitedWrite::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            depth_limit,
+            DEFAULT_MAX_DEPTH_LIMIT,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
@@ -604,12 +712,13 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
         w.with_limited_depth(|w| {
-            Ok(if let Some(t) = self {
+            if let Some(t) = self {
                 1u32.write_xdr(w)?;
                 t.write_xdr(w)?;
             } else {
                 0u32.write_xdr(w)?;
-            })
+            }
+            Ok(())
         })
     }
 }
@@ -1877,30 +1986,31 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use crate::{DepthLimitedRead, DepthLimitedWrite};
-
-    use super::{Error, ReadXdr, VecM, WriteXdr};
-
-    const DEPTH_LIMIT: u32 = 10;
+    use super::{
+        DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
+        DEFAULT_MAX_DEPTH_LIMIT,
+    };
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT))
+            .unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1910,7 +2020,7 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1924,7 +2034,7 @@ mod tests {
 
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEPTH_LIMIT,
+            DEFAULT_MAX_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
@@ -1936,7 +2046,7 @@ mod tests {
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
         v.write_xdr(&mut DepthLimitedWrite::new(
             Cursor::new(&mut buf),
-            DEPTH_LIMIT,
+            DEFAULT_MAX_DEPTH_LIMIT,
         ))
         .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
@@ -1945,21 +2055,23 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v =
+            <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT)).unwrap();
+        let v =
+            <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT)).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -1969,7 +2081,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_MAX_DEPTH_LIMIT));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -1982,7 +2094,7 @@ mod tests {
         [2u8, 2, 2, 2]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEPTH_LIMIT,
+                DEFAULT_MAX_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -1994,7 +2106,7 @@ mod tests {
         [2u8]
             .write_xdr(&mut DepthLimitedWrite::new(
                 Cursor::new(&mut buf),
-                DEPTH_LIMIT,
+                DEFAULT_MAX_DEPTH_LIMIT,
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2040,23 +2152,32 @@ mod test {
         assert_eq!(a, a_back);
     }
 
-    #[should_panic]
     #[test]
     fn write_over_depth_limit_fail() {
+        let depth_limit = 3;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 3);
-        a.write_xdr(&mut buf).unwrap();
+        let mut buf = DepthLimitedWrite::new(Vec::new(), depth_limit);
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::DepthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
     }
 
-    #[should_panic]
     #[test]
     fn read_over_depth_limit_fail() {
+        let read_depth_limit = 3;
+        let write_depth_limit = 5;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 5);
+        let mut buf = DepthLimitedWrite::new(Vec::new(), write_depth_limit);
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 3);
-        let _: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
+        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), read_depth_limit);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::DepthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
     }
 }
 
@@ -2182,7 +2303,7 @@ Self::Multi => "Multi",
         impl WriteXdr for UnionKey {
             #[cfg(feature = "std")]
             fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
-                w.with_limited_write(|w| {
+                w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
                 })
@@ -2269,7 +2390,7 @@ Self::Multi(_) => UnionKey::Multi,
         impl ReadXdr for MyUnion {
             #[cfg(feature = "std")]
             fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                r.with_limited_read(|r| {
+                r.with_limited_depth(|r| {
                     let dv: UnionKey = <UnionKey as ReadXdr>::read_xdr(r)?;
                     #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
                     let v = match dv {
@@ -2279,13 +2400,13 @@ UnionKey::Multi => Self::Multi(VecM::<i32>::read_xdr(r)?),
                         _ => return Err(Error::Invalid),
                     };
                     Ok(v)
-                }
+                })
             }
         }
 
         impl WriteXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     self.discriminant().write_xdr(w)?;
                     #[allow(clippy::match_same_arms)]
@@ -2377,7 +2498,7 @@ Self::V1(_) => 1,
         impl ReadXdr for IntUnion {
             #[cfg(feature = "std")]
             fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                r.with_limited_read(|r| {
+                r.with_limited_depth(|r| {
                     let dv: i32 = <i32 as ReadXdr>::read_xdr(r)?;
                     #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
                     let v = match dv {
@@ -2387,13 +2508,13 @@ Self::V1(_) => 1,
                         _ => return Err(Error::Invalid),
                     };
                     Ok(v)
-                }
+                })
             }
         }
 
         impl WriteXdr for IntUnion {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     self.discriminant().write_xdr(w)?;
                     #[allow(clippy::match_same_arms)]
@@ -2443,7 +2564,7 @@ impl ReadXdr for IntUnion2 {
         r.with_limited_depth(|r| {
             let i = IntUnion::read_xdr(r)?;
             let v = IntUnion2(i);
-            Ok(v)})
+            Ok(v)
         })
     }
 }
@@ -2567,21 +2688,18 @@ TypeVariant::IntUnion2, ];
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
                 match v {
-                    TypeVariant::SError => r.with_limited_depth(|r| Ok(Self::SError(Box::new(SError::read_xdr(r)?))))?,
-TypeVariant::Multi => r.with_limited_depth(|r| Ok(Self::Multi(Box::new(Multi::read_xdr(r)?))))?,
-TypeVariant::UnionKey => r.with_limited_depth(|r| Ok(Self::UnionKey(Box::new(UnionKey::read_xdr(r)?))))?,
-TypeVariant::MyUnion => r.with_limited_depth(|r| Ok(Self::MyUnion(Box::new(MyUnion::read_xdr(r)?))))?,
-TypeVariant::IntUnion => r.with_limited_depth(|r| Ok(Self::IntUnion(Box::new(IntUnion::read_xdr(r)?))))?,
-TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(IntUnion2::read_xdr(r)?))))?,
+                    TypeVariant::SError => r.with_limited_depth(|r| Ok(Self::SError(Box::new(SError::read_xdr(r)?)))),
+TypeVariant::Multi => r.with_limited_depth(|r| Ok(Self::Multi(Box::new(Multi::read_xdr(r)?)))),
+TypeVariant::UnionKey => r.with_limited_depth(|r| Ok(Self::UnionKey(Box::new(UnionKey::read_xdr(r)?)))),
+TypeVariant::MyUnion => r.with_limited_depth(|r| Ok(Self::MyUnion(Box::new(MyUnion::read_xdr(r)?)))),
+TypeVariant::IntUnion => r.with_limited_depth(|r| Ok(Self::IntUnion(Box::new(IntUnion::read_xdr(r)?)))),
+TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(IntUnion2::read_xdr(r)?)))),
                 }
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(
-                  base64::read::DecoderReader::new(r, base64::STANDARD),
-                  depth_limit,
-                );
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2599,66 +2717,63 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end(v: TypeVariant, r: &mut impl Read, depth_limit: u32) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(
-                  base64::read::DecoderReader::new(r, base64::STANDARD),
-                  depth_limit,
-                );
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth.take());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit: u32) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(r, depth_limit).map(|r| r.map(|t| Self::SError(Box::new(t))))),
-TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(r, depth_limit).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
-TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(r, depth_limit).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(r, depth_limit).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(r, depth_limit).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
-TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(r, depth_limit).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
+                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::SError(Box::new(t))))),
+TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
+TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
+TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::SError => Box::new(ReadXdrIter::<_, Frame<SError>>::new(r, depth_limit).map(|r| r.map(|t| Self::SError(Box::new(t.0))))),
-TypeVariant::Multi => Box::new(ReadXdrIter::<_, Frame<Multi>>::new(r, depth_limit).map(|r| r.map(|t| Self::Multi(Box::new(t.0))))),
-TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(r, depth_limit).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(r, depth_limit).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
-TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, Frame<IntUnion>>::new(r, depth_limit).map(|r| r.map(|t| Self::IntUnion(Box::new(t.0))))),
-TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, Frame<IntUnion2>>::new(r, depth_limit).map(|r| r.map(|t| Self::IntUnion2(Box::new(t.0))))),
+                    TypeVariant::SError => Box::new(ReadXdrIter::<_, Frame<SError>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::SError(Box::new(t.0))))),
+TypeVariant::Multi => Box::new(ReadXdrIter::<_, Frame<Multi>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::Multi(Box::new(t.0))))),
+TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
+TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, Frame<IntUnion>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::IntUnion(Box::new(t.0))))),
+TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, Frame<IntUnion2>>::new(&mut r.inner, r.depth.take()).map(|r| r.map(|t| Self::IntUnion2(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut R, depth_limit) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(r, base64::STANDARD);
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(dec, depth_limit).map(|r| r.map(|t| Self::SError(Box::new(t))))),
-TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(dec, depth_limit).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
-TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, depth_limit).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, depth_limit).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(dec, depth_limit).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
-TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, depth_limit).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
+                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::SError(Box::new(t))))),
+TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
+TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
+TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.depth.take()).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, depth_limit: u32) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
+                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_MAX_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String, depth_limit: u32) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), depth_limit);
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_MAX_DEPTH_LIMIT);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -11,7 +11,7 @@ pub const XDR_FILES_SHA256: [(&str, &str); 1] = [
 use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref, slice};
 
 #[cfg(feature = "std")]
-use core::{cell::RefCell, marker::PhantomData};
+use core::marker::PhantomData;
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -194,15 +194,18 @@ where
 /// It provides a mechanism to limit recursion depth, and defines the behavior upon
 /// entering and leaving a recursion level.
 pub trait DepthLimiter {
-    /// The error type returned by methods when they fail due to exceeding the depth limit.
-    type DepthError;
+    /// A general error type for any type implementing, or an operation under the guard of
+    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
+    /// which is returned from `enter`.
+    type DepthLimiterError;
 
     /// Defines the behavior for entering a new recursion level.
-    /// A `DepthError` is returned if the new level exceeds the depth limit.
-    fn enter(&self) -> core::result::Result<(), Self::DepthError>;
+    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
+    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
 
     /// Defines the behavior for leaving a recursion level.
-    fn leave(&self);
+    /// A `DepthLimiterError` is returned if an error occurs.
+    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
 
     /// Wraps a given function `f` with depth limiting guards.
     /// It triggers an `enter` before, and a `leave` after the execution of `f`.
@@ -213,16 +216,17 @@ pub trait DepthLimiter {
     ///
     /// # Returns
     ///
-    /// - `Ok` with function result if `f` executes without exceeding depth limits,
-    ///   `Err` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthError>
+    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
+    ///         with an error 3. if error occurs on `leave`.
+    ///   `Ok` otherwise.
+    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
     where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthError>,
+        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
     {
         self.enter()?;
-        let res = f(self)?;
-        self.leave();
-        Ok(res)
+        let res = f(self);
+        self.leave()?;
+        res
     }
 }
 
@@ -232,7 +236,7 @@ pub trait DepthLimiter {
 #[cfg(feature = "std")]
 pub struct DepthLimitedRead<R: Read> {
     pub inner: R,
-    pub(crate) depth_remaining: RefCell<u32>,
+    pub(crate) depth_remaining: u32,
 }
 
 #[cfg(feature = "std")]
@@ -244,30 +248,31 @@ impl<R: Read> DepthLimitedRead<R> {
     pub fn new(inner: R, depth_limit: u32) -> Self {
         DepthLimitedRead {
             inner,
-            depth_remaining: RefCell::new(depth_limit),
+            depth_remaining: depth_limit,
         }
     }
 }
 
 #[cfg(feature = "std")]
 impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthError = Error;
+    type DepthLimiterError = Error;
 
     /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
     /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&self) -> core::result::Result<(), Error> {
-        let depth = *self.depth_remaining.borrow();
-        if depth == 0 {
+    fn enter(&mut self) -> core::result::Result<(), Error> {
+        if let Some(depth) = self.depth_remaining.checked_sub(1) {
+            self.depth_remaining = depth;
+        } else {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
-    /// Increments the depth, without exceeding the initial depth value.
-    fn leave(&self) {
-        let depth = *self.depth_remaining.borrow();
-        self.depth_remaining.replace(depth.saturating_add(1));
+    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
+    /// doesn't exceed the initial depth limit.
+    fn leave(&mut self) -> core::result::Result<(), Error> {
+        self.depth_remaining = self.depth_remaining.saturating_add(1);
+        Ok(())
     }
 }
 
@@ -285,7 +290,7 @@ impl<R: Read> Read for DepthLimitedRead<R> {
 #[cfg(feature = "std")]
 pub struct DepthLimitedWrite<W: Write> {
     pub inner: W,
-    pub(crate) depth_remaining: RefCell<u32>,
+    pub(crate) depth_remaining: u32,
 }
 
 #[cfg(feature = "std")]
@@ -297,30 +302,31 @@ impl<W: Write> DepthLimitedWrite<W> {
     pub fn new(inner: W, depth_limit: u32) -> Self {
         DepthLimitedWrite {
             inner,
-            depth_remaining: RefCell::new(depth_limit),
+            depth_remaining: depth_limit,
         }
     }
 }
 
 #[cfg(feature = "std")]
 impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthError = Error;
+    type DepthLimiterError = Error;
 
     /// Decrements the `depth_remaining`. If the depth is already zero, an error is
     /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&self) -> Result<()> {
-        let depth = *self.depth_remaining.borrow();
-        if depth == 0 {
+    fn enter(&mut self) -> Result<()> {
+        if let Some(depth) = self.depth_remaining.checked_sub(1) {
+            self.depth_remaining = depth;
+        } else {
             return Err(Error::DepthLimitExceeded);
         }
-        self.depth_remaining.replace(depth - 1);
         Ok(())
     }
 
-    /// Increments the depth, without exceeding the initial depth value.
-    fn leave(&self) {
-        let depth = *self.depth_remaining.borrow();
-        self.depth_remaining.replace(depth.saturating_add(1));
+    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
+    /// doesn't exceed the initial depth limit.
+    fn leave(&mut self) -> core::result::Result<(), Error> {
+        self.depth_remaining = self.depth_remaining.saturating_add(1);
+        Ok(())
     }
 }
 
@@ -349,7 +355,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
         Self {
             reader: DepthLimitedRead {
                 inner: BufReader::new(r),
-                depth_remaining: RefCell::new(depth_limit),
+                depth_remaining: depth_limit,
             },
             _s: PhantomData,
         }
@@ -421,7 +427,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining.take(),
+            r.depth_remaining,
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -465,7 +471,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
         let mut dec = DepthLimitedRead::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining.take(),
+            r.depth_remaining,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -541,7 +547,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining.take())
+        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -551,7 +557,7 @@ where
         r: &mut DepthLimitedRead<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining.take())
+        ReadXdrIter::new(dec, r.depth_remaining)
     }
 
     /// Construct the type from the XDR bytes, specifying a depth limit.
@@ -2777,7 +2783,7 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2796,7 +2802,7 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining.take());
+                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2805,12 +2811,12 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::SError(Box::new(t))))),
-TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
-TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
-TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
+                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::SError(Box::new(t))))),
+TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
+TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
+TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
                 }
             }
 
@@ -2818,12 +2824,12 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(&mut r.inner
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::SError => Box::new(ReadXdrIter::<_, Frame<SError>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::SError(Box::new(t.0))))),
-TypeVariant::Multi => Box::new(ReadXdrIter::<_, Frame<Multi>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::Multi(Box::new(t.0))))),
-TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
-TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, Frame<IntUnion>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::IntUnion(Box::new(t.0))))),
-TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, Frame<IntUnion2>>::new(&mut r.inner, r.depth_remaining.take()).map(|r| r.map(|t| Self::IntUnion2(Box::new(t.0))))),
+                    TypeVariant::SError => Box::new(ReadXdrIter::<_, Frame<SError>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::SError(Box::new(t.0))))),
+TypeVariant::Multi => Box::new(ReadXdrIter::<_, Frame<Multi>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Multi(Box::new(t.0))))),
+TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
+TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, Frame<IntUnion>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::IntUnion(Box::new(t.0))))),
+TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, Frame<IntUnion2>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::IntUnion2(Box::new(t.0))))),
                 }
             }
 
@@ -2832,12 +2838,12 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, Frame<IntUnion2>>::new(&mut 
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::SError(Box::new(t))))),
-TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
-TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
-TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.depth_remaining.take()).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
+                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::SError(Box::new(t))))),
+TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
+TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
+TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
                 }
             }
 


### PR DESCRIPTION
This is the xdrgen side of changed needed for https://github.com/stellar/rs-soroban-env/issues/861
Generated rs-stellar-xdr: https://github.com/stellar/rs-stellar-xdr/pull/281
The corresponding env PR is https://github.com/stellar/rs-soroban-env/pull/904

- Adds a new trait `DepthLimiter` and implements it on two new structures `DepthLimitedRead` and `DepthLimitedWrite`, which replace the normal `R: Read` and `W: Write` in `[Read,Write]Xdr`. 
- The depth limiter provides a guard that automatically increases and decreases a counter on `enter` and `leave`. Thus limiting the number of recursions on `[read_ write_]xdr` calls. 
- Defines a `pub const DEFAULT_MAX_DEPTH_LIMIT: u32` which is used for scenarios where DepthLimited structure is constructed internally ( `from_xdr(bytes)` and `from_xdr_base64(bytes)`). I don't quite like the fact that this is an internal constant, I think ideally this should be externally defined, like the other scenarios where the user constructs the DepthLimited struct.  This also means the same workflows may have two different limits, depending on which api to call. 
But passing an additional u32 into these apis makes the UX hideous, and I've checked there is no `extern std::uint32_t` (how xdrpp does it) equivalent in Rust, and Rust doesn't like static mutable variables (I experimented with it in one commit but it would require turning off the "no-unsafe" guard so I reverted it). So I just decided using a pub const here is the best compromise (I can think of, would much welcome suggestions) for UX.
- Added a the `_with_depth_limit` version of `from_xdr` to allow user-specified depth limits, and having one version calling another. This is a fair compromise that allows the user deal the the inconsistency mentioned above.

cc @graydon @anupsdf 