### PR TITLE
refactor(java): Remove the dependency on third-party libraries.

### DIFF
--- a/lib/xdrgen/generators/java.rb
+++ b/lib/xdrgen/generators/java.rb
@@ -43,7 +43,7 @@ module Xdrgen
       end
 
       def add_imports_for_definition(defn, imports)
-        imports.add("com.google.common.io.BaseEncoding")
+        imports.add("java.util.Base64;")
         imports.add("java.io.ByteArrayInputStream")
         imports.add("java.io.ByteArrayOutputStream")
 
@@ -53,15 +53,15 @@ module Xdrgen
             if is_decl_array(m.declaration)
               imports.add('java.util.Arrays')
             else
-              imports.add('com.google.common.base.Objects')
+              imports.add('java.util.Objects')
             end
           end
           # if we have more than one member field then the
           # hash code will be computed by
-          # Objects.hashCode(field1, field2, ..., fieldN)
-          # therefore, we should always import com.google.common.base.Objects
+          # Objects.hash(field1, field2, ..., fieldN)
+          # therefore, we should always import java.util.Objects
           if defn.members.length > 1
-            imports.add("com.google.common.base.Objects")
+            imports.add("java.util.Objects")
           end
         when AST::Definitions::Enum ;
           # no imports required for enums
@@ -73,30 +73,30 @@ module Xdrgen
           if is_type_array(defn.discriminant.type)
             imports.add('java.util.Arrays')
           else
-            imports.add('com.google.common.base.Objects')
+            imports.add('java.util.Objects')
           end
 
           nonVoidArms.each do |a|
             if is_decl_array(a.declaration)
               imports.add('java.util.Arrays')
             else
-              imports.add('com.google.common.base.Objects')
+              imports.add('java.util.Objects')
             end
           end
 
           # if we have more than one field then the
           # hash code will be computed by
-          # Objects.hashCode(field1, field2, ..., fieldN)
-          # therefore, we should always import com.google.common.base.Objects
+          # Objects.hash(field1, field2, ..., fieldN)
+          # therefore, we should always import java.util.Objects
           # if we have more than one field
           if totalFields > 1
-            imports.add("com.google.common.base.Objects")
+            imports.add("java.util.Objects")
           end
         when AST::Definitions::Typedef ;
           if is_decl_array(defn.declaration)
             imports.add('java.util.Arrays')
           else
-            imports.add('com.google.common.base.Objects')
+            imports.add('java.util.Objects')
           end
         end
 
@@ -300,10 +300,10 @@ module Xdrgen
             if is_decl_array(struct.members[0].declaration)
               "Arrays.hashCode(this.#{struct.members[0].name})"
             else
-              "Objects.hashCode(this.#{struct.members[0].name})"
+              "Objects.hash(this.#{struct.members[0].name})"
             end
           else
-            "Objects.hashCode(#{
+            "Objects.hash(#{
               (struct.members.map { |m|
                 if is_decl_array(m.declaration)
                   "Arrays.hashCode(this.#{m.name})"
@@ -324,7 +324,7 @@ module Xdrgen
           if is_decl_array(m.declaration)
             "Arrays.equals(this.#{m.name}, other.#{m.name})"
           else
-            "Objects.equal(this.#{m.name}, other.#{m.name})"
+            "Objects.equals(this.#{m.name}, other.#{m.name})"
           end
         }
         equalExpression = case equalParts.length
@@ -432,7 +432,7 @@ module Xdrgen
           if is_decl_array(typedef.declaration)
             "Arrays.hashCode"
           else
-            "Objects.hashCode"
+            "Objects.hash"
           end
         out.puts <<-EOS.strip_heredoc
           @Override
@@ -446,7 +446,7 @@ module Xdrgen
           if is_decl_array(typedef.declaration)
             "Arrays.equals"
           else
-            "Objects.equal"
+            "Objects.equals"
           end
         type = name_string typedef.name
         out.puts <<-EOS.strip_heredoc
@@ -639,7 +639,7 @@ module Xdrgen
         }
         parts.append(discriminantPart)
 
-        hashCodeExpression = "Objects.hashCode(#{parts.join(", ")})"
+        hashCodeExpression = "Objects.hash(#{parts.join(", ")})"
         out.puts <<-EOS.strip_heredoc
           @Override
           public int hashCode() {
@@ -651,14 +651,14 @@ module Xdrgen
           if is_decl_array(a.declaration)
             "Arrays.equals(this.#{a.name}, other.#{a.name})"
           else
-            "Objects.equal(this.#{a.name}, other.#{a.name})"
+            "Objects.equals(this.#{a.name}, other.#{a.name})"
           end
         }
         equalParts.append(
           if is_type_array(union.discriminant.type)
             "Arrays.equals(this.#{union.discriminant.name}, other.#{union.discriminant.name})"
           else
-            "Objects.equal(this.#{union.discriminant.name}, other.#{union.discriminant.name})"
+            "Objects.equals(this.#{union.discriminant.name}, other.#{union.discriminant.name})"
           end
         )
 
@@ -716,8 +716,7 @@ module Xdrgen
         out.puts <<-EOS.strip_heredoc
           @Override
           public String toXdrBase64() throws IOException {
-            BaseEncoding base64Encoding = BaseEncoding.base64();
-            return base64Encoding.encode(toXdrByteArray());
+            return Base64.getEncoder().encodeToString(toXdrByteArray());
           }
 
           @Override
@@ -729,8 +728,7 @@ module Xdrgen
           }
 
           public static #{return_type} fromXdrBase64(String xdr) throws IOException {
-            BaseEncoding base64Encoding = BaseEncoding.base64();
-            byte[] bytes = base64Encoding.decode(xdr);
+            byte[] bytes = Base64.getDecoder().decode(xdr);
             return fromXdrByteArray(bytes);
           }
 

--- a/lib/xdrgen/generators/java.rb
+++ b/lib/xdrgen/generators/java.rb
@@ -43,7 +43,7 @@ module Xdrgen
       end
 
       def add_imports_for_definition(defn, imports)
-        imports.add("java.util.Base64;")
+        imports.add("java.util.Base64")
         imports.add("java.io.ByteArrayInputStream")
         imports.add("java.io.ByteArrayOutputStream")
 

--- a/lib/xdrgen/generators/java/XdrString.erb
+++ b/lib/xdrgen/generators/java/XdrString.erb
@@ -1,12 +1,12 @@
 package <%= @namespace %>;
 
-import com.google.common.io.BaseEncoding;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.Base64;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,8 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        BaseEncoding base64Encoding = BaseEncoding.base64();
-        return base64Encoding.encode(toXdrByteArray());
+        return Base64.getEncoder().encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -54,8 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        BaseEncoding base64Encoding = BaseEncoding.base64();
-        byte[] bytes = base64Encoding.decode(xdr);
+        byte[] bytes = Base64.getDecoder().decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/lib/xdrgen/generators/java/XdrUnsignedHyperInteger.erb
+++ b/lib/xdrgen/generators/java/XdrUnsignedHyperInteger.erb
@@ -1,12 +1,11 @@
 package <%= @namespace %>;
 
-import com.google.common.base.Objects;
-import com.google.common.io.BaseEncoding;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.Base64;
+import java.util.Objects;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -62,8 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,8 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -88,7 +85,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.number);
+    return Objects.hash(this.number);
   }
 
   @Override
