### PR TITLE
refactor(java): Replace `java.util.Base64` with `org.stellar.sdk.Base64` to ensure compatibility on lower version Android platforms.

### DIFF
--- a/lib/xdrgen/generators/java.rb
+++ b/lib/xdrgen/generators/java.rb
@@ -43,7 +43,7 @@ module Xdrgen
       end
 
       def add_imports_for_definition(defn, imports)
-        imports.add("java.util.Base64")
+        imports.add("org.stellar.sdk.Base64")
         imports.add("java.io.ByteArrayInputStream")
         imports.add("java.io.ByteArrayOutputStream")
 
@@ -716,7 +716,7 @@ module Xdrgen
         out.puts <<-EOS.strip_heredoc
           @Override
           public String toXdrBase64() throws IOException {
-            return Base64.getEncoder().encodeToString(toXdrByteArray());
+            return Base64.encodeToString(toXdrByteArray());
           }
 
           @Override
@@ -728,7 +728,7 @@ module Xdrgen
           }
 
           public static #{return_type} fromXdrBase64(String xdr) throws IOException {
-            byte[] bytes = Base64.getDecoder().decode(xdr);
+            byte[] bytes = Base64.decode(xdr);
             return fromXdrByteArray(bytes);
           }
 

--- a/lib/xdrgen/generators/java.rb
+++ b/lib/xdrgen/generators/java.rb
@@ -43,7 +43,7 @@ module Xdrgen
       end
 
       def add_imports_for_definition(defn, imports)
-        imports.add("org.stellar.sdk.Base64")
+        imports.add("org.stellar.sdk.Base64Factory")
         imports.add("java.io.ByteArrayInputStream")
         imports.add("java.io.ByteArrayOutputStream")
 
@@ -716,7 +716,7 @@ module Xdrgen
         out.puts <<-EOS.strip_heredoc
           @Override
           public String toXdrBase64() throws IOException {
-            return Base64.encodeToString(toXdrByteArray());
+            return Base64Factory.getInstance().encodeToString(toXdrByteArray());
           }
 
           @Override
@@ -728,7 +728,7 @@ module Xdrgen
           }
 
           public static #{return_type} fromXdrBase64(String xdr) throws IOException {
-            byte[] bytes = Base64.decode(xdr);
+            byte[] bytes = Base64Factory.getInstance().decode(xdr);
             return fromXdrByteArray(bytes);
           }
 

--- a/lib/xdrgen/generators/java/XdrString.erb
+++ b/lib/xdrgen/generators/java/XdrString.erb
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,7 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        return Base64.encodeToString(toXdrByteArray());
+        return Base64Factory.getInstance().encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -53,7 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64.decode(xdr);
+        byte[] bytes = Base64Factory.getInstance().decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/lib/xdrgen/generators/java/XdrString.erb
+++ b/lib/xdrgen/generators/java/XdrString.erb
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,7 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        return Base64.getEncoder().encodeToString(toXdrByteArray());
+        return Base64.encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -53,7 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64.getDecoder().decode(xdr);
+        byte[] bytes = Base64.decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/lib/xdrgen/generators/java/XdrUnsignedHyperInteger.erb
+++ b/lib/xdrgen/generators/java/XdrUnsignedHyperInteger.erb
@@ -5,7 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Objects;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -61,7 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -73,7 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/lib/xdrgen/generators/java/XdrUnsignedHyperInteger.erb
+++ b/lib/xdrgen/generators/java/XdrUnsignedHyperInteger.erb
@@ -1,11 +1,11 @@
-package <%= @namespace %>;
+package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Base64;
 import java.util.Objects;
+import org.stellar.sdk.Base64;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -61,7 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -73,7 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/lib/xdrgen/generators/java/XdrUnsignedInteger.erb
+++ b/lib/xdrgen/generators/java/XdrUnsignedInteger.erb
@@ -4,7 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Objects;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -49,7 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -61,7 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/lib/xdrgen/generators/java/XdrUnsignedInteger.erb
+++ b/lib/xdrgen/generators/java/XdrUnsignedInteger.erb
@@ -1,10 +1,10 @@
-package <%= @namespace %>;
+package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Base64;
 import java.util.Objects;
+import org.stellar.sdk.Base64;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -49,7 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -61,7 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/block_comments.x/AccountFlags.java
+++ b/spec/output/generator_spec_java/block_comments.x/AccountFlags.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -49,7 +49,7 @@ public enum AccountFlags implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -61,7 +61,7 @@ public enum AccountFlags implements XdrElement {
   }
 
   public static AccountFlags fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/block_comments.x/AccountFlags.java
+++ b/spec/output/generator_spec_java/block_comments.x/AccountFlags.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -49,7 +49,7 @@ public enum AccountFlags implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -61,7 +61,7 @@ public enum AccountFlags implements XdrElement {
   }
 
   public static AccountFlags fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/block_comments.x/XdrString.java
