### PR TITLE
Escape certain reserved terms when building member functions

### DIFF
--- a/lib/xdrgen/generators/javascript.rb
+++ b/lib/xdrgen/generators/javascript.rb
@@ -131,8 +131,6 @@ module Xdrgen
                   if union.discriminant.type.is_a?(AST::Typespecs::Int)
                     member = union.resolved_case(acase)
                     "#{member.value}"
-                  elsif member_name(acase.value) == 'set'
-                    '"set_"'
                   else
                     '"' + member_name(acase.value) + '"'
                   end
@@ -192,7 +190,11 @@ module Xdrgen
       end
 
       def member_name(member)
-        name(member).camelize(:lower)
+        fixedName = name(member).camelize(:lower)
+        if fixedName == 'set'
+          return 'set_'
+        end
+        fixedName
       end
 
       def reference(type)

--- a/lib/xdrgen/generators/javascript.rb
+++ b/lib/xdrgen/generators/javascript.rb
@@ -131,6 +131,8 @@ module Xdrgen
                   if union.discriminant.type.is_a?(AST::Typespecs::Int)
                     member = union.resolved_case(acase)
                     "#{member.value}"
+                  elsif member_name(acase.value) == 'set'
+                    '"set_"'
                   else
                     '"' + member_name(acase.value) + '"'
                   end


### PR DESCRIPTION
Closes #153.

Note: I'm still testing the end-to-end with js-stellar-base.