@@ -98,7 +95,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     }
 
     XdrUnsignedHyperInteger other = (XdrUnsignedHyperInteger) object;
-    return Objects.equal(this.number, other.number);
+    return Objects.equals(this.number, other.number);
   }
 
   public String toString() {

--- a/lib/xdrgen/generators/java/XdrUnsignedInteger.erb
+++ b/lib/xdrgen/generators/java/XdrUnsignedInteger.erb
@@ -1,11 +1,10 @@
 package <%= @namespace %>;
 
-import com.google.common.base.Objects;
-import com.google.common.io.BaseEncoding;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Base64;
+import java.util.Objects;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -50,8 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -63,8 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -76,7 +73,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.number);
+    return Objects.hash(this.number);
   }
 
   @Override
@@ -86,7 +83,7 @@ public class XdrUnsignedInteger implements XdrElement {
     }
 
     XdrUnsignedInteger other = (XdrUnsignedInteger) object;
-    return Objects.equal(this.number, other.number);
+    return Objects.equals(this.number, other.number);
   }
 
   public String toString() {

--- a/spec/output/generator_spec_java/block_comments.x/AccountFlags.java
+++ b/spec/output/generator_spec_java/block_comments.x/AccountFlags.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -49,8 +49,7 @@ public enum AccountFlags implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -62,8 +61,7 @@ public enum AccountFlags implements XdrElement {
   }
 
   public static AccountFlags fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/block_comments.x/AccountFlags.java
+++ b/spec/output/generator_spec_java/block_comments.x/AccountFlags.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 

--- a/spec/output/generator_spec_java/block_comments.x/XdrString.java
+++ b/spec/output/generator_spec_java/block_comments.x/XdrString.java
@@ -1,12 +1,12 @@
 package MyXDR;
 
-import com.google.common.io.BaseEncoding;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.Base64;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,8 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        BaseEncoding base64Encoding = BaseEncoding.base64();
-        return base64Encoding.encode(toXdrByteArray());
+        return Base64.getEncoder().encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -54,8 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        BaseEncoding base64Encoding = BaseEncoding.base64();
-        byte[] bytes = base64Encoding.decode(xdr);
+        byte[] bytes = Base64.getDecoder().decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/block_comments.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/block_comments.x/XdrUnsignedHyperInteger.java
@@ -1,12 +1,11 @@
 package MyXDR;
 
-import com.google.common.base.Objects;
-import com.google.common.io.BaseEncoding;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.Base64;
+import java.util.Objects;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -62,8 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,8 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -88,7 +85,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.number);
+    return Objects.hash(this.number);
   }
 
   @Override
@@ -98,7 +95,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     }
 
     XdrUnsignedHyperInteger other = (XdrUnsignedHyperInteger) object;
-    return Objects.equal(this.number, other.number);
+    return Objects.equals(this.number, other.number);
   }
 
   public String toString() {

--- a/spec/output/generator_spec_java/block_comments.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/block_comments.x/XdrUnsignedInteger.java
@@ -1,11 +1,10 @@
 package MyXDR;
 
-import com.google.common.base.Objects;
-import com.google.common.io.BaseEncoding;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Base64;
+import java.util.Objects;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -50,8 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -63,8 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -76,7 +73,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.number);
+    return Objects.hash(this.number);
   }
 
   @Override
@@ -86,7 +83,7 @@ public class XdrUnsignedInteger implements XdrElement {
     }
 
     XdrUnsignedInteger other = (XdrUnsignedInteger) object;
-    return Objects.equal(this.number, other.number);
+    return Objects.equals(this.number, other.number);
   }
 
   public String toString() {

--- a/spec/output/generator_spec_java/const.x/TestArray.java
+++ b/spec/output/generator_spec_java/const.x/TestArray.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -69,8 +69,7 @@ public class TestArray implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -82,8 +81,7 @@ public class TestArray implements XdrElement {
   }
 
   public static TestArray fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/const.x/TestArray.java
+++ b/spec/output/generator_spec_java/const.x/TestArray.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;

--- a/spec/output/generator_spec_java/const.x/TestArray2.java
+++ b/spec/output/generator_spec_java/const.x/TestArray2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -70,8 +70,7 @@ public class TestArray2 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -83,8 +82,7 @@ public class TestArray2 implements XdrElement {
   }
 
   public static TestArray2 fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/const.x/TestArray2.java
+++ b/spec/output/generator_spec_java/const.x/TestArray2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;

--- a/spec/output/generator_spec_java/const.x/XdrString.java
+++ b/spec/output/generator_spec_java/const.x/XdrString.java
@@ -1,12 +1,12 @@
 package MyXDR;
 
-import com.google.common.io.BaseEncoding;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.Base64;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,8 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        BaseEncoding base64Encoding = BaseEncoding.base64();
-        return base64Encoding.encode(toXdrByteArray());
+        return Base64.getEncoder().encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -54,8 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        BaseEncoding base64Encoding = BaseEncoding.base64();
-        byte[] bytes = base64Encoding.decode(xdr);
+        byte[] bytes = Base64.getDecoder().decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/const.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/const.x/XdrUnsignedHyperInteger.java
@@ -1,12 +1,11 @@
 package MyXDR;
 
-import com.google.common.base.Objects;
-import com.google.common.io.BaseEncoding;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.Base64;
+import java.util.Objects;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -62,8 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,8 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -88,7 +85,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.number);
+    return Objects.hash(this.number);
   }
 
   @Override
@@ -98,7 +95,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     }
 
     XdrUnsignedHyperInteger other = (XdrUnsignedHyperInteger) object;
-    return Objects.equal(this.number, other.number);
+    return Objects.equals(this.number, other.number);
   }
 
   public String toString() {

--- a/spec/output/generator_spec_java/const.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/const.x/XdrUnsignedInteger.java
@@ -1,11 +1,10 @@
 package MyXDR;
 
-import com.google.common.base.Objects;
-import com.google.common.io.BaseEncoding;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Base64;
+import java.util.Objects;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -50,8 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -63,8 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -76,7 +73,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.number);
+    return Objects.hash(this.number);
   }
 
   @Override
@@ -86,7 +83,7 @@ public class XdrUnsignedInteger implements XdrElement {
     }
 
     XdrUnsignedInteger other = (XdrUnsignedInteger) object;