+++ b/spec/output/generator_spec_java/block_comments.x/XdrString.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,7 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        return Base64.encodeToString(toXdrByteArray());
+        return Base64Factory.getInstance().encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -53,7 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64.decode(xdr);
+        byte[] bytes = Base64Factory.getInstance().decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/block_comments.x/XdrString.java
+++ b/spec/output/generator_spec_java/block_comments.x/XdrString.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,7 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        return Base64.getEncoder().encodeToString(toXdrByteArray());
+        return Base64.encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -53,7 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64.getDecoder().decode(xdr);
+        byte[] bytes = Base64.decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/block_comments.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/block_comments.x/XdrUnsignedHyperInteger.java
@@ -5,7 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Objects;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -61,7 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -73,7 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/block_comments.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/block_comments.x/XdrUnsignedHyperInteger.java
@@ -1,11 +1,11 @@
-package MyXDR;
+package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Base64;
 import java.util.Objects;
+import org.stellar.sdk.Base64;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -61,7 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -73,7 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/block_comments.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/block_comments.x/XdrUnsignedInteger.java
@@ -4,7 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Objects;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -49,7 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -61,7 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/block_comments.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/block_comments.x/XdrUnsignedInteger.java
@@ -1,10 +1,10 @@
-package MyXDR;
+package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Base64;
 import java.util.Objects;
+import org.stellar.sdk.Base64;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -49,7 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -61,7 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/const.x/TestArray.java
+++ b/spec/output/generator_spec_java/const.x/TestArray.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -69,7 +69,7 @@ public class TestArray implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -81,7 +81,7 @@ public class TestArray implements XdrElement {
   }
 
   public static TestArray fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/const.x/TestArray.java
+++ b/spec/output/generator_spec_java/const.x/TestArray.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -69,7 +69,7 @@ public class TestArray implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -81,7 +81,7 @@ public class TestArray implements XdrElement {
   }
 
   public static TestArray fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/const.x/TestArray2.java
+++ b/spec/output/generator_spec_java/const.x/TestArray2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -70,7 +70,7 @@ public class TestArray2 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -82,7 +82,7 @@ public class TestArray2 implements XdrElement {
   }
 
   public static TestArray2 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/const.x/TestArray2.java
+++ b/spec/output/generator_spec_java/const.x/TestArray2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -70,7 +70,7 @@ public class TestArray2 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -82,7 +82,7 @@ public class TestArray2 implements XdrElement {
   }
 
   public static TestArray2 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/const.x/XdrString.java
+++ b/spec/output/generator_spec_java/const.x/XdrString.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,7 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        return Base64.encodeToString(toXdrByteArray());
+        return Base64Factory.getInstance().encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -53,7 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64.decode(xdr);
+        byte[] bytes = Base64Factory.getInstance().decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/const.x/XdrString.java
+++ b/spec/output/generator_spec_java/const.x/XdrString.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,7 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        return Base64.getEncoder().encodeToString(toXdrByteArray());
+        return Base64.encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -53,7 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64.getDecoder().decode(xdr);
+        byte[] bytes = Base64.decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/const.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/const.x/XdrUnsignedHyperInteger.java
@@ -5,7 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Objects;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -61,7 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -73,7 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/const.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/const.x/XdrUnsignedHyperInteger.java
@@ -1,11 +1,11 @@
-package MyXDR;
+package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Base64;
 import java.util.Objects;
+import org.stellar.sdk.Base64;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -61,7 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -73,7 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/const.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/const.x/XdrUnsignedInteger.java
@@ -4,7 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Objects;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -49,7 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -61,7 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/const.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/const.x/XdrUnsignedInteger.java
@@ -1,10 +1,10 @@
-package MyXDR;
+package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Base64;
 import java.util.Objects;
+import org.stellar.sdk.Base64;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -49,7 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -61,7 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/enum.x/Color.java
+++ b/spec/output/generator_spec_java/enum.x/Color.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -54,7 +54,7 @@ public enum Color implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -66,7 +66,7 @@ public enum Color implements XdrElement {
   }
 
   public static Color fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/enum.x/Color.java
+++ b/spec/output/generator_spec_java/enum.x/Color.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -54,7 +54,7 @@ public enum Color implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -66,7 +66,7 @@ public enum Color implements XdrElement {
   }
 
   public static Color fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/enum.x/Color2.java
+++ b/spec/output/generator_spec_java/enum.x/Color2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -54,7 +54,7 @@ public enum Color2 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -66,7 +66,7 @@ public enum Color2 implements XdrElement {
   }
 
   public static Color2 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/enum.x/Color2.java
+++ b/spec/output/generator_spec_java/enum.x/Color2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -54,7 +54,7 @@ public enum Color2 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -66,7 +66,7 @@ public enum Color2 implements XdrElement {
   }
 
   public static Color2 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/enum.x/MessageType.java
+++ b/spec/output/generator_spec_java/enum.x/MessageType.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -94,7 +94,7 @@ public enum MessageType implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -106,7 +106,7 @@ public enum MessageType implements XdrElement {
   }
 
   public static MessageType fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/enum.x/MessageType.java
+++ b/spec/output/generator_spec_java/enum.x/MessageType.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -94,7 +94,7 @@ public enum MessageType implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -106,7 +106,7 @@ public enum MessageType implements XdrElement {
   }
 
   public static MessageType fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/enum.x/XdrString.java
