### PR TITLE
Rust: Limit preallocation during byte (opaque, string) reads to 1kb

### DIFF
--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -658,11 +658,11 @@ fn pad_len(len: usize) -> usize {
 /// required for each batch as it goes while reading so that no large
 /// preallocation occurs without the message data being available.
 #[cfg(feature = "std")]
-fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Result<Vec<u8>> {
+fn read_exact_in_batches<R: Read>(r: &mut R, len: usize, batch_size: usize) -> Result<Vec<u8>> {
     let mut vec = vec![0u8; 0];
-    let mut len_remaining = len as usize;
 
     // Read one batch at a time.
+    let mut len_remaining = len;
     while len_remaining > 0 {
         let len_read = core::cmp::min(len_remaining, batch_size);
         let offset = vec.len();
@@ -679,6 +679,7 @@ fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Result
         r.read_exact(&mut vec[offset..])?;
         len_remaining -= len_read;
     }
+
     Ok(vec)
 }
 
@@ -1251,7 +1252,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
+            let vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1648,7 +1649,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
+            let vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2030,7 +2031,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
+            let vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -3,6 +3,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
+#[cfg(feature = "std")]
 const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1224,11 +1224,11 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -1629,11 +1629,11 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -2019,11 +2019,11 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -3,6 +3,8 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
+const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
+
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
 mod noalloc {
@@ -1219,8 +1221,15 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; len as usize];
-            r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; 0];
+            let mut len_remaining = len as usize;
+            while len_remaining > 0 {
+                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let offset = vec.len();
+                vec.resize(vec.len() + len_to_read, 0);
+                r.read_exact(&mut vec[offset..])?;
+                len_remaining -= read_len;
+            }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1617,8 +1626,15 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; len as usize];
-            r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; 0];
+            let mut len_remaining = len as usize;
+            while len_remaining > 0 {
+                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let offset = vec.len();
+                vec.resize(vec.len() + len_to_read, 0);
+                r.read_exact(&mut vec[offset..])?;
+                len_remaining -= read_len;
+            }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2000,8 +2016,15 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; len as usize];
-            r.read_exact(&mut vec)?;
+            let mut vec = vec![0u8; 0];
+            let mut len_remaining = len as usize;
+            while len_remaining > 0 {
+                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let offset = vec.len();
+                vec.resize(vec.len() + len_to_read, 0);
+                r.read_exact(&mut vec[offset..])?;
+                len_remaining -= read_len;
+            }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -658,7 +658,7 @@ fn pad_len(len: usize) -> usize {
 /// required for each batch as it goes while reading so that no large
 /// preallocation occurs without the message data being available.
 #[cfg(feature = "std")]
-fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Result<Vec<u8>> {
     let mut vec = vec![0u8; 0];
     let mut len_remaining = len as usize;
 
@@ -679,7 +679,7 @@ fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8
         r.read_exact(&mut vec[offset..])?;
         len_remaining -= len_read;
     }
-    vec
+    Ok(vec)
 }
 
 impl ReadXdr for i32 {
@@ -1251,7 +1251,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1648,7 +1648,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2030,7 +2030,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -663,6 +663,35 @@ fn pad_len(len: usize) -> usize {
     (4 - (len % 4)) % 4
 }
 
+/// Read exactly the specified length of bytes from the read into a new Vec that
+/// is returned in batches. The function will preallocate only the memory
+/// required for each batch as it goes while reading so that no large
+/// preallocation occurs without the message data being available.
+#[cfg(feature = "std")]
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+    let mut vec = vec![0u8; 0];
+    let mut len_remaining = len as usize;
+
+    // Read one batch at a time.
+    while len_remaining > 0 {
+        let len_read = core::cmp::min(len_remaining, batch_size);
+        let offset = vec.len();
+        let len_new = vec.len() + len_read;
+
+        // Reserve exactly the new space required. Reserving exact prevents vec
+        // from increasing the allocated memory 2x which could result with large
+        // unnecessary allocations.
+        vec.reserve_exact(len_new);
+
+        // Resize the vec so that the read can read into the next batch of space.
+        vec.resize(len_new, 0);
+
+        r.read_exact(&mut vec[offset..])?;
+        len_remaining -= len_read;
+    }
+    vec
+}
+
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
@@ -1232,15 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1637,15 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2027,15 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -13,7 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
-const MAX_PREALLOCATED_BYTES_READ: usize = 1048576; // 1MB
+const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -1234,11 +1234,11 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -1639,11 +1639,11 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -2029,11 +2029,11 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -668,7 +668,7 @@ fn pad_len(len: usize) -> usize {
 /// required for each batch as it goes while reading so that no large
 /// preallocation occurs without the message data being available.
 #[cfg(feature = "std")]
-fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Result<Vec<u8>> {
     let mut vec = vec![0u8; 0];
     let mut len_remaining = len as usize;
 
@@ -689,7 +689,7 @@ fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8
         r.read_exact(&mut vec[offset..])?;
         len_remaining -= len_read;
     }
-    vec
+    Ok(vec)
 }
 
 impl ReadXdr for i32 {
@@ -1261,7 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1658,7 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2040,7 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -13,6 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
+#[cfg(feature = "std")]
 const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -663,6 +663,35 @@ fn pad_len(len: usize) -> usize {
     (4 - (len % 4)) % 4
 }
 
+/// Read exactly the specified length of bytes from the read into a new Vec that
+/// is returned in batches. The function will preallocate only the memory
+/// required for each batch as it goes while reading so that no large
+/// preallocation occurs without the message data being available.
+#[cfg(feature = "std")]
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+    let mut vec = vec![0u8; 0];
+    let mut len_remaining = len as usize;
+
+    // Read one batch at a time.
+    while len_remaining > 0 {
+        let len_read = core::cmp::min(len_remaining, batch_size);
+        let offset = vec.len();
+        let len_new = vec.len() + len_read;
+
+        // Reserve exactly the new space required. Reserving exact prevents vec
+        // from increasing the allocated memory 2x which could result with large
+        // unnecessary allocations.
+        vec.reserve_exact(len_new);
+
+        // Resize the vec so that the read can read into the next batch of space.
+        vec.resize(len_new, 0);
+
+        r.read_exact(&mut vec[offset..])?;
+        len_remaining -= len_read;
+    }
+    vec
+}
+
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
@@ -1232,15 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1637,15 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2027,15 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -13,7 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
-const MAX_PREALLOCATED_BYTES_READ: usize = 1048576; // 1MB
+const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -1234,11 +1234,11 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -1639,11 +1639,11 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -2029,11 +2029,11 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -668,7 +668,7 @@ fn pad_len(len: usize) -> usize {
 /// required for each batch as it goes while reading so that no large
 /// preallocation occurs without the message data being available.
 #[cfg(feature = "std")]
-fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Result<Vec<u8>> {
     let mut vec = vec![0u8; 0];
     let mut len_remaining = len as usize;
 
@@ -689,7 +689,7 @@ fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8
         r.read_exact(&mut vec[offset..])?;
         len_remaining -= len_read;
     }
-    vec
+    Ok(vec)
 }
 
 impl ReadXdr for i32 {
@@ -1261,7 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1658,7 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2040,7 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -13,6 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
+#[cfg(feature = "std")]
 const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -663,6 +663,35 @@ fn pad_len(len: usize) -> usize {
     (4 - (len % 4)) % 4
 }
 
+/// Read exactly the specified length of bytes from the read into a new Vec that
+/// is returned in batches. The function will preallocate only the memory
+/// required for each batch as it goes while reading so that no large
+/// preallocation occurs without the message data being available.
+#[cfg(feature = "std")]
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+    let mut vec = vec![0u8; 0];
+    let mut len_remaining = len as usize;
+
+    // Read one batch at a time.
+    while len_remaining > 0 {
+        let len_read = core::cmp::min(len_remaining, batch_size);
+        let offset = vec.len();
+        let len_new = vec.len() + len_read;
+
+        // Reserve exactly the new space required. Reserving exact prevents vec
+        // from increasing the allocated memory 2x which could result with large
+        // unnecessary allocations.
+        vec.reserve_exact(len_new);
+
+        // Resize the vec so that the read can read into the next batch of space.
+        vec.resize(len_new, 0);
+
+        r.read_exact(&mut vec[offset..])?;
+        len_remaining -= len_read;
+    }
+    vec
+}
+
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
@@ -1232,15 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1637,15 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2027,15 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -13,7 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
-const MAX_PREALLOCATED_BYTES_READ: usize = 1048576; // 1MB
+const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -1234,11 +1234,11 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -1639,11 +1639,11 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -2029,11 +2029,11 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -668,7 +668,7 @@ fn pad_len(len: usize) -> usize {
 /// required for each batch as it goes while reading so that no large
 /// preallocation occurs without the message data being available.
 #[cfg(feature = "std")]
-fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Result<Vec<u8>> {
     let mut vec = vec![0u8; 0];
     let mut len_remaining = len as usize;
 
@@ -689,7 +689,7 @@ fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8
         r.read_exact(&mut vec[offset..])?;
         len_remaining -= len_read;
     }
-    vec
+    Ok(vec)
 }
 
 impl ReadXdr for i32 {
@@ -1261,7 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1658,7 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2040,7 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -13,6 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
+#[cfg(feature = "std")]
 const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -663,6 +663,35 @@ fn pad_len(len: usize) -> usize {
     (4 - (len % 4)) % 4
 }
 
+/// Read exactly the specified length of bytes from the read into a new Vec that
+/// is returned in batches. The function will preallocate only the memory
+/// required for each batch as it goes while reading so that no large
+/// preallocation occurs without the message data being available.
+#[cfg(feature = "std")]
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+    let mut vec = vec![0u8; 0];
+    let mut len_remaining = len as usize;
+
+    // Read one batch at a time.
+    while len_remaining > 0 {
+        let len_read = core::cmp::min(len_remaining, batch_size);
+        let offset = vec.len();
+        let len_new = vec.len() + len_read;
+
+        // Reserve exactly the new space required. Reserving exact prevents vec
+        // from increasing the allocated memory 2x which could result with large
+        // unnecessary allocations.
+        vec.reserve_exact(len_new);
+
+        // Resize the vec so that the read can read into the next batch of space.
+        vec.resize(len_new, 0);
+
+        r.read_exact(&mut vec[offset..])?;
+        len_remaining -= len_read;
+    }
+    vec
+}
+
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
@@ -1232,15 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1637,15 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2027,15 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -13,7 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
-const MAX_PREALLOCATED_BYTES_READ: usize = 1048576; // 1MB
+const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -1234,11 +1234,11 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -1639,11 +1639,11 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -2029,11 +2029,11 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -668,7 +668,7 @@ fn pad_len(len: usize) -> usize {
 /// required for each batch as it goes while reading so that no large
 /// preallocation occurs without the message data being available.
 #[cfg(feature = "std")]
-fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Result<Vec<u8>> {
     let mut vec = vec![0u8; 0];
     let mut len_remaining = len as usize;
 
@@ -689,7 +689,7 @@ fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8
         r.read_exact(&mut vec[offset..])?;
         len_remaining -= len_read;
     }
-    vec
+    Ok(vec)
 }
 
 impl ReadXdr for i32 {
@@ -1261,7 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1658,7 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2040,7 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -13,6 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
+#[cfg(feature = "std")]
 const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -663,6 +663,35 @@ fn pad_len(len: usize) -> usize {
     (4 - (len % 4)) % 4
 }
 
+/// Read exactly the specified length of bytes from the read into a new Vec that
+/// is returned in batches. The function will preallocate only the memory
+/// required for each batch as it goes while reading so that no large
+/// preallocation occurs without the message data being available.
+#[cfg(feature = "std")]
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+    let mut vec = vec![0u8; 0];
+    let mut len_remaining = len as usize;
+
+    // Read one batch at a time.
+    while len_remaining > 0 {
+        let len_read = core::cmp::min(len_remaining, batch_size);
+        let offset = vec.len();
+        let len_new = vec.len() + len_read;
+
+        // Reserve exactly the new space required. Reserving exact prevents vec
+        // from increasing the allocated memory 2x which could result with large
+        // unnecessary allocations.
+        vec.reserve_exact(len_new);
+
+        // Resize the vec so that the read can read into the next batch of space.
+        vec.resize(len_new, 0);
+
+        r.read_exact(&mut vec[offset..])?;
+        len_remaining -= len_read;
+    }
+    vec
+}
+
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
@@ -1232,15 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1637,15 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2027,15 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -13,7 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
-const MAX_PREALLOCATED_BYTES_READ: usize = 1048576; // 1MB
+const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -1234,11 +1234,11 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -1639,11 +1639,11 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -2029,11 +2029,11 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -668,7 +668,7 @@ fn pad_len(len: usize) -> usize {
 /// required for each batch as it goes while reading so that no large
 /// preallocation occurs without the message data being available.
 #[cfg(feature = "std")]
-fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Result<Vec<u8>> {
     let mut vec = vec![0u8; 0];
     let mut len_remaining = len as usize;
 
@@ -689,7 +689,7 @@ fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8
         r.read_exact(&mut vec[offset..])?;
         len_remaining -= len_read;
     }
-    vec
+    Ok(vec)
 }
 
 impl ReadXdr for i32 {
@@ -1261,7 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1658,7 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2040,7 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -13,6 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
+#[cfg(feature = "std")]
 const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -663,6 +663,35 @@ fn pad_len(len: usize) -> usize {
     (4 - (len % 4)) % 4
 }
 
+/// Read exactly the specified length of bytes from the read into a new Vec that
+/// is returned in batches. The function will preallocate only the memory
+/// required for each batch as it goes while reading so that no large
+/// preallocation occurs without the message data being available.
+#[cfg(feature = "std")]
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+    let mut vec = vec![0u8; 0];
+    let mut len_remaining = len as usize;
+
+    // Read one batch at a time.
+    while len_remaining > 0 {
+        let len_read = core::cmp::min(len_remaining, batch_size);
+        let offset = vec.len();
+        let len_new = vec.len() + len_read;
+
+        // Reserve exactly the new space required. Reserving exact prevents vec
+        // from increasing the allocated memory 2x which could result with large
+        // unnecessary allocations.
+        vec.reserve_exact(len_new);
+
+        // Resize the vec so that the read can read into the next batch of space.
+        vec.resize(len_new, 0);
+
+        r.read_exact(&mut vec[offset..])?;
+        len_remaining -= len_read;
+    }
+    vec
+}
+
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
@@ -1232,15 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1637,15 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2027,15 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -13,7 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
-const MAX_PREALLOCATED_BYTES_READ: usize = 1048576; // 1MB
+const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -1234,11 +1234,11 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -1639,11 +1639,11 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -2029,11 +2029,11 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -668,7 +668,7 @@ fn pad_len(len: usize) -> usize {
 /// required for each batch as it goes while reading so that no large
 /// preallocation occurs without the message data being available.
 #[cfg(feature = "std")]
-fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Result<Vec<u8>> {
     let mut vec = vec![0u8; 0];
     let mut len_remaining = len as usize;
 
@@ -689,7 +689,7 @@ fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8
         r.read_exact(&mut vec[offset..])?;
         len_remaining -= len_read;
     }
-    vec
+    Ok(vec)
 }
 
 impl ReadXdr for i32 {
@@ -1261,7 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1658,7 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2040,7 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -13,6 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
+#[cfg(feature = "std")]
 const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -663,6 +663,35 @@ fn pad_len(len: usize) -> usize {
     (4 - (len % 4)) % 4
 }
 
+/// Read exactly the specified length of bytes from the read into a new Vec that
+/// is returned in batches. The function will preallocate only the memory
+/// required for each batch as it goes while reading so that no large
+/// preallocation occurs without the message data being available.
+#[cfg(feature = "std")]
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+    let mut vec = vec![0u8; 0];
+    let mut len_remaining = len as usize;
+
+    // Read one batch at a time.
+    while len_remaining > 0 {
+        let len_read = core::cmp::min(len_remaining, batch_size);
+        let offset = vec.len();
+        let len_new = vec.len() + len_read;
+
+        // Reserve exactly the new space required. Reserving exact prevents vec
+        // from increasing the allocated memory 2x which could result with large
+        // unnecessary allocations.
+        vec.reserve_exact(len_new);
+
+        // Resize the vec so that the read can read into the next batch of space.
+        vec.resize(len_new, 0);
+
+        r.read_exact(&mut vec[offset..])?;
+        len_remaining -= len_read;
+    }
+    vec
+}
+
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
@@ -1232,15 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1637,15 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2027,15 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -13,7 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
-const MAX_PREALLOCATED_BYTES_READ: usize = 1048576; // 1MB
+const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -1234,11 +1234,11 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -1639,11 +1639,11 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -2029,11 +2029,11 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -668,7 +668,7 @@ fn pad_len(len: usize) -> usize {
 /// required for each batch as it goes while reading so that no large
 /// preallocation occurs without the message data being available.
 #[cfg(feature = "std")]
-fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Result<Vec<u8>> {
     let mut vec = vec![0u8; 0];
     let mut len_remaining = len as usize;
 
@@ -689,7 +689,7 @@ fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8
         r.read_exact(&mut vec[offset..])?;
         len_remaining -= len_read;
     }
-    vec
+    Ok(vec)
 }
 
 impl ReadXdr for i32 {
@@ -1261,7 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1658,7 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2040,7 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -13,6 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
+#[cfg(feature = "std")]
 const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -663,6 +663,35 @@ fn pad_len(len: usize) -> usize {
     (4 - (len % 4)) % 4
 }
 
+/// Read exactly the specified length of bytes from the read into a new Vec that
+/// is returned in batches. The function will preallocate only the memory
+/// required for each batch as it goes while reading so that no large
+/// preallocation occurs without the message data being available.
+#[cfg(feature = "std")]
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+    let mut vec = vec![0u8; 0];
+    let mut len_remaining = len as usize;
+
+    // Read one batch at a time.
+    while len_remaining > 0 {
+        let len_read = core::cmp::min(len_remaining, batch_size);
+        let offset = vec.len();
+        let len_new = vec.len() + len_read;
+
+        // Reserve exactly the new space required. Reserving exact prevents vec
+        // from increasing the allocated memory 2x which could result with large
+        // unnecessary allocations.
+        vec.reserve_exact(len_new);
+
+        // Resize the vec so that the read can read into the next batch of space.
+        vec.resize(len_new, 0);
+
+        r.read_exact(&mut vec[offset..])?;
+        len_remaining -= len_read;
+    }
+    vec
+}
+
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
@@ -1232,15 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1637,15 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2027,15 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -13,7 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
-const MAX_PREALLOCATED_BYTES_READ: usize = 1048576; // 1MB
+const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -1234,11 +1234,11 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -1639,11 +1639,11 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -2029,11 +2029,11 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -668,7 +668,7 @@ fn pad_len(len: usize) -> usize {
 /// required for each batch as it goes while reading so that no large
 /// preallocation occurs without the message data being available.
 #[cfg(feature = "std")]
-fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Result<Vec<u8>> {
     let mut vec = vec![0u8; 0];
     let mut len_remaining = len as usize;
 
@@ -689,7 +689,7 @@ fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8
         r.read_exact(&mut vec[offset..])?;
         len_remaining -= len_read;
     }
-    vec
+    Ok(vec)
 }
 
 impl ReadXdr for i32 {
@@ -1261,7 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1658,7 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2040,7 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -13,6 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
+#[cfg(feature = "std")]
 const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -663,6 +663,35 @@ fn pad_len(len: usize) -> usize {
     (4 - (len % 4)) % 4
 }
 
+/// Read exactly the specified length of bytes from the read into a new Vec that
+/// is returned in batches. The function will preallocate only the memory
+/// required for each batch as it goes while reading so that no large
+/// preallocation occurs without the message data being available.
+#[cfg(feature = "std")]
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+    let mut vec = vec![0u8; 0];
+    let mut len_remaining = len as usize;
+
+    // Read one batch at a time.
+    while len_remaining > 0 {
+        let len_read = core::cmp::min(len_remaining, batch_size);
+        let offset = vec.len();
+        let len_new = vec.len() + len_read;
+
+        // Reserve exactly the new space required. Reserving exact prevents vec
+        // from increasing the allocated memory 2x which could result with large
+        // unnecessary allocations.
+        vec.reserve_exact(len_new);
+
+        // Resize the vec so that the read can read into the next batch of space.
+        vec.resize(len_new, 0);
+
+        r.read_exact(&mut vec[offset..])?;
+        len_remaining -= len_read;
+    }
+    vec
+}
+
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
@@ -1232,15 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1637,15 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2027,15 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -13,7 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
-const MAX_PREALLOCATED_BYTES_READ: usize = 1048576; // 1MB
+const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -1234,11 +1234,11 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -1639,11 +1639,11 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -2029,11 +2029,11 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -668,7 +668,7 @@ fn pad_len(len: usize) -> usize {
 /// required for each batch as it goes while reading so that no large
 /// preallocation occurs without the message data being available.
 #[cfg(feature = "std")]
-fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Result<Vec<u8>> {
     let mut vec = vec![0u8; 0];
     let mut len_remaining = len as usize;
 
@@ -689,7 +689,7 @@ fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8
         r.read_exact(&mut vec[offset..])?;
         len_remaining -= len_read;
     }
-    vec
+    Ok(vec)
 }
 
 impl ReadXdr for i32 {
@@ -1261,7 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1658,7 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2040,7 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -13,6 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
+#[cfg(feature = "std")]
 const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -663,6 +663,35 @@ fn pad_len(len: usize) -> usize {
     (4 - (len % 4)) % 4
 }
 
+/// Read exactly the specified length of bytes from the read into a new Vec that
+/// is returned in batches. The function will preallocate only the memory
+/// required for each batch as it goes while reading so that no large
+/// preallocation occurs without the message data being available.
+#[cfg(feature = "std")]
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+    let mut vec = vec![0u8; 0];
+    let mut len_remaining = len as usize;
+
+    // Read one batch at a time.
+    while len_remaining > 0 {
+        let len_read = core::cmp::min(len_remaining, batch_size);
+        let offset = vec.len();
+        let len_new = vec.len() + len_read;
+
+        // Reserve exactly the new space required. Reserving exact prevents vec
+        // from increasing the allocated memory 2x which could result with large
+        // unnecessary allocations.
+        vec.reserve_exact(len_new);
+
+        // Resize the vec so that the read can read into the next batch of space.
+        vec.resize(len_new, 0);
+
+        r.read_exact(&mut vec[offset..])?;
+        len_remaining -= len_read;
+    }
+    vec
+}
+
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
@@ -1232,15 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1637,15 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2027,15 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -13,7 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
-const MAX_PREALLOCATED_BYTES_READ: usize = 1048576; // 1MB
+const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -1234,11 +1234,11 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -1639,11 +1639,11 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -2029,11 +2029,11 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -668,7 +668,7 @@ fn pad_len(len: usize) -> usize {
 /// required for each batch as it goes while reading so that no large
 /// preallocation occurs without the message data being available.
 #[cfg(feature = "std")]
-fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Result<Vec<u8>> {
     let mut vec = vec![0u8; 0];
     let mut len_remaining = len as usize;
 
@@ -689,7 +689,7 @@ fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8
         r.read_exact(&mut vec[offset..])?;
         len_remaining -= len_read;
     }
-    vec
+    Ok(vec)
 }
 
 impl ReadXdr for i32 {
@@ -1261,7 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1658,7 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2040,7 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -13,6 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
+#[cfg(feature = "std")]
 const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -663,6 +663,35 @@ fn pad_len(len: usize) -> usize {
     (4 - (len % 4)) % 4
 }
 
+/// Read exactly the specified length of bytes from the read into a new Vec that
+/// is returned in batches. The function will preallocate only the memory
+/// required for each batch as it goes while reading so that no large
+/// preallocation occurs without the message data being available.
+#[cfg(feature = "std")]
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+    let mut vec = vec![0u8; 0];
+    let mut len_remaining = len as usize;
+
+    // Read one batch at a time.
+    while len_remaining > 0 {
+        let len_read = core::cmp::min(len_remaining, batch_size);
+        let offset = vec.len();
+        let len_new = vec.len() + len_read;
+
+        // Reserve exactly the new space required. Reserving exact prevents vec
+        // from increasing the allocated memory 2x which could result with large
+        // unnecessary allocations.
+        vec.reserve_exact(len_new);
+
+        // Resize the vec so that the read can read into the next batch of space.
+        vec.resize(len_new, 0);
+
+        r.read_exact(&mut vec[offset..])?;
+        len_remaining -= len_read;
+    }
+    vec
+}
+
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
@@ -1232,15 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1637,15 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2027,15 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -13,7 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
-const MAX_PREALLOCATED_BYTES_READ: usize = 1048576; // 1MB
+const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -1234,11 +1234,11 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -1639,11 +1639,11 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -2029,11 +2029,11 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -668,7 +668,7 @@ fn pad_len(len: usize) -> usize {
 /// required for each batch as it goes while reading so that no large
 /// preallocation occurs without the message data being available.
 #[cfg(feature = "std")]
-fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Result<Vec<u8>> {
     let mut vec = vec![0u8; 0];
     let mut len_remaining = len as usize;
 
@@ -689,7 +689,7 @@ fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8
         r.read_exact(&mut vec[offset..])?;
         len_remaining -= len_read;
     }
-    vec
+    Ok(vec)
 }
 
 impl ReadXdr for i32 {
@@ -1261,7 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1658,7 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2040,7 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -13,6 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
+#[cfg(feature = "std")]
 const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -663,6 +663,35 @@ fn pad_len(len: usize) -> usize {
     (4 - (len % 4)) % 4
 }
 
+/// Read exactly the specified length of bytes from the read into a new Vec that
+/// is returned in batches. The function will preallocate only the memory
+/// required for each batch as it goes while reading so that no large
+/// preallocation occurs without the message data being available.
+#[cfg(feature = "std")]
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+    let mut vec = vec![0u8; 0];
+    let mut len_remaining = len as usize;
+
+    // Read one batch at a time.
+    while len_remaining > 0 {
+        let len_read = core::cmp::min(len_remaining, batch_size);
+        let offset = vec.len();
+        let len_new = vec.len() + len_read;
+
+        // Reserve exactly the new space required. Reserving exact prevents vec
+        // from increasing the allocated memory 2x which could result with large
+        // unnecessary allocations.
+        vec.reserve_exact(len_new);
+
+        // Resize the vec so that the read can read into the next batch of space.
+        vec.resize(len_new, 0);
+
+        r.read_exact(&mut vec[offset..])?;
+        len_remaining -= len_read;
+    }
+    vec
+}
+
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
@@ -1232,15 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1637,15 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2027,15 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -13,7 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
-const MAX_PREALLOCATED_BYTES_READ: usize = 1048576; // 1MB
+const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -1234,11 +1234,11 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -1639,11 +1639,11 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -2029,11 +2029,11 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -668,7 +668,7 @@ fn pad_len(len: usize) -> usize {
 /// required for each batch as it goes while reading so that no large
 /// preallocation occurs without the message data being available.
 #[cfg(feature = "std")]
-fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Result<Vec<u8>> {
     let mut vec = vec![0u8; 0];
     let mut len_remaining = len as usize;
 
@@ -689,7 +689,7 @@ fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8
         r.read_exact(&mut vec[offset..])?;
         len_remaining -= len_read;
     }
-    vec
+    Ok(vec)
 }
 
 impl ReadXdr for i32 {
@@ -1261,7 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1658,7 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2040,7 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -13,6 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
+#[cfg(feature = "std")]
 const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -663,6 +663,35 @@ fn pad_len(len: usize) -> usize {
     (4 - (len % 4)) % 4
 }
 
+/// Read exactly the specified length of bytes from the read into a new Vec that
+/// is returned in batches. The function will preallocate only the memory
+/// required for each batch as it goes while reading so that no large
+/// preallocation occurs without the message data being available.
+#[cfg(feature = "std")]
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+    let mut vec = vec![0u8; 0];
+    let mut len_remaining = len as usize;
+
+    // Read one batch at a time.
+    while len_remaining > 0 {
+        let len_read = core::cmp::min(len_remaining, batch_size);
+        let offset = vec.len();
+        let len_new = vec.len() + len_read;
+
+        // Reserve exactly the new space required. Reserving exact prevents vec
+        // from increasing the allocated memory 2x which could result with large
+        // unnecessary allocations.
+        vec.reserve_exact(len_new);
+
+        // Resize the vec so that the read can read into the next batch of space.
+        vec.resize(len_new, 0);
+
+        r.read_exact(&mut vec[offset..])?;
+        len_remaining -= len_read;
+    }
+    vec
+}
+
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
@@ -1232,15 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1637,15 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2027,15 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -13,7 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
-const MAX_PREALLOCATED_BYTES_READ: usize = 1048576; // 1MB
+const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -1234,11 +1234,11 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -1639,11 +1639,11 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -2029,11 +2029,11 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -668,7 +668,7 @@ fn pad_len(len: usize) -> usize {
 /// required for each batch as it goes while reading so that no large
 /// preallocation occurs without the message data being available.
 #[cfg(feature = "std")]
-fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Result<Vec<u8>> {
     let mut vec = vec![0u8; 0];
     let mut len_remaining = len as usize;
 
@@ -689,7 +689,7 @@ fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8
         r.read_exact(&mut vec[offset..])?;
         len_remaining -= len_read;
     }
-    vec
+    Ok(vec)
 }
 
 impl ReadXdr for i32 {
@@ -1261,7 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1658,7 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2040,7 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -13,6 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
+#[cfg(feature = "std")]
 const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -663,6 +663,35 @@ fn pad_len(len: usize) -> usize {
     (4 - (len % 4)) % 4
 }
 
+/// Read exactly the specified length of bytes from the read into a new Vec that
+/// is returned in batches. The function will preallocate only the memory
+/// required for each batch as it goes while reading so that no large
+/// preallocation occurs without the message data being available.
+#[cfg(feature = "std")]
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+    let mut vec = vec![0u8; 0];
+    let mut len_remaining = len as usize;
+
+    // Read one batch at a time.
+    while len_remaining > 0 {
+        let len_read = core::cmp::min(len_remaining, batch_size);
+        let offset = vec.len();
+        let len_new = vec.len() + len_read;
+
+        // Reserve exactly the new space required. Reserving exact prevents vec
+        // from increasing the allocated memory 2x which could result with large
+        // unnecessary allocations.
+        vec.reserve_exact(len_new);
+
+        // Resize the vec so that the read can read into the next batch of space.
+        vec.resize(len_new, 0);
+
+        r.read_exact(&mut vec[offset..])?;
+        len_remaining -= len_read;
+    }
+    vec
+}
+
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
@@ -1232,15 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1637,15 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2027,15 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -13,7 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
-const MAX_PREALLOCATED_BYTES_READ: usize = 1048576; // 1MB
+const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -1234,11 +1234,11 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -1639,11 +1639,11 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -2029,11 +2029,11 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -668,7 +668,7 @@ fn pad_len(len: usize) -> usize {
 /// required for each batch as it goes while reading so that no large
 /// preallocation occurs without the message data being available.
 #[cfg(feature = "std")]
-fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Result<Vec<u8>> {
     let mut vec = vec![0u8; 0];
     let mut len_remaining = len as usize;
 
@@ -689,7 +689,7 @@ fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8
         r.read_exact(&mut vec[offset..])?;
         len_remaining -= len_read;
     }
-    vec
+    Ok(vec)
 }
 
 impl ReadXdr for i32 {
@@ -1261,7 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1658,7 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2040,7 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -13,6 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
+#[cfg(feature = "std")]
 const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -663,6 +663,35 @@ fn pad_len(len: usize) -> usize {
     (4 - (len % 4)) % 4
 }
 
+/// Read exactly the specified length of bytes from the read into a new Vec that
+/// is returned in batches. The function will preallocate only the memory
+/// required for each batch as it goes while reading so that no large
+/// preallocation occurs without the message data being available.
+#[cfg(feature = "std")]
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+    let mut vec = vec![0u8; 0];
+    let mut len_remaining = len as usize;
+
+    // Read one batch at a time.
+    while len_remaining > 0 {
+        let len_read = core::cmp::min(len_remaining, batch_size);
+        let offset = vec.len();
+        let len_new = vec.len() + len_read;
+
+        // Reserve exactly the new space required. Reserving exact prevents vec
+        // from increasing the allocated memory 2x which could result with large
+        // unnecessary allocations.
+        vec.reserve_exact(len_new);
+
+        // Resize the vec so that the read can read into the next batch of space.
+        vec.resize(len_new, 0);
+
+        r.read_exact(&mut vec[offset..])?;
+        len_remaining -= len_read;
+    }
+    vec
+}
+
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
@@ -1232,15 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1637,15 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2027,15 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -13,7 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
-const MAX_PREALLOCATED_BYTES_READ: usize = 1048576; // 1MB
+const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -1234,11 +1234,11 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -1639,11 +1639,11 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -2029,11 +2029,11 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -668,7 +668,7 @@ fn pad_len(len: usize) -> usize {
 /// required for each batch as it goes while reading so that no large
 /// preallocation occurs without the message data being available.
 #[cfg(feature = "std")]
-fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Result<Vec<u8>> {
     let mut vec = vec![0u8; 0];
     let mut len_remaining = len as usize;
 
@@ -689,7 +689,7 @@ fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8
         r.read_exact(&mut vec[offset..])?;
         len_remaining -= len_read;
     }
-    vec
+    Ok(vec)
 }
 
 impl ReadXdr for i32 {
@@ -1261,7 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1658,7 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2040,7 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -13,6 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
+#[cfg(feature = "std")]
 const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -663,6 +663,35 @@ fn pad_len(len: usize) -> usize {
     (4 - (len % 4)) % 4
 }
 
+/// Read exactly the specified length of bytes from the read into a new Vec that
+/// is returned in batches. The function will preallocate only the memory
+/// required for each batch as it goes while reading so that no large
+/// preallocation occurs without the message data being available.
+#[cfg(feature = "std")]
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+    let mut vec = vec![0u8; 0];
+    let mut len_remaining = len as usize;
+
+    // Read one batch at a time.
+    while len_remaining > 0 {
+        let len_read = core::cmp::min(len_remaining, batch_size);
+        let offset = vec.len();
+        let len_new = vec.len() + len_read;
+
+        // Reserve exactly the new space required. Reserving exact prevents vec
+        // from increasing the allocated memory 2x which could result with large
+        // unnecessary allocations.
+        vec.reserve_exact(len_new);
+
+        // Resize the vec so that the read can read into the next batch of space.
+        vec.resize(len_new, 0);
+
+        r.read_exact(&mut vec[offset..])?;
+        len_remaining -= len_read;
+    }
+    vec
+}
+
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
@@ -1232,15 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1637,15 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2027,15 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = vec![0u8; 0];
-            let mut len_remaining = len as usize;
-            while len_remaining > 0 {
-                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
-                let offset = vec.len();
-                vec.resize(vec.len() + len_read, 0);
-                r.read_exact(&mut vec[offset..])?;
-                len_remaining -= len_read;
-            }
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -13,7 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
-const MAX_PREALLOCATED_BYTES_READ: usize = 1048576; // 1MB
+const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.
 #[cfg(not(feature = "alloc"))]