-    return Objects.equal(this.number, other.number);
+    return Objects.equals(this.number, other.number);
   }
 
   public String toString() {

--- a/spec/output/generator_spec_java/enum.x/Color.java
+++ b/spec/output/generator_spec_java/enum.x/Color.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -54,8 +54,7 @@ public enum Color implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -67,8 +66,7 @@ public enum Color implements XdrElement {
   }
 
   public static Color fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/enum.x/Color.java
+++ b/spec/output/generator_spec_java/enum.x/Color.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 

--- a/spec/output/generator_spec_java/enum.x/Color2.java
+++ b/spec/output/generator_spec_java/enum.x/Color2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 

--- a/spec/output/generator_spec_java/enum.x/Color2.java
+++ b/spec/output/generator_spec_java/enum.x/Color2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -54,8 +54,7 @@ public enum Color2 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -67,8 +66,7 @@ public enum Color2 implements XdrElement {
   }
 
   public static Color2 fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/enum.x/MessageType.java
+++ b/spec/output/generator_spec_java/enum.x/MessageType.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 

--- a/spec/output/generator_spec_java/enum.x/MessageType.java
+++ b/spec/output/generator_spec_java/enum.x/MessageType.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -94,8 +94,7 @@ public enum MessageType implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -107,8 +106,7 @@ public enum MessageType implements XdrElement {
   }
 
   public static MessageType fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/enum.x/XdrString.java
+++ b/spec/output/generator_spec_java/enum.x/XdrString.java
@@ -1,12 +1,12 @@
 package MyXDR;
 
-import com.google.common.io.BaseEncoding;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.Base64;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,8 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        BaseEncoding base64Encoding = BaseEncoding.base64();
-        return base64Encoding.encode(toXdrByteArray());
+        return Base64.getEncoder().encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -54,8 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        BaseEncoding base64Encoding = BaseEncoding.base64();
-        byte[] bytes = base64Encoding.decode(xdr);
+        byte[] bytes = Base64.getDecoder().decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/enum.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/enum.x/XdrUnsignedHyperInteger.java
@@ -1,12 +1,11 @@
 package MyXDR;
 
-import com.google.common.base.Objects;
-import com.google.common.io.BaseEncoding;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.Base64;
+import java.util.Objects;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -62,8 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,8 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -88,7 +85,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.number);
+    return Objects.hash(this.number);
   }
 
   @Override
@@ -98,7 +95,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     }
 
     XdrUnsignedHyperInteger other = (XdrUnsignedHyperInteger) object;
-    return Objects.equal(this.number, other.number);
+    return Objects.equals(this.number, other.number);
   }
 
   public String toString() {

--- a/spec/output/generator_spec_java/enum.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/enum.x/XdrUnsignedInteger.java
@@ -1,11 +1,10 @@
 package MyXDR;
 
-import com.google.common.base.Objects;
-import com.google.common.io.BaseEncoding;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Base64;
+import java.util.Objects;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -50,8 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -63,8 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -76,7 +73,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.number);
+    return Objects.hash(this.number);
   }
 
   @Override
@@ -86,7 +83,7 @@ public class XdrUnsignedInteger implements XdrElement {
     }
 
     XdrUnsignedInteger other = (XdrUnsignedInteger) object;
-    return Objects.equal(this.number, other.number);
+    return Objects.equals(this.number, other.number);
   }
 
   public String toString() {

--- a/spec/output/generator_spec_java/nesting.x/Foo.java
+++ b/spec/output/generator_spec_java/nesting.x/Foo.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;

--- a/spec/output/generator_spec_java/nesting.x/Foo.java
+++ b/spec/output/generator_spec_java/nesting.x/Foo.java
@@ -6,10 +6,10 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 // === xdr source ============================================================
 
@@ -48,7 +48,7 @@ public class Foo implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.Foo);
+    return Objects.hash(this.Foo);
   }
 
   @Override
@@ -58,12 +58,11 @@ public class Foo implements XdrElement {
     }
 
     Foo other = (Foo) object;
-    return Objects.equal(this.Foo, other.Foo);
+    return Objects.equals(this.Foo, other.Foo);
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,8 +74,7 @@ public class Foo implements XdrElement {
   }
 
   public static Foo fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/nesting.x/MyUnion.java
+++ b/spec/output/generator_spec_java/nesting.x/MyUnion.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;

--- a/spec/output/generator_spec_java/nesting.x/MyUnion.java
+++ b/spec/output/generator_spec_java/nesting.x/MyUnion.java
@@ -6,10 +6,10 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 // === xdr source ============================================================
 
@@ -120,7 +120,7 @@ public class MyUnion implements XdrElement {
   }
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.one, this.two, this.type);
+    return Objects.hash(this.one, this.two, this.type);
   }
   @Override
   public boolean equals(Object object) {
@@ -129,12 +129,11 @@ public class MyUnion implements XdrElement {
     }
 
     MyUnion other = (MyUnion) object;
-    return Objects.equal(this.one, other.one) && Objects.equal(this.two, other.two) && Objects.equal(this.type, other.type);
+    return Objects.equals(this.one, other.one) && Objects.equals(this.two, other.two) && Objects.equals(this.type, other.type);
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -146,8 +145,7 @@ public class MyUnion implements XdrElement {
   }
 
   public static MyUnion fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -179,7 +177,7 @@ public class MyUnion implements XdrElement {
     }
     @Override
     public int hashCode() {
-      return Objects.hashCode(this.someInt);
+      return Objects.hash(this.someInt);
     }
     @Override
     public boolean equals(Object object) {
@@ -188,13 +186,12 @@ public class MyUnion implements XdrElement {
       }
 
       MyUnionOne other = (MyUnionOne) object;
-      return Objects.equal(this.someInt, other.someInt);
+      return Objects.equals(this.someInt, other.someInt);
     }
 
     @Override
     public String toXdrBase64() throws IOException {
-      BaseEncoding base64Encoding = BaseEncoding.base64();
-      return base64Encoding.encode(toXdrByteArray());
+      return Base64.getEncoder().encodeToString(toXdrByteArray());
     }
 
     @Override
@@ -206,8 +203,7 @@ public class MyUnion implements XdrElement {
     }
 
     public static MyUnionOne fromXdrBase64(String xdr) throws IOException {
-      BaseEncoding base64Encoding = BaseEncoding.base64();
-      byte[] bytes = base64Encoding.decode(xdr);
+      byte[] bytes = Base64.getDecoder().decode(xdr);
       return fromXdrByteArray(bytes);
     }
 
@@ -263,7 +259,7 @@ public class MyUnion implements XdrElement {
     }
     @Override
     public int hashCode() {
-      return Objects.hashCode(this.someInt, this.foo);
+      return Objects.hash(this.someInt, this.foo);
     }
     @Override
     public boolean equals(Object object) {
@@ -272,13 +268,12 @@ public class MyUnion implements XdrElement {
       }
 
       MyUnionTwo other = (MyUnionTwo) object;
-      return Objects.equal(this.someInt, other.someInt) && Objects.equal(this.foo, other.foo);
+      return Objects.equals(this.someInt, other.someInt) && Objects.equals(this.foo, other.foo);
     }
 
     @Override
     public String toXdrBase64() throws IOException {
-      BaseEncoding base64Encoding = BaseEncoding.base64();
-      return base64Encoding.encode(toXdrByteArray());
+      return Base64.getEncoder().encodeToString(toXdrByteArray());
     }
 
     @Override
@@ -290,8 +285,7 @@ public class MyUnion implements XdrElement {
     }
 
     public static MyUnionTwo fromXdrBase64(String xdr) throws IOException {
-      BaseEncoding base64Encoding = BaseEncoding.base64();
-      byte[] bytes = base64Encoding.decode(xdr);
+      byte[] bytes = Base64.getDecoder().decode(xdr);
       return fromXdrByteArray(bytes);
     }
 

--- a/spec/output/generator_spec_java/nesting.x/UnionKey.java
+++ b/spec/output/generator_spec_java/nesting.x/UnionKey.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -54,8 +54,7 @@ public enum UnionKey implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -67,8 +66,7 @@ public enum UnionKey implements XdrElement {
   }
 
   public static UnionKey fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/nesting.x/UnionKey.java
+++ b/spec/output/generator_spec_java/nesting.x/UnionKey.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 

--- a/spec/output/generator_spec_java/nesting.x/XdrString.java
+++ b/spec/output/generator_spec_java/nesting.x/XdrString.java
@@ -1,12 +1,12 @@
 package MyXDR;
 
-import com.google.common.io.BaseEncoding;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.Base64;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,8 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        BaseEncoding base64Encoding = BaseEncoding.base64();
-        return base64Encoding.encode(toXdrByteArray());
+        return Base64.getEncoder().encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -54,8 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        BaseEncoding base64Encoding = BaseEncoding.base64();
-        byte[] bytes = base64Encoding.decode(xdr);
+        byte[] bytes = Base64.getDecoder().decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/nesting.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/nesting.x/XdrUnsignedHyperInteger.java
@@ -1,12 +1,11 @@
 package MyXDR;
 
-import com.google.common.base.Objects;
-import com.google.common.io.BaseEncoding;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.Base64;
+import java.util.Objects;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -62,8 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,8 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -88,7 +85,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.number);
+    return Objects.hash(this.number);
   }
 
   @Override