+++ b/spec/output/generator_spec_java/enum.x/XdrString.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,7 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        return Base64.encodeToString(toXdrByteArray());
+        return Base64Factory.getInstance().encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -53,7 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64.decode(xdr);
+        byte[] bytes = Base64Factory.getInstance().decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/enum.x/XdrString.java
+++ b/spec/output/generator_spec_java/enum.x/XdrString.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,7 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        return Base64.getEncoder().encodeToString(toXdrByteArray());
+        return Base64.encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -53,7 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64.getDecoder().decode(xdr);
+        byte[] bytes = Base64.decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/enum.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/enum.x/XdrUnsignedHyperInteger.java
@@ -5,7 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Objects;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -61,7 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -73,7 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/enum.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/enum.x/XdrUnsignedHyperInteger.java
@@ -1,11 +1,11 @@
-package MyXDR;
+package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Base64;
 import java.util.Objects;
+import org.stellar.sdk.Base64;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -61,7 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -73,7 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/enum.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/enum.x/XdrUnsignedInteger.java
@@ -4,7 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Objects;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -49,7 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -61,7 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/enum.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/enum.x/XdrUnsignedInteger.java
@@ -1,10 +1,10 @@
-package MyXDR;
+package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Base64;
 import java.util.Objects;
+import org.stellar.sdk.Base64;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -49,7 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -61,7 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/nesting.x/Foo.java
+++ b/spec/output/generator_spec_java/nesting.x/Foo.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class Foo implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class Foo implements XdrElement {
   }
 
   public static Foo fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/nesting.x/Foo.java
+++ b/spec/output/generator_spec_java/nesting.x/Foo.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class Foo implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class Foo implements XdrElement {
   }
 
   public static Foo fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/nesting.x/MyUnion.java
+++ b/spec/output/generator_spec_java/nesting.x/MyUnion.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -133,7 +133,7 @@ public class MyUnion implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -145,7 +145,7 @@ public class MyUnion implements XdrElement {
   }
 
   public static MyUnion fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -191,7 +191,7 @@ public class MyUnion implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-      return Base64.getEncoder().encodeToString(toXdrByteArray());
+      return Base64.encodeToString(toXdrByteArray());
     }
 
     @Override
@@ -203,7 +203,7 @@ public class MyUnion implements XdrElement {
     }
 
     public static MyUnionOne fromXdrBase64(String xdr) throws IOException {
-      byte[] bytes = Base64.getDecoder().decode(xdr);
+      byte[] bytes = Base64.decode(xdr);
       return fromXdrByteArray(bytes);
     }
 
@@ -273,7 +273,7 @@ public class MyUnion implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-      return Base64.getEncoder().encodeToString(toXdrByteArray());
+      return Base64.encodeToString(toXdrByteArray());
     }
 
     @Override
@@ -285,7 +285,7 @@ public class MyUnion implements XdrElement {
     }
 
     public static MyUnionTwo fromXdrBase64(String xdr) throws IOException {
-      byte[] bytes = Base64.getDecoder().decode(xdr);
+      byte[] bytes = Base64.decode(xdr);
       return fromXdrByteArray(bytes);
     }
 

--- a/spec/output/generator_spec_java/nesting.x/MyUnion.java
+++ b/spec/output/generator_spec_java/nesting.x/MyUnion.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -133,7 +133,7 @@ public class MyUnion implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -145,7 +145,7 @@ public class MyUnion implements XdrElement {
   }
 
   public static MyUnion fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -191,7 +191,7 @@ public class MyUnion implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-      return Base64.encodeToString(toXdrByteArray());
+      return Base64Factory.getInstance().encodeToString(toXdrByteArray());
     }
 
     @Override
@@ -203,7 +203,7 @@ public class MyUnion implements XdrElement {
     }
 
     public static MyUnionOne fromXdrBase64(String xdr) throws IOException {
-      byte[] bytes = Base64.decode(xdr);
+      byte[] bytes = Base64Factory.getInstance().decode(xdr);
       return fromXdrByteArray(bytes);
     }
 
@@ -273,7 +273,7 @@ public class MyUnion implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-      return Base64.encodeToString(toXdrByteArray());
+      return Base64Factory.getInstance().encodeToString(toXdrByteArray());
     }
 
     @Override
@@ -285,7 +285,7 @@ public class MyUnion implements XdrElement {
     }
 
     public static MyUnionTwo fromXdrBase64(String xdr) throws IOException {
-      byte[] bytes = Base64.decode(xdr);
+      byte[] bytes = Base64Factory.getInstance().decode(xdr);
       return fromXdrByteArray(bytes);
     }
 

--- a/spec/output/generator_spec_java/nesting.x/UnionKey.java
+++ b/spec/output/generator_spec_java/nesting.x/UnionKey.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -54,7 +54,7 @@ public enum UnionKey implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -66,7 +66,7 @@ public enum UnionKey implements XdrElement {
   }
 
   public static UnionKey fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/nesting.x/UnionKey.java
+++ b/spec/output/generator_spec_java/nesting.x/UnionKey.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -54,7 +54,7 @@ public enum UnionKey implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -66,7 +66,7 @@ public enum UnionKey implements XdrElement {
   }
 
   public static UnionKey fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/nesting.x/XdrString.java