@@ -1234,11 +1234,11 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -1639,11 +1639,11 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
@@ -2029,11 +2029,11 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
             let mut vec = vec![0u8; 0];
             let mut len_remaining = len as usize;
             while len_remaining > 0 {
-                let len_to_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
+                let len_read = core::cmp::min(len_remaining, MAX_PREALLOCATED_BYTES_READ);
                 let offset = vec.len();
-                vec.resize(vec.len() + len_to_read, 0);
+                vec.resize(vec.len() + len_read, 0);
                 r.read_exact(&mut vec[offset..])?;
-                len_remaining -= read_len;
+                len_remaining -= len_read;
             }
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -668,7 +668,7 @@ fn pad_len(len: usize) -> usize {
 /// required for each batch as it goes while reading so that no large
 /// preallocation occurs without the message data being available.
 #[cfg(feature = "std")]
-fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8> {
+fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Result<Vec<u8>> {
     let mut vec = vec![0u8; 0];
     let mut len_remaining = len as usize;
 
@@ -689,7 +689,7 @@ fn read_exact_in_batches<R: Read>(r: R, len: usize, batch_size: usize) -> Vec<u8
         r.read_exact(&mut vec[offset..])?;
         len_remaining -= len_read;
     }
-    vec
+    Ok(vec)
 }
 
 impl ReadXdr for i32 {
@@ -1261,7 +1261,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -1658,7 +1658,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;
@@ -2040,7 +2040,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
                 return Err(Error::LengthExceedsMax);
             }
 
-            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ);
+            let mut vec = read_exact_in_batches(r, len as usize, MAX_PREALLOCATED_BYTES_READ)?;
 
             let pad = &mut [0u8; 3][..pad_len(len as usize)];
             r.read_exact(pad)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -13,6 +13,7 @@ use core::{array::TryFromSliceError, fmt, fmt::Debug, marker::Sized, ops::Deref,
 #[cfg(feature = "std")]
 use core::marker::PhantomData;
 
+#[cfg(feature = "std")]
 const MAX_PREALLOCATED_BYTES_READ: usize = 1024; // 1KB
 
 // When feature alloc is turned off use static lifetime Box and Vec types.


### PR DESCRIPTION
### What
In the Rust generated code limit preallocation during byte (opaque, string) reads to 1kb.

### Why
Close #174