@@ -98,7 +95,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     }
 
     XdrUnsignedHyperInteger other = (XdrUnsignedHyperInteger) object;
-    return Objects.equal(this.number, other.number);
+    return Objects.equals(this.number, other.number);
   }
 
   public String toString() {

--- a/spec/output/generator_spec_java/nesting.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/nesting.x/XdrUnsignedInteger.java
@@ -1,11 +1,10 @@
 package MyXDR;
 
-import com.google.common.base.Objects;
-import com.google.common.io.BaseEncoding;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Base64;
+import java.util.Objects;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -50,8 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -63,8 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -76,7 +73,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.number);
+    return Objects.hash(this.number);
   }
 
   @Override
@@ -86,7 +83,7 @@ public class XdrUnsignedInteger implements XdrElement {
     }
 
     XdrUnsignedInteger other = (XdrUnsignedInteger) object;
-    return Objects.equal(this.number, other.number);
+    return Objects.equals(this.number, other.number);
   }
 
   public String toString() {

--- a/spec/output/generator_spec_java/optional.x/Arr.java
+++ b/spec/output/generator_spec_java/optional.x/Arr.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;

--- a/spec/output/generator_spec_java/optional.x/Arr.java
+++ b/spec/output/generator_spec_java/optional.x/Arr.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -69,8 +69,7 @@ public class Arr implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -82,8 +81,7 @@ public class Arr implements XdrElement {
   }
 
   public static Arr fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/optional.x/HasOptions.java
+++ b/spec/output/generator_spec_java/optional.x/HasOptions.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;

--- a/spec/output/generator_spec_java/optional.x/HasOptions.java
+++ b/spec/output/generator_spec_java/optional.x/HasOptions.java
@@ -6,10 +6,10 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 // === xdr source ============================================================
 
@@ -85,7 +85,7 @@ public class HasOptions implements XdrElement {
   }
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.firstOption, this.secondOption, this.thirdOption);
+    return Objects.hash(this.firstOption, this.secondOption, this.thirdOption);
   }
   @Override
   public boolean equals(Object object) {
@@ -94,13 +94,12 @@ public class HasOptions implements XdrElement {
     }
 
     HasOptions other = (HasOptions) object;
-    return Objects.equal(this.firstOption, other.firstOption) && Objects.equal(this.secondOption, other.secondOption) && Objects.equal(this.thirdOption, other.thirdOption);
+    return Objects.equals(this.firstOption, other.firstOption) && Objects.equals(this.secondOption, other.secondOption) && Objects.equals(this.thirdOption, other.thirdOption);
   }
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -112,8 +111,7 @@ public class HasOptions implements XdrElement {
   }
 
   public static HasOptions fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/optional.x/XdrString.java
+++ b/spec/output/generator_spec_java/optional.x/XdrString.java
@@ -1,12 +1,12 @@
 package MyXDR;
 
-import com.google.common.io.BaseEncoding;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.Base64;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,8 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        BaseEncoding base64Encoding = BaseEncoding.base64();
-        return base64Encoding.encode(toXdrByteArray());
+        return Base64.getEncoder().encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -54,8 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        BaseEncoding base64Encoding = BaseEncoding.base64();
-        byte[] bytes = base64Encoding.decode(xdr);
+        byte[] bytes = Base64.getDecoder().decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/optional.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/optional.x/XdrUnsignedHyperInteger.java
@@ -1,12 +1,11 @@
 package MyXDR;
 
-import com.google.common.base.Objects;
-import com.google.common.io.BaseEncoding;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.Base64;
+import java.util.Objects;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -62,8 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,8 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -88,7 +85,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.number);
+    return Objects.hash(this.number);
   }
 
   @Override
@@ -98,7 +95,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     }
 
     XdrUnsignedHyperInteger other = (XdrUnsignedHyperInteger) object;
-    return Objects.equal(this.number, other.number);
+    return Objects.equals(this.number, other.number);
   }
 
   public String toString() {

--- a/spec/output/generator_spec_java/optional.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/optional.x/XdrUnsignedInteger.java
@@ -1,11 +1,10 @@
 package MyXDR;
 
-import com.google.common.base.Objects;
-import com.google.common.io.BaseEncoding;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Base64;
+import java.util.Objects;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -50,8 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -63,8 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -76,7 +73,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.number);
+    return Objects.hash(this.number);
   }
 
   @Override
@@ -86,7 +83,7 @@ public class XdrUnsignedInteger implements XdrElement {
     }
 
     XdrUnsignedInteger other = (XdrUnsignedInteger) object;
-    return Objects.equal(this.number, other.number);
+    return Objects.equals(this.number, other.number);
   }
 
   public String toString() {

--- a/spec/output/generator_spec_java/struct.x/Int64.java
+++ b/spec/output/generator_spec_java/struct.x/Int64.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;

--- a/spec/output/generator_spec_java/struct.x/Int64.java
+++ b/spec/output/generator_spec_java/struct.x/Int64.java
@@ -6,10 +6,10 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 // === xdr source ============================================================
 
@@ -48,7 +48,7 @@ public class Int64 implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.int64);
+    return Objects.hash(this.int64);
   }
 
   @Override
@@ -58,12 +58,11 @@ public class Int64 implements XdrElement {
     }
 
     Int64 other = (Int64) object;
-    return Objects.equal(this.int64, other.int64);
+    return Objects.equals(this.int64, other.int64);
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,8 +74,7 @@ public class Int64 implements XdrElement {
   }
 
   public static Int64 fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/struct.x/MyStruct.java
+++ b/spec/output/generator_spec_java/struct.x/MyStruct.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;

--- a/spec/output/generator_spec_java/struct.x/MyStruct.java
+++ b/spec/output/generator_spec_java/struct.x/MyStruct.java
@@ -6,10 +6,10 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import com.google.common.base.Objects;
+import java.util.Objects;
 import java.util.Arrays;
 
 // === xdr source ============================================================