+++ b/spec/output/generator_spec_java/nesting.x/XdrString.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,7 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        return Base64.encodeToString(toXdrByteArray());
+        return Base64Factory.getInstance().encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -53,7 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64.decode(xdr);
+        byte[] bytes = Base64Factory.getInstance().decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/nesting.x/XdrString.java
+++ b/spec/output/generator_spec_java/nesting.x/XdrString.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,7 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        return Base64.getEncoder().encodeToString(toXdrByteArray());
+        return Base64.encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -53,7 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64.getDecoder().decode(xdr);
+        byte[] bytes = Base64.decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/nesting.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/nesting.x/XdrUnsignedHyperInteger.java
@@ -5,7 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Objects;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -61,7 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -73,7 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/nesting.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/nesting.x/XdrUnsignedHyperInteger.java
@@ -1,11 +1,11 @@
-package MyXDR;
+package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Base64;
 import java.util.Objects;
+import org.stellar.sdk.Base64;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -61,7 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -73,7 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/nesting.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/nesting.x/XdrUnsignedInteger.java
@@ -4,7 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Objects;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -49,7 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -61,7 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/nesting.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/nesting.x/XdrUnsignedInteger.java
@@ -1,10 +1,10 @@
-package MyXDR;
+package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Base64;
 import java.util.Objects;
+import org.stellar.sdk.Base64;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -49,7 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -61,7 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/optional.x/Arr.java
+++ b/spec/output/generator_spec_java/optional.x/Arr.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -69,7 +69,7 @@ public class Arr implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -81,7 +81,7 @@ public class Arr implements XdrElement {
   }
 
   public static Arr fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/optional.x/Arr.java
+++ b/spec/output/generator_spec_java/optional.x/Arr.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -69,7 +69,7 @@ public class Arr implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -81,7 +81,7 @@ public class Arr implements XdrElement {
   }
 
   public static Arr fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/optional.x/HasOptions.java
+++ b/spec/output/generator_spec_java/optional.x/HasOptions.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -99,7 +99,7 @@ public class HasOptions implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -111,7 +111,7 @@ public class HasOptions implements XdrElement {
   }
 
   public static HasOptions fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/optional.x/HasOptions.java
+++ b/spec/output/generator_spec_java/optional.x/HasOptions.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -99,7 +99,7 @@ public class HasOptions implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -111,7 +111,7 @@ public class HasOptions implements XdrElement {
   }
 
   public static HasOptions fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/optional.x/XdrString.java
+++ b/spec/output/generator_spec_java/optional.x/XdrString.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,7 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        return Base64.encodeToString(toXdrByteArray());
+        return Base64Factory.getInstance().encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -53,7 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64.decode(xdr);
+        byte[] bytes = Base64Factory.getInstance().decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/optional.x/XdrString.java
+++ b/spec/output/generator_spec_java/optional.x/XdrString.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,7 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        return Base64.getEncoder().encodeToString(toXdrByteArray());
+        return Base64.encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -53,7 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64.getDecoder().decode(xdr);
+        byte[] bytes = Base64.decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/optional.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/optional.x/XdrUnsignedHyperInteger.java
@@ -5,7 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Objects;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -61,7 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -73,7 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/optional.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/optional.x/XdrUnsignedHyperInteger.java
@@ -1,11 +1,11 @@
-package MyXDR;
+package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Base64;
 import java.util.Objects;
+import org.stellar.sdk.Base64;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -61,7 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -73,7 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/optional.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/optional.x/XdrUnsignedInteger.java
@@ -4,7 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Objects;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -49,7 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -61,7 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/optional.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/optional.x/XdrUnsignedInteger.java
@@ -1,10 +1,10 @@
-package MyXDR;
+package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Base64;
 import java.util.Objects;
+import org.stellar.sdk.Base64;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -49,7 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -61,7 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/struct.x/Int64.java
+++ b/spec/output/generator_spec_java/struct.x/Int64.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class Int64 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class Int64 implements XdrElement {
   }
 
   public static Int64 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/struct.x/Int64.java
+++ b/spec/output/generator_spec_java/struct.x/Int64.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class Int64 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class Int64 implements XdrElement {
   }
 
   public static Int64 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/struct.x/MyStruct.java
+++ b/spec/output/generator_spec_java/struct.x/MyStruct.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -99,7 +99,7 @@ public class MyStruct implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -111,7 +111,7 @@ public class MyStruct implements XdrElement {
   }
 
   public static MyStruct fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/struct.x/MyStruct.java
+++ b/spec/output/generator_spec_java/struct.x/MyStruct.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -99,7 +99,7 @@ public class MyStruct implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -111,7 +111,7 @@ public class MyStruct implements XdrElement {
   }
 
   public static MyStruct fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/struct.x/XdrString.java
+++ b/spec/output/generator_spec_java/struct.x/XdrString.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,7 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        return Base64.encodeToString(toXdrByteArray());
+        return Base64Factory.getInstance().encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -53,7 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64.decode(xdr);
+        byte[] bytes = Base64Factory.getInstance().decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/struct.x/XdrString.java
+++ b/spec/output/generator_spec_java/struct.x/XdrString.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,7 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        return Base64.getEncoder().encodeToString(toXdrByteArray());
+        return Base64.encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -53,7 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64.getDecoder().decode(xdr);
+        byte[] bytes = Base64.decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/struct.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/struct.x/XdrUnsignedHyperInteger.java
@@ -5,7 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Objects;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -61,7 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -73,7 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/struct.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/struct.x/XdrUnsignedHyperInteger.java
@@ -1,11 +1,11 @@
-package MyXDR;
+package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Base64;
 import java.util.Objects;
