### PR TITLE
JS: Make numeric union arms callable by adding a `_` prefix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    xdrgen (0.1.1)
+    xdrgen (0.1.2)
       activesupport (~> 6)
       memoist (~> 0.11.0)
       slop (~> 3.4)

--- a/lib/xdrgen/generators/javascript.rb
+++ b/lib/xdrgen/generators/javascript.rb
@@ -130,10 +130,12 @@ module Xdrgen
                 switch = if acase.value.is_a?(AST::Identifier)
                   if union.discriminant.type.is_a?(AST::Typespecs::Int)
                     member = union.resolved_case(acase)
-                    "#{member.value}"
                   else
                     '"' + member_name(acase.value) + '"'
                   end
+                # render integers with a prefix so it's a callable method
+                elsif is_integer?(acase.value.text_value)
+                  '"_' + acase.value.text_value + '"'
                 else
                   acase.value.text_value
                 end
@@ -191,10 +193,15 @@ module Xdrgen
 
       def member_name(member)
         fixedName = name(member).camelize(:lower)
+        # render set() as set_() because set is reserved by stellar/js-xdr
         if fixedName == 'set'
           return 'set_'
         end
         fixedName
+      end
+
+      def is_integer? s
+        true if Integer(s) rescue false
       end
 
       def reference(type)

--- a/lib/xdrgen/version.rb
+++ b/lib/xdrgen/version.rb
@@ -1,3 +1,3 @@
 module Xdrgen
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/output/generator_spec_javascript/union.x/MyXDR_generated.js
+++ b/spec/output/generator_spec_javascript/union.x/MyXDR_generated.js
@@ -77,8 +77,8 @@ xdr.union("IntUnion", {
   switchOn: xdr.int(),
   switchName: "type",
   switches: [
-    [0, "error"],
-    [1, "things"],
+    ["_0", "error"],
+    ["_1", "things"],
   ],
   arms: {
     error: xdr.lookup("Error"),


### PR DESCRIPTION
The JavaScript generator handles unions like this:

```js
// === xdr source ============================================================
//
//   union StoredTransactionSet switch (int v)
//   {
//   case 0:
//   	TransactionSet txSet;
//   case 1:
//   	GeneralizedTransactionSet generalizedTxSet;
//   };
//
// ===========================================================================
xdr.union("StoredTransactionSet", {
  switchOn: xdr.int(),
  switchName: "v",
  switches: [
    [0, "txSet"],
    [1, "generalizedTxSet"],
  ],
  arms: {
    txSet: xdr.lookup("TransactionSet"),
    generalizedTxSet: xdr.lookup("GeneralizedTransactionSet"),
  },
});
```

which results in uncallable methods (i.e. you can't do `let txset = StoredTransactionSet.0()`). This PR renames switches that are made of only digits to have underscores so that they're callable.

Closes https://github.com/stellar/dts-xdr/issues/5.