@@ -85,7 +85,7 @@ public class MyStruct implements XdrElement {
   }
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.someInt, this.aBigInt, Arrays.hashCode(this.someOpaque), this.someString, this.maxString);
+    return Objects.hash(this.someInt, this.aBigInt, Arrays.hashCode(this.someOpaque), this.someString, this.maxString);
   }
   @Override
   public boolean equals(Object object) {
@@ -94,13 +94,12 @@ public class MyStruct implements XdrElement {
     }
 
     MyStruct other = (MyStruct) object;
-    return Objects.equal(this.someInt, other.someInt) && Objects.equal(this.aBigInt, other.aBigInt) && Arrays.equals(this.someOpaque, other.someOpaque) && Objects.equal(this.someString, other.someString) && Objects.equal(this.maxString, other.maxString);
+    return Objects.equals(this.someInt, other.someInt) && Objects.equals(this.aBigInt, other.aBigInt) && Arrays.equals(this.someOpaque, other.someOpaque) && Objects.equals(this.someString, other.someString) && Objects.equals(this.maxString, other.maxString);
   }
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -112,8 +111,7 @@ public class MyStruct implements XdrElement {
   }
 
   public static MyStruct fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/struct.x/XdrString.java
+++ b/spec/output/generator_spec_java/struct.x/XdrString.java
@@ -1,12 +1,12 @@
 package MyXDR;
 
-import com.google.common.io.BaseEncoding;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.Base64;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,8 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        BaseEncoding base64Encoding = BaseEncoding.base64();
-        return base64Encoding.encode(toXdrByteArray());
+        return Base64.getEncoder().encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -54,8 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        BaseEncoding base64Encoding = BaseEncoding.base64();
-        byte[] bytes = base64Encoding.decode(xdr);
+        byte[] bytes = Base64.getDecoder().decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/struct.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/struct.x/XdrUnsignedHyperInteger.java
@@ -1,12 +1,11 @@
 package MyXDR;
 
-import com.google.common.base.Objects;
-import com.google.common.io.BaseEncoding;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.Base64;
+import java.util.Objects;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -62,8 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,8 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -88,7 +85,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.number);
+    return Objects.hash(this.number);
   }
 
   @Override
@@ -98,7 +95,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     }
 
     XdrUnsignedHyperInteger other = (XdrUnsignedHyperInteger) object;
-    return Objects.equal(this.number, other.number);
+    return Objects.equals(this.number, other.number);
   }
 
   public String toString() {

--- a/spec/output/generator_spec_java/struct.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/struct.x/XdrUnsignedInteger.java
@@ -1,11 +1,10 @@
 package MyXDR;
 
-import com.google.common.base.Objects;
-import com.google.common.io.BaseEncoding;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Base64;
+import java.util.Objects;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -50,8 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -63,8 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -76,7 +73,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.number);
+    return Objects.hash(this.number);
   }
 
   @Override
@@ -86,7 +83,7 @@ public class XdrUnsignedInteger implements XdrElement {
     }
 
     XdrUnsignedInteger other = (XdrUnsignedInteger) object;
-    return Objects.equal(this.number, other.number);
+    return Objects.equals(this.number, other.number);
   }
 
   public String toString() {

--- a/spec/output/generator_spec_java/test.x/Color.java
+++ b/spec/output/generator_spec_java/test.x/Color.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -54,8 +54,7 @@ public enum Color implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -67,8 +66,7 @@ public enum Color implements XdrElement {
   }
 
   public static Color fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Color.java
+++ b/spec/output/generator_spec_java/test.x/Color.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 

--- a/spec/output/generator_spec_java/test.x/HasStuff.java
+++ b/spec/output/generator_spec_java/test.x/HasStuff.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;

--- a/spec/output/generator_spec_java/test.x/HasStuff.java
+++ b/spec/output/generator_spec_java/test.x/HasStuff.java
@@ -6,10 +6,10 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 // === xdr source ============================================================
 
@@ -41,7 +41,7 @@ public class HasStuff implements XdrElement {
   }
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.data);
+    return Objects.hash(this.data);
   }
   @Override
   public boolean equals(Object object) {
@@ -50,13 +50,12 @@ public class HasStuff implements XdrElement {
     }
 
     HasStuff other = (HasStuff) object;
-    return Objects.equal(this.data, other.data);
+    return Objects.equals(this.data, other.data);
   }
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -68,8 +67,7 @@ public class HasStuff implements XdrElement {
   }
 
   public static HasStuff fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Hash.java
+++ b/spec/output/generator_spec_java/test.x/Hash.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -65,8 +65,7 @@ public class Hash implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -78,8 +77,7 @@ public class Hash implements XdrElement {
   }
 
   public static Hash fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Hash.java
+++ b/spec/output/generator_spec_java/test.x/Hash.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;

--- a/spec/output/generator_spec_java/test.x/Hashes1.java
+++ b/spec/output/generator_spec_java/test.x/Hashes1.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;

--- a/spec/output/generator_spec_java/test.x/Hashes1.java
+++ b/spec/output/generator_spec_java/test.x/Hashes1.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -69,8 +69,7 @@ public class Hashes1 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -82,8 +81,7 @@ public class Hashes1 implements XdrElement {
   }
 
   public static Hashes1 fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Hashes2.java
+++ b/spec/output/generator_spec_java/test.x/Hashes2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -70,8 +70,7 @@ public class Hashes2 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -83,8 +82,7 @@ public class Hashes2 implements XdrElement {
   }
 
   public static Hashes2 fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Hashes2.java
+++ b/spec/output/generator_spec_java/test.x/Hashes2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;

--- a/spec/output/generator_spec_java/test.x/Hashes3.java
+++ b/spec/output/generator_spec_java/test.x/Hashes3.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;

--- a/spec/output/generator_spec_java/test.x/Hashes3.java
+++ b/spec/output/generator_spec_java/test.x/Hashes3.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -70,8 +70,7 @@ public class Hashes3 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -83,8 +82,7 @@ public class Hashes3 implements XdrElement {
   }
 
   public static Hashes3 fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Int1.java
+++ b/spec/output/generator_spec_java/test.x/Int1.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;

--- a/spec/output/generator_spec_java/test.x/Int1.java
+++ b/spec/output/generator_spec_java/test.x/Int1.java
@@ -6,10 +6,10 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 // === xdr source ============================================================
 
@@ -48,7 +48,7 @@ public class Int1 implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.int1);
+    return Objects.hash(this.int1);
   }
 
   @Override
@@ -58,12 +58,11 @@ public class Int1 implements XdrElement {
     }
 
     Int1 other = (Int1) object;
-    return Objects.equal(this.int1, other.int1);
+    return Objects.equals(this.int1, other.int1);
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,8 +74,7 @@ public class Int1 implements XdrElement {
   }
 
   public static Int1 fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Int2.java
+++ b/spec/output/generator_spec_java/test.x/Int2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;

--- a/spec/output/generator_spec_java/test.x/Int2.java
+++ b/spec/output/generator_spec_java/test.x/Int2.java
@@ -6,10 +6,10 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 // === xdr source ============================================================
 
@@ -48,7 +48,7 @@ public class Int2 implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.int2);
+    return Objects.hash(this.int2);
   }
 
   @Override
@@ -58,12 +58,11 @@ public class Int2 implements XdrElement {
     }
 
     Int2 other = (Int2) object;
-    return Objects.equal(this.int2, other.int2);
+    return Objects.equals(this.int2, other.int2);
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,8 +74,7 @@ public class Int2 implements XdrElement {
   }
 
   public static Int2 fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Int3.java
+++ b/spec/output/generator_spec_java/test.x/Int3.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;

--- a/spec/output/generator_spec_java/test.x/Int3.java
+++ b/spec/output/generator_spec_java/test.x/Int3.java
@@ -6,10 +6,10 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 // === xdr source ============================================================
 