+import org.stellar.sdk.Base64;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -61,7 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -73,7 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/struct.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/struct.x/XdrUnsignedInteger.java
@@ -4,7 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Objects;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -49,7 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -61,7 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/struct.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/struct.x/XdrUnsignedInteger.java
@@ -1,10 +1,10 @@
-package MyXDR;
+package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Base64;
 import java.util.Objects;
+import org.stellar.sdk.Base64;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -49,7 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -61,7 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Color.java
+++ b/spec/output/generator_spec_java/test.x/Color.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -54,7 +54,7 @@ public enum Color implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -66,7 +66,7 @@ public enum Color implements XdrElement {
   }
 
   public static Color fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Color.java
+++ b/spec/output/generator_spec_java/test.x/Color.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -54,7 +54,7 @@ public enum Color implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -66,7 +66,7 @@ public enum Color implements XdrElement {
   }
 
   public static Color fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/HasStuff.java
+++ b/spec/output/generator_spec_java/test.x/HasStuff.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -55,7 +55,7 @@ public class HasStuff implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -67,7 +67,7 @@ public class HasStuff implements XdrElement {
   }
 
   public static HasStuff fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/HasStuff.java
+++ b/spec/output/generator_spec_java/test.x/HasStuff.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -55,7 +55,7 @@ public class HasStuff implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -67,7 +67,7 @@ public class HasStuff implements XdrElement {
   }
 
   public static HasStuff fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Hash.java
+++ b/spec/output/generator_spec_java/test.x/Hash.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -65,7 +65,7 @@ public class Hash implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -77,7 +77,7 @@ public class Hash implements XdrElement {
   }
 
   public static Hash fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Hash.java
+++ b/spec/output/generator_spec_java/test.x/Hash.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -65,7 +65,7 @@ public class Hash implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -77,7 +77,7 @@ public class Hash implements XdrElement {
   }
 
   public static Hash fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Hashes1.java
+++ b/spec/output/generator_spec_java/test.x/Hashes1.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -69,7 +69,7 @@ public class Hashes1 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -81,7 +81,7 @@ public class Hashes1 implements XdrElement {
   }
 
   public static Hashes1 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Hashes1.java
+++ b/spec/output/generator_spec_java/test.x/Hashes1.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -69,7 +69,7 @@ public class Hashes1 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -81,7 +81,7 @@ public class Hashes1 implements XdrElement {
   }
 
   public static Hashes1 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Hashes2.java
+++ b/spec/output/generator_spec_java/test.x/Hashes2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -70,7 +70,7 @@ public class Hashes2 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -82,7 +82,7 @@ public class Hashes2 implements XdrElement {
   }
 
   public static Hashes2 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Hashes2.java
+++ b/spec/output/generator_spec_java/test.x/Hashes2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -70,7 +70,7 @@ public class Hashes2 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -82,7 +82,7 @@ public class Hashes2 implements XdrElement {
   }
 
   public static Hashes2 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Hashes3.java
+++ b/spec/output/generator_spec_java/test.x/Hashes3.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -70,7 +70,7 @@ public class Hashes3 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -82,7 +82,7 @@ public class Hashes3 implements XdrElement {
   }
 
   public static Hashes3 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Hashes3.java
+++ b/spec/output/generator_spec_java/test.x/Hashes3.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -70,7 +70,7 @@ public class Hashes3 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -82,7 +82,7 @@ public class Hashes3 implements XdrElement {
   }
 
   public static Hashes3 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Int1.java
+++ b/spec/output/generator_spec_java/test.x/Int1.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class Int1 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class Int1 implements XdrElement {
   }
 
   public static Int1 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Int1.java
+++ b/spec/output/generator_spec_java/test.x/Int1.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class Int1 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class Int1 implements XdrElement {
   }
 
   public static Int1 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Int2.java
+++ b/spec/output/generator_spec_java/test.x/Int2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class Int2 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class Int2 implements XdrElement {
   }
 
   public static Int2 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Int2.java
+++ b/spec/output/generator_spec_java/test.x/Int2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class Int2 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class Int2 implements XdrElement {
   }
 
   public static Int2 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Int3.java
+++ b/spec/output/generator_spec_java/test.x/Int3.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class Int3 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class Int3 implements XdrElement {
   }
 
   public static Int3 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Int3.java
+++ b/spec/output/generator_spec_java/test.x/Int3.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class Int3 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class Int3 implements XdrElement {
   }
 
   public static Int3 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Int4.java
+++ b/spec/output/generator_spec_java/test.x/Int4.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class Int4 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class Int4 implements XdrElement {
   }
 
   public static Int4 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Int4.java
+++ b/spec/output/generator_spec_java/test.x/Int4.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class Int4 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class Int4 implements XdrElement {
   }
 
   public static Int4 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/LotsOfMyStructs.java
+++ b/spec/output/generator_spec_java/test.x/LotsOfMyStructs.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -63,7 +63,7 @@ public class LotsOfMyStructs implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,7 +75,7 @@ public class LotsOfMyStructs implements XdrElement {
   }
 
   public static LotsOfMyStructs fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/LotsOfMyStructs.java
