### PR TITLE
Revert "JS: Make numeric union arms callable by adding a `_` prefix"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    xdrgen (0.1.1)
+    xdrgen (0.1.3)
       activesupport (~> 6)
       memoist (~> 0.11.0)
       slop (~> 3.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    xdrgen (0.1.2)
+    xdrgen (0.1.1)
       activesupport (~> 6)
       memoist (~> 0.11.0)
       slop (~> 3.4)

--- a/lib/xdrgen/generators/javascript.rb
+++ b/lib/xdrgen/generators/javascript.rb
@@ -130,12 +130,10 @@ module Xdrgen
                 switch = if acase.value.is_a?(AST::Identifier)
                   if union.discriminant.type.is_a?(AST::Typespecs::Int)
                     member = union.resolved_case(acase)
+                    "#{member.value}"
                   else
                     '"' + member_name(acase.value) + '"'
                   end
-                # render integers with a prefix so it's a callable method
-                elsif is_integer?(acase.value.text_value)
-                  '"_' + acase.value.text_value + '"'
                 else
                   acase.value.text_value
                 end
@@ -193,15 +191,10 @@ module Xdrgen
 
       def member_name(member)
         fixedName = name(member).camelize(:lower)
-        # render set() as set_() because set is reserved by stellar/js-xdr
         if fixedName == 'set'
           return 'set_'
         end
         fixedName
-      end
-
-      def is_integer? s
-        true if Integer(s) rescue false
       end
 
       def reference(type)

--- a/lib/xdrgen/generators/javascript.rb
+++ b/lib/xdrgen/generators/javascript.rb
@@ -191,6 +191,7 @@ module Xdrgen
 
       def member_name(member)
         fixedName = name(member).camelize(:lower)
+        # render set() as set_() because set is reserved by stellar/js-xdr
         if fixedName == 'set'
           return 'set_'
         end

--- a/lib/xdrgen/version.rb
+++ b/lib/xdrgen/version.rb
@@ -1,3 +1,3 @@
 module Xdrgen
-  VERSION = "0.1.1"
+  VERSION = "0.1.3"
 end

--- a/lib/xdrgen/version.rb
+++ b/lib/xdrgen/version.rb
@@ -1,3 +1,3 @@
 module Xdrgen
-  VERSION = "0.1.2"
+  VERSION = "0.1.1"
 end

--- a/spec/output/generator_spec_javascript/union.x/MyXDR_generated.js
+++ b/spec/output/generator_spec_javascript/union.x/MyXDR_generated.js
@@ -77,8 +77,8 @@ xdr.union("IntUnion", {
   switchOn: xdr.int(),
   switchName: "type",
   switches: [
-    ["_0", "error"],
-    ["_1", "things"],
+    [0, "error"],
+    [1, "things"],
   ],
   arms: {
     error: xdr.lookup("Error"),


### PR DESCRIPTION
This alleged fix is a product of a fundamental misunderstanding of the way that js-xdr works in terms of building the Union structures. In fact, this breaks them. The way that you can initialize numeric unions such as `TransactionMeta`, whose definition is:

```xdr
union TransactionMeta switch (int v)
{
case 0:
    OperationMeta operations<>;
case 1:
    TransactionMetaV1 v1;
case 2:
    TransactionMetaV2 v2;
case 3:
    TransactionMetaV3 v3;
};
```

is by passing the enum switch and its value to the constructor, e.g.

```javascript

  //   case 0:
  //       OperationMeta operations<>;
  //   case 1:
  //       TransactionMetaV1 v1;
  //   case 2:
  //       TransactionMetaV2 v2;
  //   case 3:
  //       TransactionMetaV3 v3;
  //   };
```

is by passing the enum switch and its value to the constructor, e.g.

```javascript
const v3 = new xdr.TransactionMeta(3, new xdr.TransactionMetaV3({
  /* v3 parameters go here */
});
```

The "correct" way to fix this odd behavior is just by adding a constructor on the TypeScript side (i.e. in stellar/dts-xdr) as such:

```typescript
class TransactionMeta {
  constructor(
    v: number, 
    value: 
      | xdr.TransactionMetaV1
      | xdr.TransactionMetaV2
      | xdr.TransactionMetaV3);
}
```