@@ -48,7 +48,7 @@ public class Int3 implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.int3);
+    return Objects.hash(this.int3);
   }
 
   @Override
@@ -58,12 +58,11 @@ public class Int3 implements XdrElement {
     }
 
     Int3 other = (Int3) object;
-    return Objects.equal(this.int3, other.int3);
+    return Objects.equals(this.int3, other.int3);
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,8 +74,7 @@ public class Int3 implements XdrElement {
   }
 
   public static Int3 fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Int4.java
+++ b/spec/output/generator_spec_java/test.x/Int4.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;

--- a/spec/output/generator_spec_java/test.x/Int4.java
+++ b/spec/output/generator_spec_java/test.x/Int4.java
@@ -6,10 +6,10 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 // === xdr source ============================================================
 
@@ -48,7 +48,7 @@ public class Int4 implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.int4);
+    return Objects.hash(this.int4);
   }
 
   @Override
@@ -58,12 +58,11 @@ public class Int4 implements XdrElement {
     }
 
     Int4 other = (Int4) object;
-    return Objects.equal(this.int4, other.int4);
+    return Objects.equals(this.int4, other.int4);
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,8 +74,7 @@ public class Int4 implements XdrElement {
   }
 
   public static Int4 fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/LotsOfMyStructs.java
+++ b/spec/output/generator_spec_java/test.x/LotsOfMyStructs.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;

--- a/spec/output/generator_spec_java/test.x/LotsOfMyStructs.java
+++ b/spec/output/generator_spec_java/test.x/LotsOfMyStructs.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -63,8 +63,7 @@ public class LotsOfMyStructs implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -76,8 +75,7 @@ public class LotsOfMyStructs implements XdrElement {
   }
 
   public static LotsOfMyStructs fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/MyStruct.java
+++ b/spec/output/generator_spec_java/test.x/MyStruct.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;

--- a/spec/output/generator_spec_java/test.x/MyStruct.java
+++ b/spec/output/generator_spec_java/test.x/MyStruct.java
@@ -6,10 +6,10 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 // === xdr source ============================================================
 
@@ -101,7 +101,7 @@ public class MyStruct implements XdrElement {
   }
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.field1, this.field2, this.field3, this.field4, this.field5, this.field6, this.field7);
+    return Objects.hash(this.field1, this.field2, this.field3, this.field4, this.field5, this.field6, this.field7);
   }
   @Override
   public boolean equals(Object object) {
@@ -110,13 +110,12 @@ public class MyStruct implements XdrElement {
     }
 
     MyStruct other = (MyStruct) object;
-    return Objects.equal(this.field1, other.field1) && Objects.equal(this.field2, other.field2) && Objects.equal(this.field3, other.field3) && Objects.equal(this.field4, other.field4) && Objects.equal(this.field5, other.field5) && Objects.equal(this.field6, other.field6) && Objects.equal(this.field7, other.field7);
+    return Objects.equals(this.field1, other.field1) && Objects.equals(this.field2, other.field2) && Objects.equals(this.field3, other.field3) && Objects.equals(this.field4, other.field4) && Objects.equals(this.field5, other.field5) && Objects.equals(this.field6, other.field6) && Objects.equals(this.field7, other.field7);
   }
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -128,8 +127,7 @@ public class MyStruct implements XdrElement {
   }
 
   public static MyStruct fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Nester.java
+++ b/spec/output/generator_spec_java/test.x/Nester.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;

--- a/spec/output/generator_spec_java/test.x/Nester.java
+++ b/spec/output/generator_spec_java/test.x/Nester.java
@@ -6,10 +6,10 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 // === xdr source ============================================================
 
@@ -75,7 +75,7 @@ public class Nester implements XdrElement {
   }
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.nestedEnum, this.nestedStruct, this.nestedUnion);
+    return Objects.hash(this.nestedEnum, this.nestedStruct, this.nestedUnion);
   }
   @Override
   public boolean equals(Object object) {
@@ -84,13 +84,12 @@ public class Nester implements XdrElement {
     }
 
     Nester other = (Nester) object;
-    return Objects.equal(this.nestedEnum, other.nestedEnum) && Objects.equal(this.nestedStruct, other.nestedStruct) && Objects.equal(this.nestedUnion, other.nestedUnion);
+    return Objects.equals(this.nestedEnum, other.nestedEnum) && Objects.equals(this.nestedStruct, other.nestedStruct) && Objects.equals(this.nestedUnion, other.nestedUnion);
   }
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -102,8 +101,7 @@ public class Nester implements XdrElement {
   }
 
   public static Nester fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -174,8 +172,7 @@ public class Nester implements XdrElement {
     }
     @Override
     public String toXdrBase64() throws IOException {
-      BaseEncoding base64Encoding = BaseEncoding.base64();
-      return base64Encoding.encode(toXdrByteArray());
+      return Base64.getEncoder().encodeToString(toXdrByteArray());
     }
 
     @Override
@@ -187,8 +184,7 @@ public class Nester implements XdrElement {
     }
 
     public static NestedEnum fromXdrBase64(String xdr) throws IOException {
-      BaseEncoding base64Encoding = BaseEncoding.base64();
-      byte[] bytes = base64Encoding.decode(xdr);
+      byte[] bytes = Base64.getDecoder().decode(xdr);
       return fromXdrByteArray(bytes);
     }
 
@@ -221,7 +217,7 @@ public class Nester implements XdrElement {
     }
     @Override
     public int hashCode() {
-      return Objects.hashCode(this.blah);
+      return Objects.hash(this.blah);
     }
     @Override
     public boolean equals(Object object) {
@@ -230,13 +226,12 @@ public class Nester implements XdrElement {
       }
 
       NesterNestedStruct other = (NesterNestedStruct) object;
-      return Objects.equal(this.blah, other.blah);
+      return Objects.equals(this.blah, other.blah);
     }
 
     @Override
     public String toXdrBase64() throws IOException {
-      BaseEncoding base64Encoding = BaseEncoding.base64();
-      return base64Encoding.encode(toXdrByteArray());
+      return Base64.getEncoder().encodeToString(toXdrByteArray());
     }
 
     @Override
@@ -248,8 +243,7 @@ public class Nester implements XdrElement {
     }
 
     public static NesterNestedStruct fromXdrBase64(String xdr) throws IOException {
-      BaseEncoding base64Encoding = BaseEncoding.base64();
-      byte[] bytes = base64Encoding.decode(xdr);
+      byte[] bytes = Base64.getDecoder().decode(xdr);
       return fromXdrByteArray(bytes);
     }
 
@@ -343,7 +337,7 @@ public class Nester implements XdrElement {
     }
     @Override
     public int hashCode() {
-      return Objects.hashCode(this.blah2, this.color);
+      return Objects.hash(this.blah2, this.color);
     }
     @Override
     public boolean equals(Object object) {
@@ -352,12 +346,11 @@ public class Nester implements XdrElement {
       }
 
       NesterNestedUnion other = (NesterNestedUnion) object;
-      return Objects.equal(this.blah2, other.blah2) && Objects.equal(this.color, other.color);
+      return Objects.equals(this.blah2, other.blah2) && Objects.equals(this.color, other.color);
     }
     @Override
     public String toXdrBase64() throws IOException {
-      BaseEncoding base64Encoding = BaseEncoding.base64();
-      return base64Encoding.encode(toXdrByteArray());
+      return Base64.getEncoder().encodeToString(toXdrByteArray());
     }
 
     @Override