+++ b/spec/output/generator_spec_java/test.x/LotsOfMyStructs.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -63,7 +63,7 @@ public class LotsOfMyStructs implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -75,7 +75,7 @@ public class LotsOfMyStructs implements XdrElement {
   }
 
   public static LotsOfMyStructs fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/MyStruct.java
+++ b/spec/output/generator_spec_java/test.x/MyStruct.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -115,7 +115,7 @@ public class MyStruct implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -127,7 +127,7 @@ public class MyStruct implements XdrElement {
   }
 
   public static MyStruct fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/MyStruct.java
+++ b/spec/output/generator_spec_java/test.x/MyStruct.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -115,7 +115,7 @@ public class MyStruct implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -127,7 +127,7 @@ public class MyStruct implements XdrElement {
   }
 
   public static MyStruct fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Nester.java
+++ b/spec/output/generator_spec_java/test.x/Nester.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -89,7 +89,7 @@ public class Nester implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -101,7 +101,7 @@ public class Nester implements XdrElement {
   }
 
   public static Nester fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -172,7 +172,7 @@ public class Nester implements XdrElement {
     }
     @Override
     public String toXdrBase64() throws IOException {
-      return Base64.encodeToString(toXdrByteArray());
+      return Base64Factory.getInstance().encodeToString(toXdrByteArray());
     }
 
     @Override
@@ -184,7 +184,7 @@ public class Nester implements XdrElement {
     }
 
     public static NestedEnum fromXdrBase64(String xdr) throws IOException {
-      byte[] bytes = Base64.decode(xdr);
+      byte[] bytes = Base64Factory.getInstance().decode(xdr);
       return fromXdrByteArray(bytes);
     }
 
@@ -231,7 +231,7 @@ public class Nester implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-      return Base64.encodeToString(toXdrByteArray());
+      return Base64Factory.getInstance().encodeToString(toXdrByteArray());
     }
 
     @Override
@@ -243,7 +243,7 @@ public class Nester implements XdrElement {
     }
 
     public static NesterNestedStruct fromXdrBase64(String xdr) throws IOException {
-      byte[] bytes = Base64.decode(xdr);
+      byte[] bytes = Base64Factory.getInstance().decode(xdr);
       return fromXdrByteArray(bytes);
     }
 
@@ -350,7 +350,7 @@ public class Nester implements XdrElement {
     }
     @Override
     public String toXdrBase64() throws IOException {
-      return Base64.encodeToString(toXdrByteArray());
+      return Base64Factory.getInstance().encodeToString(toXdrByteArray());
     }
 
     @Override
@@ -362,7 +362,7 @@ public class Nester implements XdrElement {
     }
 
     public static NesterNestedUnion fromXdrBase64(String xdr) throws IOException {
-      byte[] bytes = Base64.decode(xdr);
+      byte[] bytes = Base64Factory.getInstance().decode(xdr);
       return fromXdrByteArray(bytes);
     }
 

--- a/spec/output/generator_spec_java/test.x/Nester.java
+++ b/spec/output/generator_spec_java/test.x/Nester.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -89,7 +89,7 @@ public class Nester implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -101,7 +101,7 @@ public class Nester implements XdrElement {
   }
 
   public static Nester fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 
@@ -172,7 +172,7 @@ public class Nester implements XdrElement {
     }
     @Override
     public String toXdrBase64() throws IOException {
-      return Base64.getEncoder().encodeToString(toXdrByteArray());
+      return Base64.encodeToString(toXdrByteArray());
     }
 
     @Override
@@ -184,7 +184,7 @@ public class Nester implements XdrElement {
     }
 
     public static NestedEnum fromXdrBase64(String xdr) throws IOException {
-      byte[] bytes = Base64.getDecoder().decode(xdr);
+      byte[] bytes = Base64.decode(xdr);
       return fromXdrByteArray(bytes);
     }
 
@@ -231,7 +231,7 @@ public class Nester implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-      return Base64.getEncoder().encodeToString(toXdrByteArray());
+      return Base64.encodeToString(toXdrByteArray());
     }
 
     @Override
@@ -243,7 +243,7 @@ public class Nester implements XdrElement {
     }
 
     public static NesterNestedStruct fromXdrBase64(String xdr) throws IOException {
-      byte[] bytes = Base64.getDecoder().decode(xdr);
+      byte[] bytes = Base64.decode(xdr);
       return fromXdrByteArray(bytes);
     }
 
@@ -350,7 +350,7 @@ public class Nester implements XdrElement {
     }
     @Override
     public String toXdrBase64() throws IOException {
-      return Base64.getEncoder().encodeToString(toXdrByteArray());
+      return Base64.encodeToString(toXdrByteArray());
     }
 
     @Override
@@ -362,7 +362,7 @@ public class Nester implements XdrElement {
     }
 
     public static NesterNestedUnion fromXdrBase64(String xdr) throws IOException {
-      byte[] bytes = Base64.getDecoder().decode(xdr);
+      byte[] bytes = Base64.decode(xdr);
       return fromXdrByteArray(bytes);
     }
 

