### PR TITLE
Allocate memory for vararray as needed in Rust

### DIFF
--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1258,7 +1258,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = Vec::with_capacity(len as usize);
+            let mut vec = Vec::new(len as usize);
             for _ in 0..len {
                 let t = T::read_xdr(r)?;
                 vec.push(t);

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1258,7 +1258,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = Vec::new(len as usize);
+            let mut vec = Vec::new();
             for _ in 0..len {
                 let t = T::read_xdr(r)?;
                 vec.push(t);

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -1268,7 +1268,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = Vec::new(len as usize);
+            let mut vec = Vec::new();
             for _ in 0..len {
                 let t = T::read_xdr(r)?;
                 vec.push(t);

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -1268,7 +1268,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = Vec::with_capacity(len as usize);
+            let mut vec = Vec::new(len as usize);
             for _ in 0..len {
                 let t = T::read_xdr(r)?;
                 vec.push(t);

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -1268,7 +1268,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = Vec::new(len as usize);
+            let mut vec = Vec::new();
             for _ in 0..len {
                 let t = T::read_xdr(r)?;
                 vec.push(t);

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -1268,7 +1268,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = Vec::with_capacity(len as usize);
+            let mut vec = Vec::new(len as usize);
             for _ in 0..len {
                 let t = T::read_xdr(r)?;
                 vec.push(t);

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -1268,7 +1268,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = Vec::new(len as usize);
+            let mut vec = Vec::new();
             for _ in 0..len {
                 let t = T::read_xdr(r)?;
                 vec.push(t);

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -1268,7 +1268,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = Vec::with_capacity(len as usize);
+            let mut vec = Vec::new(len as usize);
             for _ in 0..len {
                 let t = T::read_xdr(r)?;
                 vec.push(t);

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -1268,7 +1268,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = Vec::new(len as usize);
+            let mut vec = Vec::new();
             for _ in 0..len {
                 let t = T::read_xdr(r)?;
                 vec.push(t);

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -1268,7 +1268,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = Vec::with_capacity(len as usize);
+            let mut vec = Vec::new(len as usize);
             for _ in 0..len {
                 let t = T::read_xdr(r)?;
                 vec.push(t);

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -1268,7 +1268,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = Vec::new(len as usize);
+            let mut vec = Vec::new();
             for _ in 0..len {
                 let t = T::read_xdr(r)?;
                 vec.push(t);

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -1268,7 +1268,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = Vec::with_capacity(len as usize);
+            let mut vec = Vec::new(len as usize);
             for _ in 0..len {
                 let t = T::read_xdr(r)?;
                 vec.push(t);

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -1268,7 +1268,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = Vec::new(len as usize);
+            let mut vec = Vec::new();
             for _ in 0..len {
                 let t = T::read_xdr(r)?;
                 vec.push(t);

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -1268,7 +1268,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = Vec::with_capacity(len as usize);
+            let mut vec = Vec::new(len as usize);
             for _ in 0..len {
                 let t = T::read_xdr(r)?;
                 vec.push(t);

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -1268,7 +1268,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = Vec::new(len as usize);
+            let mut vec = Vec::new();
             for _ in 0..len {
                 let t = T::read_xdr(r)?;
                 vec.push(t);

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -1268,7 +1268,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = Vec::with_capacity(len as usize);
+            let mut vec = Vec::new(len as usize);
             for _ in 0..len {
                 let t = T::read_xdr(r)?;
                 vec.push(t);

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -1268,7 +1268,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = Vec::new(len as usize);
+            let mut vec = Vec::new();
             for _ in 0..len {
                 let t = T::read_xdr(r)?;
                 vec.push(t);

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -1268,7 +1268,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = Vec::with_capacity(len as usize);
+            let mut vec = Vec::new(len as usize);
             for _ in 0..len {
                 let t = T::read_xdr(r)?;
                 vec.push(t);


### PR DESCRIPTION
### What
Allocate memory for vararray as needed in Rust generated code.

### Why