@@ -369,8 +362,7 @@ public class Nester implements XdrElement {
     }
 
     public static NesterNestedUnion fromXdrBase64(String xdr) throws IOException {
-      BaseEncoding base64Encoding = BaseEncoding.base64();
-      byte[] bytes = base64Encoding.decode(xdr);
+      byte[] bytes = Base64.getDecoder().decode(xdr);
       return fromXdrByteArray(bytes);
     }
 

--- a/spec/output/generator_spec_java/test.x/OptHash1.java
+++ b/spec/output/generator_spec_java/test.x/OptHash1.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;

--- a/spec/output/generator_spec_java/test.x/OptHash1.java
+++ b/spec/output/generator_spec_java/test.x/OptHash1.java
@@ -6,10 +6,10 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 // === xdr source ============================================================
 
@@ -56,7 +56,7 @@ public class OptHash1 implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.optHash1);
+    return Objects.hash(this.optHash1);
   }
 
   @Override
@@ -66,12 +66,11 @@ public class OptHash1 implements XdrElement {
     }
 
     OptHash1 other = (OptHash1) object;
-    return Objects.equal(this.optHash1, other.optHash1);
+    return Objects.equals(this.optHash1, other.optHash1);
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -83,8 +82,7 @@ public class OptHash1 implements XdrElement {
   }
 
   public static OptHash1 fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/OptHash2.java
+++ b/spec/output/generator_spec_java/test.x/OptHash2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;

--- a/spec/output/generator_spec_java/test.x/OptHash2.java
+++ b/spec/output/generator_spec_java/test.x/OptHash2.java
@@ -6,10 +6,10 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 // === xdr source ============================================================
 
@@ -56,7 +56,7 @@ public class OptHash2 implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.optHash2);
+    return Objects.hash(this.optHash2);
   }
 
   @Override
@@ -66,12 +66,11 @@ public class OptHash2 implements XdrElement {
     }
 
     OptHash2 other = (OptHash2) object;
-    return Objects.equal(this.optHash2, other.optHash2);
+    return Objects.equals(this.optHash2, other.optHash2);
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -83,8 +82,7 @@ public class OptHash2 implements XdrElement {
   }
 
   public static OptHash2 fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Str.java
+++ b/spec/output/generator_spec_java/test.x/Str.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;

--- a/spec/output/generator_spec_java/test.x/Str.java
+++ b/spec/output/generator_spec_java/test.x/Str.java
@@ -6,10 +6,10 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 // === xdr source ============================================================
 
@@ -48,7 +48,7 @@ public class Str implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.str);
+    return Objects.hash(this.str);
   }
 
   @Override
@@ -58,12 +58,11 @@ public class Str implements XdrElement {
     }
 
     Str other = (Str) object;
-    return Objects.equal(this.str, other.str);
+    return Objects.equals(this.str, other.str);
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,8 +74,7 @@ public class Str implements XdrElement {
   }
 
   public static Str fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Str2.java
+++ b/spec/output/generator_spec_java/test.x/Str2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;

--- a/spec/output/generator_spec_java/test.x/Str2.java
+++ b/spec/output/generator_spec_java/test.x/Str2.java
@@ -6,10 +6,10 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 // === xdr source ============================================================
 
@@ -48,7 +48,7 @@ public class Str2 implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.str2);
+    return Objects.hash(this.str2);
   }
 
   @Override
@@ -58,12 +58,11 @@ public class Str2 implements XdrElement {
     }
 
     Str2 other = (Str2) object;
-    return Objects.equal(this.str2, other.str2);
+    return Objects.equals(this.str2, other.str2);
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,8 +74,7 @@ public class Str2 implements XdrElement {
   }
 
   public static Str2 fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Uint512.java
+++ b/spec/output/generator_spec_java/test.x/Uint512.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -65,8 +65,7 @@ public class Uint512 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -78,8 +77,7 @@ public class Uint512 implements XdrElement {
   }
 
   public static Uint512 fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Uint512.java
+++ b/spec/output/generator_spec_java/test.x/Uint512.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;

--- a/spec/output/generator_spec_java/test.x/Uint513.java
+++ b/spec/output/generator_spec_java/test.x/Uint513.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -66,8 +66,7 @@ public class Uint513 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -79,8 +78,7 @@ public class Uint513 implements XdrElement {
   }
 
   public static Uint513 fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Uint513.java
+++ b/spec/output/generator_spec_java/test.x/Uint513.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;

--- a/spec/output/generator_spec_java/test.x/Uint514.java
+++ b/spec/output/generator_spec_java/test.x/Uint514.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;

--- a/spec/output/generator_spec_java/test.x/Uint514.java
+++ b/spec/output/generator_spec_java/test.x/Uint514.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -66,8 +66,7 @@ public class Uint514 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -79,8 +78,7 @@ public class Uint514 implements XdrElement {
   }
 
   public static Uint514 fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/XdrString.java
+++ b/spec/output/generator_spec_java/test.x/XdrString.java
@@ -1,12 +1,12 @@
 package MyXDR;
 
-import com.google.common.io.BaseEncoding;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.Base64;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,8 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        BaseEncoding base64Encoding = BaseEncoding.base64();
-        return base64Encoding.encode(toXdrByteArray());
+        return Base64.getEncoder().encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -54,8 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        BaseEncoding base64Encoding = BaseEncoding.base64();
-        byte[] bytes = base64Encoding.decode(xdr);
+        byte[] bytes = Base64.getDecoder().decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/test.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/test.x/XdrUnsignedHyperInteger.java
@@ -1,12 +1,11 @@
 package MyXDR;
 
-import com.google.common.base.Objects;
-import com.google.common.io.BaseEncoding;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.Base64;
+import java.util.Objects;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -62,8 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,8 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -88,7 +85,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.number);
+    return Objects.hash(this.number);
   }
 
   @Override
@@ -98,7 +95,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     }
 
     XdrUnsignedHyperInteger other = (XdrUnsignedHyperInteger) object;
-    return Objects.equal(this.number, other.number);
+    return Objects.equals(this.number, other.number);
   }
 
   public String toString() {

--- a/spec/output/generator_spec_java/test.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/test.x/XdrUnsignedInteger.java
@@ -1,11 +1,10 @@
 package MyXDR;
 
-import com.google.common.base.Objects;
-import com.google.common.io.BaseEncoding;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Base64;
+import java.util.Objects;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -50,8 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -63,8 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -76,7 +73,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.number);
+    return Objects.hash(this.number);
   }
 
   @Override
@@ -86,7 +83,7 @@ public class XdrUnsignedInteger implements XdrElement {
     }
 
     XdrUnsignedInteger other = (XdrUnsignedInteger) object;
-    return Objects.equal(this.number, other.number);
+    return Objects.equals(this.number, other.number);
   }
 
   public String toString() {

--- a/spec/output/generator_spec_java/union.x/Error.java
+++ b/spec/output/generator_spec_java/union.x/Error.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;

--- a/spec/output/generator_spec_java/union.x/Error.java
+++ b/spec/output/generator_spec_java/union.x/Error.java
@@ -6,10 +6,10 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 // === xdr source ============================================================
 
@@ -48,7 +48,7 @@ public class Error implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.Error);
+    return Objects.hash(this.Error);
   }
 
   @Override