--- a/spec/output/generator_spec_java/test.x/OptHash1.java
+++ b/spec/output/generator_spec_java/test.x/OptHash1.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -70,7 +70,7 @@ public class OptHash1 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -82,7 +82,7 @@ public class OptHash1 implements XdrElement {
   }
 
   public static OptHash1 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/OptHash1.java
+++ b/spec/output/generator_spec_java/test.x/OptHash1.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -70,7 +70,7 @@ public class OptHash1 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -82,7 +82,7 @@ public class OptHash1 implements XdrElement {
   }
 
   public static OptHash1 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/OptHash2.java
+++ b/spec/output/generator_spec_java/test.x/OptHash2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -70,7 +70,7 @@ public class OptHash2 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -82,7 +82,7 @@ public class OptHash2 implements XdrElement {
   }
 
   public static OptHash2 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/OptHash2.java
+++ b/spec/output/generator_spec_java/test.x/OptHash2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -70,7 +70,7 @@ public class OptHash2 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -82,7 +82,7 @@ public class OptHash2 implements XdrElement {
   }
 
   public static OptHash2 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Str.java
+++ b/spec/output/generator_spec_java/test.x/Str.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class Str implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class Str implements XdrElement {
   }
 
   public static Str fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Str.java
+++ b/spec/output/generator_spec_java/test.x/Str.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class Str implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class Str implements XdrElement {
   }
 
   public static Str fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Str2.java
+++ b/spec/output/generator_spec_java/test.x/Str2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class Str2 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class Str2 implements XdrElement {
   }
 
   public static Str2 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Str2.java
+++ b/spec/output/generator_spec_java/test.x/Str2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class Str2 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class Str2 implements XdrElement {
   }
 
   public static Str2 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Uint512.java
+++ b/spec/output/generator_spec_java/test.x/Uint512.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -65,7 +65,7 @@ public class Uint512 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -77,7 +77,7 @@ public class Uint512 implements XdrElement {
   }
 
   public static Uint512 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Uint512.java
+++ b/spec/output/generator_spec_java/test.x/Uint512.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -65,7 +65,7 @@ public class Uint512 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -77,7 +77,7 @@ public class Uint512 implements XdrElement {
   }
 
   public static Uint512 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Uint513.java
+++ b/spec/output/generator_spec_java/test.x/Uint513.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -66,7 +66,7 @@ public class Uint513 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -78,7 +78,7 @@ public class Uint513 implements XdrElement {
   }
 
   public static Uint513 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Uint513.java
+++ b/spec/output/generator_spec_java/test.x/Uint513.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -66,7 +66,7 @@ public class Uint513 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -78,7 +78,7 @@ public class Uint513 implements XdrElement {
   }
 
   public static Uint513 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Uint514.java
+++ b/spec/output/generator_spec_java/test.x/Uint514.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -66,7 +66,7 @@ public class Uint514 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -78,7 +78,7 @@ public class Uint514 implements XdrElement {
   }
 
   public static Uint514 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/Uint514.java
+++ b/spec/output/generator_spec_java/test.x/Uint514.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -66,7 +66,7 @@ public class Uint514 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -78,7 +78,7 @@ public class Uint514 implements XdrElement {
   }
 
   public static Uint514 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/XdrString.java
+++ b/spec/output/generator_spec_java/test.x/XdrString.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,7 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        return Base64.encodeToString(toXdrByteArray());
+        return Base64Factory.getInstance().encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -53,7 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64.decode(xdr);
+        byte[] bytes = Base64Factory.getInstance().decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/test.x/XdrString.java
+++ b/spec/output/generator_spec_java/test.x/XdrString.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,7 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        return Base64.getEncoder().encodeToString(toXdrByteArray());
+        return Base64.encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -53,7 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64.getDecoder().decode(xdr);
+        byte[] bytes = Base64.decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/test.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/test.x/XdrUnsignedHyperInteger.java
@@ -5,7 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Objects;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -61,7 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -73,7 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/test.x/XdrUnsignedHyperInteger.java
@@ -1,11 +1,11 @@
-package MyXDR;
+package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Base64;
 import java.util.Objects;
+import org.stellar.sdk.Base64;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -61,7 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -73,7 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/test.x/XdrUnsignedInteger.java
@@ -4,7 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Objects;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -49,7 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -61,7 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/test.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/test.x/XdrUnsignedInteger.java
@@ -1,10 +1,10 @@
-package MyXDR;
+package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Base64;
 import java.util.Objects;
+import org.stellar.sdk.Base64;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -49,7 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -61,7 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/Error.java
+++ b/spec/output/generator_spec_java/union.x/Error.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class Error implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class Error implements XdrElement {
   }
 
   public static Error fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/Error.java
+++ b/spec/output/generator_spec_java/union.x/Error.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class Error implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class Error implements XdrElement {
   }
 
   public static Error fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/IntUnion.java
+++ b/spec/output/generator_spec_java/union.x/IntUnion.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -130,7 +130,7 @@ public class IntUnion implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -142,7 +142,7 @@ public class IntUnion implements XdrElement {
   }
 
   public static IntUnion fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/IntUnion.java