@@ -58,12 +58,11 @@ public class Error implements XdrElement {
     }
 
     Error other = (Error) object;
-    return Objects.equal(this.Error, other.Error);
+    return Objects.equals(this.Error, other.Error);
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,8 +74,7 @@ public class Error implements XdrElement {
   }
 
   public static Error fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/IntUnion.java
+++ b/spec/output/generator_spec_java/union.x/IntUnion.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;

--- a/spec/output/generator_spec_java/union.x/IntUnion.java
+++ b/spec/output/generator_spec_java/union.x/IntUnion.java
@@ -6,10 +6,10 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import com.google.common.base.Objects;
+import java.util.Objects;
 import java.util.Arrays;
 
 // === xdr source ============================================================
@@ -117,7 +117,7 @@ public class IntUnion implements XdrElement {
   }
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.error, Arrays.hashCode(this.things), this.type);
+    return Objects.hash(this.error, Arrays.hashCode(this.things), this.type);
   }
   @Override
   public boolean equals(Object object) {
@@ -126,12 +126,11 @@ public class IntUnion implements XdrElement {
     }
 
     IntUnion other = (IntUnion) object;
-    return Objects.equal(this.error, other.error) && Arrays.equals(this.things, other.things) && Objects.equal(this.type, other.type);
+    return Objects.equals(this.error, other.error) && Arrays.equals(this.things, other.things) && Objects.equals(this.type, other.type);
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -143,8 +142,7 @@ public class IntUnion implements XdrElement {
   }
 
   public static IntUnion fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/IntUnion2.java
+++ b/spec/output/generator_spec_java/union.x/IntUnion2.java
@@ -6,10 +6,10 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 // === xdr source ============================================================
 
@@ -48,7 +48,7 @@ public class IntUnion2 implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.IntUnion2);
+    return Objects.hash(this.IntUnion2);
   }
 
   @Override
@@ -58,12 +58,11 @@ public class IntUnion2 implements XdrElement {
     }
 
     IntUnion2 other = (IntUnion2) object;
-    return Objects.equal(this.IntUnion2, other.IntUnion2);
+    return Objects.equals(this.IntUnion2, other.IntUnion2);
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,8 +74,7 @@ public class IntUnion2 implements XdrElement {
   }
 
   public static IntUnion2 fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/IntUnion2.java
+++ b/spec/output/generator_spec_java/union.x/IntUnion2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;

--- a/spec/output/generator_spec_java/union.x/Multi.java
+++ b/spec/output/generator_spec_java/union.x/Multi.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;

--- a/spec/output/generator_spec_java/union.x/Multi.java
+++ b/spec/output/generator_spec_java/union.x/Multi.java
@@ -6,10 +6,10 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 // === xdr source ============================================================
 
@@ -48,7 +48,7 @@ public class Multi implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.Multi);
+    return Objects.hash(this.Multi);
   }
 
   @Override
@@ -58,12 +58,11 @@ public class Multi implements XdrElement {
     }
 
     Multi other = (Multi) object;
-    return Objects.equal(this.Multi, other.Multi);
+    return Objects.equals(this.Multi, other.Multi);
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,8 +74,7 @@ public class Multi implements XdrElement {
   }
 
   public static Multi fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/MyUnion.java
+++ b/spec/output/generator_spec_java/union.x/MyUnion.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;

--- a/spec/output/generator_spec_java/union.x/MyUnion.java
+++ b/spec/output/generator_spec_java/union.x/MyUnion.java
@@ -6,10 +6,10 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import com.google.common.base.Objects;
+import java.util.Objects;
 import java.util.Arrays;
 
 // === xdr source ============================================================
@@ -118,7 +118,7 @@ public class MyUnion implements XdrElement {
   }
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.error, Arrays.hashCode(this.things), this.type);
+    return Objects.hash(this.error, Arrays.hashCode(this.things), this.type);
   }
   @Override
   public boolean equals(Object object) {
@@ -127,12 +127,11 @@ public class MyUnion implements XdrElement {
     }
 
     MyUnion other = (MyUnion) object;
-    return Objects.equal(this.error, other.error) && Arrays.equals(this.things, other.things) && Objects.equal(this.type, other.type);
+    return Objects.equals(this.error, other.error) && Arrays.equals(this.things, other.things) && Objects.equals(this.type, other.type);
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -144,8 +143,7 @@ public class MyUnion implements XdrElement {
   }
 
   public static MyUnion fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/UnionKey.java
+++ b/spec/output/generator_spec_java/union.x/UnionKey.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;;
+import java.util.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 

--- a/spec/output/generator_spec_java/union.x/UnionKey.java
+++ b/spec/output/generator_spec_java/union.x/UnionKey.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -51,8 +51,7 @@ public enum UnionKey implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -64,8 +63,7 @@ public enum UnionKey implements XdrElement {
   }
 
   public static UnionKey fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/XdrString.java
+++ b/spec/output/generator_spec_java/union.x/XdrString.java
@@ -1,12 +1,12 @@
 package MyXDR;
 
-import com.google.common.io.BaseEncoding;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.Base64;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,8 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        BaseEncoding base64Encoding = BaseEncoding.base64();
-        return base64Encoding.encode(toXdrByteArray());
+        return Base64.getEncoder().encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -54,8 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        BaseEncoding base64Encoding = BaseEncoding.base64();
-        byte[] bytes = base64Encoding.decode(xdr);
+        byte[] bytes = Base64.getDecoder().decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/union.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/union.x/XdrUnsignedHyperInteger.java
@@ -1,12 +1,11 @@
 package MyXDR;
 
-import com.google.common.base.Objects;
-import com.google.common.io.BaseEncoding;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.Base64;
+import java.util.Objects;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -62,8 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,8 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -88,7 +85,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.number);
+    return Objects.hash(this.number);
   }
 
   @Override
@@ -98,7 +95,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     }
 
     XdrUnsignedHyperInteger other = (XdrUnsignedHyperInteger) object;
-    return Objects.equal(this.number, other.number);
+    return Objects.equals(this.number, other.number);
   }
 
   public String toString() {

--- a/spec/output/generator_spec_java/union.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/union.x/XdrUnsignedInteger.java
@@ -1,11 +1,10 @@
 package MyXDR;
 
-import com.google.common.base.Objects;
-import com.google.common.io.BaseEncoding;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Base64;
+import java.util.Objects;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -50,8 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    return base64Encoding.encode(toXdrByteArray());
+    return Base64.getEncoder().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -63,8 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    BaseEncoding base64Encoding = BaseEncoding.base64();
-    byte[] bytes = base64Encoding.decode(xdr);
+    byte[] bytes = Base64.getDecoder().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -76,7 +73,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.number);
+    return Objects.hash(this.number);
   }
 
   @Override
@@ -86,7 +83,7 @@ public class XdrUnsignedInteger implements XdrElement {
     }
 
     XdrUnsignedInteger other = (XdrUnsignedInteger) object;
-    return Objects.equal(this.number, other.number);
+    return Objects.equals(this.number, other.number);
   }
 
   public String toString() {


### PR DESCRIPTION
Now, we relied on Guava. I think this is unnecessary. Let's remove it and use alternatives in the standard library.