+++ b/spec/output/generator_spec_java/union.x/IntUnion.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -130,7 +130,7 @@ public class IntUnion implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -142,7 +142,7 @@ public class IntUnion implements XdrElement {
   }
 
   public static IntUnion fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/IntUnion2.java
+++ b/spec/output/generator_spec_java/union.x/IntUnion2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class IntUnion2 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class IntUnion2 implements XdrElement {
   }
 
   public static IntUnion2 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/IntUnion2.java
+++ b/spec/output/generator_spec_java/union.x/IntUnion2.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class IntUnion2 implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class IntUnion2 implements XdrElement {
   }
 
   public static IntUnion2 fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/Multi.java
+++ b/spec/output/generator_spec_java/union.x/Multi.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class Multi implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class Multi implements XdrElement {
   }
 
   public static Multi fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/Multi.java
+++ b/spec/output/generator_spec_java/union.x/Multi.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class Multi implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -74,7 +74,7 @@ public class Multi implements XdrElement {
   }
 
   public static Multi fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/MyUnion.java
+++ b/spec/output/generator_spec_java/union.x/MyUnion.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -131,7 +131,7 @@ public class MyUnion implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -143,7 +143,7 @@ public class MyUnion implements XdrElement {
   }
 
   public static MyUnion fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/MyUnion.java
+++ b/spec/output/generator_spec_java/union.x/MyUnion.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
@@ -131,7 +131,7 @@ public class MyUnion implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -143,7 +143,7 @@ public class MyUnion implements XdrElement {
   }
 
   public static MyUnion fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/UnionKey.java
+++ b/spec/output/generator_spec_java/union.x/UnionKey.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -51,7 +51,7 @@ public enum UnionKey implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -63,7 +63,7 @@ public enum UnionKey implements XdrElement {
   }
 
   public static UnionKey fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/UnionKey.java
+++ b/spec/output/generator_spec_java/union.x/UnionKey.java
@@ -6,7 +6,7 @@ package MyXDR;
 import java.io.IOException;
 
 import static MyXDR.Constants.*;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -51,7 +51,7 @@ public enum UnionKey implements XdrElement {
   }
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -63,7 +63,7 @@ public enum UnionKey implements XdrElement {
   }
 
   public static UnionKey fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/XdrString.java
+++ b/spec/output/generator_spec_java/union.x/XdrString.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,7 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        return Base64.encodeToString(toXdrByteArray());
+        return Base64Factory.getInstance().encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -53,7 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64.decode(xdr);
+        byte[] bytes = Base64Factory.getInstance().decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/union.x/XdrString.java
+++ b/spec/output/generator_spec_java/union.x/XdrString.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.io.InvalidClassException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.Base64;
+import org.stellar.sdk.Base64;
 
 public class XdrString implements XdrElement {
     private byte[] bytes;
@@ -41,7 +41,7 @@ public class XdrString implements XdrElement {
 
     @Override
     public String toXdrBase64() throws IOException {
-        return Base64.getEncoder().encodeToString(toXdrByteArray());
+        return Base64.encodeToString(toXdrByteArray());
     }
     
     @Override
@@ -53,7 +53,7 @@ public class XdrString implements XdrElement {
     }
     
     public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64.getDecoder().decode(xdr);
+        byte[] bytes = Base64.decode(xdr);
         return fromXdrByteArray(bytes, maxSize);
     }
     

--- a/spec/output/generator_spec_java/union.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/union.x/XdrUnsignedHyperInteger.java
@@ -5,7 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Objects;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -61,7 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -73,7 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/union.x/XdrUnsignedHyperInteger.java
@@ -1,11 +1,11 @@
-package MyXDR;
+package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Base64;
 import java.util.Objects;
+import org.stellar.sdk.Base64;
 
 /**
  * Represents XDR Unsigned Hyper Integer.
@@ -61,7 +61,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -73,7 +73,7 @@ public class XdrUnsignedHyperInteger implements XdrElement {
   }
 
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/union.x/XdrUnsignedInteger.java
@@ -4,7 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Objects;
-import org.stellar.sdk.Base64;
+import org.stellar.sdk.Base64Factory;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -49,7 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.encodeToString(toXdrByteArray());
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -61,7 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.decode(xdr);
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
   }
 

--- a/spec/output/generator_spec_java/union.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/union.x/XdrUnsignedInteger.java
@@ -1,10 +1,10 @@
-package MyXDR;
+package org.stellar.sdk.xdr;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Base64;
 import java.util.Objects;
+import org.stellar.sdk.Base64;
 
 /**
  * Represents XDR Unsigned Integer.
@@ -49,7 +49,7 @@ public class XdrUnsignedInteger implements XdrElement {
 
   @Override
   public String toXdrBase64() throws IOException {
-    return Base64.getEncoder().encodeToString(toXdrByteArray());
+    return Base64.encodeToString(toXdrByteArray());
   }
 
   @Override
@@ -61,7 +61,7 @@ public class XdrUnsignedInteger implements XdrElement {
   }
 
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
-    byte[] bytes = Base64.getDecoder().decode(xdr);
+    byte[] bytes = Base64.decode(xdr);
     return fromXdrByteArray(bytes);
   }
 


### PR DESCRIPTION
Check https://github.com/stellar/java-stellar-sdk/pull/543 and https://github.com/stellar/java-stellar-sdk/issues/542 for more information.