### PR TITLE
Rust: Add length limits

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -166,21 +166,21 @@ module Xdrgen
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 match v {
                     #{types.map { |t| "TypeVariant::#{t} => r.with_limited_depth(|r| Ok(Self::#{t}(Box::new(#{t}::read_xdr(r)?))))," }.join("\n")}
                 }
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -192,48 +192,48 @@ module Xdrgen
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, #{t}>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::#{t}(Box::new(t)))))," }.join("\n")}
+                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, #{t}>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::#{t}(Box::new(t)))))," }.join("\n")}
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, Frame<#{t}>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::#{t}(Box::new(t.0)))))," }.join("\n")}
+                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, Frame<#{t}>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::#{t}(Box::new(t.0)))))," }.join("\n")}
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, #{t}>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::#{t}(Box::new(t)))))," }.join("\n")}
+                    #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, #{t}>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::#{t}(Box::new(t)))))," }.join("\n")}
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+                let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String, limits: Limits) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -295,7 +295,7 @@ module Xdrgen
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 match self {
                     #{types.map { |t| "Self::#{t}(v) => v.write_xdr(w)," }.join("\n")}
                 }
@@ -378,7 +378,7 @@ module Xdrgen
         out.puts <<-EOS.strip_heredoc
         impl ReadXdr for #{name struct} {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       #{struct.members.map do |m|
@@ -391,7 +391,7 @@ module Xdrgen
 
         impl WriteXdr for #{name struct} {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     #{struct.members.map do |m|
                       "self.#{field_name(m)}.write_xdr(w)?;"
@@ -485,7 +485,7 @@ module Xdrgen
 
         impl ReadXdr for #{name enum} {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -496,7 +496,7 @@ module Xdrgen
 
         impl WriteXdr for #{name enum} {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -621,7 +621,7 @@ module Xdrgen
 
         impl ReadXdr for #{name union} {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     let dv: #{discriminant_type} = <#{discriminant_type} as ReadXdr>::read_xdr(r)?;
                     #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
@@ -643,7 +643,7 @@ module Xdrgen
 
         impl WriteXdr for #{name union} {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     self.discriminant().write_xdr(w)?;
                     #[allow(clippy::match_same_arms)]
@@ -741,7 +741,7 @@ module Xdrgen
 
           impl ReadXdr for #{name typedef} {
               #[cfg(feature = "std")]
-              fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+              fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                   r.with_limited_depth(|r| {
                       let i = #{reference_to_call(typedef, typedef.type)}::read_xdr(r)?;
                       let v = #{name typedef}(i);
@@ -752,7 +752,7 @@ module Xdrgen
 
           impl WriteXdr for #{name typedef} {
               #[cfg(feature = "std")]
-              fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+              fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                   w.with_limited_depth(|w|{ self.0.write_xdr(w) })
               }
           }

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -201,14 +201,17 @@ pub struct Limits {
     /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
     pub depth: u32,
 
-    /// Defines the maximum number of bytes that will be read.
+    /// Defines the maximum number of bytes that will be read or read.
     pub len: usize,
 }
 
 #[cfg(feature = "std")]
 impl Default for Limits {
     fn default() -> Self {
-        Self { depth: 500, len: 0 }
+        Self {
+            depth: 500,
+            len: usize::MAX,
+        }
     }
 }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -208,11 +208,25 @@ pub struct Limits {
 }
 
 #[cfg(feature = "std")]
-impl Default for Limits {
-    fn default() -> Self {
+impl Limits {
+    fn none() -> Self {
         Self {
-            depth: 500,
+            depth: u32::MAX,
             len: usize::MAX,
+        }
+    }
+
+    fn depth(depth: u32) -> Self {
+        Limits {
+            depth,
+            ..Limits::none()
+        }
+    }
+
+    fn len(len: usize) -> Self {
+        Limits {
+            len,
+            ..Limits::none()
         }
     }
 }
@@ -2052,21 +2066,21 @@ mod tests {
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::none())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::none())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::none()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2076,7 +2090,7 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::none()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2088,7 +2102,7 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::none()))
             .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
@@ -2097,7 +2111,7 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::none()))
             .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
@@ -2105,21 +2119,21 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut Limited::new(buf, Limits::none())).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::none())).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::none()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2129,7 +2143,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::none()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2140,7 +2154,7 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::none()))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -2149,7 +2163,7 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::none()))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
@@ -2186,22 +2200,10 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(
-            Vec::new(),
-            Limits {
-                depth: 4,
-                ..Limits::default()
-            },
-        );
+        let mut buf = Limited::new(Vec::new(), Limits::depth(4));
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = Limited::new(
-            Cursor::new(buf.inner.as_slice()),
-            Limits {
-                depth: 4,
-                ..Limits::default()
-            },
-        );
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::depth(4));
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
@@ -2209,13 +2211,7 @@ mod test {
     #[test]
     fn write_over_depth_limit_fail() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(
-            Vec::new(),
-            Limits {
-                depth: 3,
-                len: usize::MAX,
-            },
-        );
+        let mut buf = Limited::new(Vec::new(), Limits::depth(3));
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2225,19 +2221,13 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_limits = Limits {
-            depth: 3,
-            ..Limits::default()
-        };
-        let write_limits = Limits {
-            depth: 5,
-            ..Limits::default()
-        };
+        let read_limits = Limits::depth(3);
+        let write_limits = Limits::depth(5);
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), read_limits);
+        let mut buf = Limited::new(Vec::new(), write_limits);
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
         let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2246,65 +2236,432 @@ mod test {
     }
 
     #[test]
-    fn length_limited_read_write_under_the_limit_success() {
-        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(
-            Vec::new(),
-            Limits {
-                len: 16,
-                ..Limits::default()
-            },
-        );
-        a.write_xdr(&mut buf).unwrap();
+    fn length_limited_read_write_i32() {
+        // Exact limit, success
+        let v = 123i32;
+        let mut buf = Limited::new(Vec::new(), Limits::len(4));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(4));
+        let v_back: i32 = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
 
-        let mut lr = Limited::new(
-            Cursor::new(buf.inner.as_slice()),
-            Limits {
-                len: 16,
-                ..Limits::default()
-            },
+        // Over limit, success
+        let v = 123i32;
+        let mut buf = Limited::new(Vec::new(), Limits::len(5));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(5));
+        let v_back: i32 = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = 123i32;
+        let mut buf = Limited::new(Vec::new(), Limits::len(3));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = 123i32;
+        let mut buf = Limited::new(Vec::new(), Limits::len(4));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(3));
+        assert_eq!(
+            <i32 as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
         );
-        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut lr).unwrap();
-        assert_eq!(a, a_back);
     }
 
     #[test]
-    fn write_over_length_limit_fail() {
-        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(
-            Vec::new(),
-            Limits {
-                len: 15,
-                ..Limits::default()
-            },
+    fn length_limited_read_write_u32() {
+        // Exact limit, success
+        let v = 123u32;
+        let mut buf = Limited::new(Vec::new(), Limits::len(4));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(4));
+        let v_back: u32 = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
+
+        // Over limit, success
+        let v = 123u32;
+        let mut buf = Limited::new(Vec::new(), Limits::len(5));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(5));
+        let v_back: u32 = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = 123u32;
+        let mut buf = Limited::new(Vec::new(), Limits::len(3));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = 123u32;
+        let mut buf = Limited::new(Vec::new(), Limits::len(4));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(3));
+        assert_eq!(
+            <u32 as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
         );
-        let res = a.write_xdr(&mut buf);
-        match res {
-            Err(Error::LengthLimitExceeded) => (),
-            _ => panic!("expected LengthLimitExceeded got {res:?}"),
-        }
     }
 
     #[test]
-    fn read_over_length_limit_fail() {
-        let read_limits = Limits {
-            len: 15,
-            ..Limits::default()
-        };
-        let write_limits = Limits {
-            len: 16,
-            ..Limits::default()
-        };
-        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), read_limits);
-        a.write_xdr(&mut buf).unwrap();
+    fn length_limited_read_write_i64() {
+        // Exact limit, success
+        let v = 123i64;
+        let mut buf = Limited::new(Vec::new(), Limits::len(8));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(8));
+        let v_back: i64 = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
 
-        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
-        match res {
-            Err(Error::LengthLimitExceeded) => (),
-            _ => panic!("expected DepthLimitExceeded got {res:?}"),
-        }
+        // Over limit, success
+        let v = 123i64;
+        let mut buf = Limited::new(Vec::new(), Limits::len(9));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(9));
+        let v_back: i64 = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = 123i64;
+        let mut buf = Limited::new(Vec::new(), Limits::len(7));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = 123i64;
+        let mut buf = Limited::new(Vec::new(), Limits::len(8));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(7));
+        assert_eq!(
+            <i64 as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn length_limited_read_write_u64() {
+        // Exact limit, success
+        let v = 123u64;
+        let mut buf = Limited::new(Vec::new(), Limits::len(8));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(8));
+        let v_back: u64 = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
+
+        // Over limit, success
+        let v = 123u64;
+        let mut buf = Limited::new(Vec::new(), Limits::len(9));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(9));
+        let v_back: u64 = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = 123u64;
+        let mut buf = Limited::new(Vec::new(), Limits::len(7));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = 123u64;
+        let mut buf = Limited::new(Vec::new(), Limits::len(8));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(7));
+        assert_eq!(
+            <u64 as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn length_limited_read_write_bool() {
+        // Exact limit, success
+        let v = true;
+        let mut buf = Limited::new(Vec::new(), Limits::len(4));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(4));
+        let v_back: bool = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
+
+        // Over limit, success
+        let v = true;
+        let mut buf = Limited::new(Vec::new(), Limits::len(5));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(5));
+        let v_back: bool = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = true;
+        let mut buf = Limited::new(Vec::new(), Limits::len(3));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = true;
+        let mut buf = Limited::new(Vec::new(), Limits::len(4));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(3));
+        assert_eq!(
+            <bool as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn length_limited_read_write_option() {
+        // Exact limit, success
+        let v = Some(true);
+        let mut buf = Limited::new(Vec::new(), Limits::len(8));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(8));
+        let v_back: Option<bool> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
+
+        // Over limit, success
+        let v = Some(true);
+        let mut buf = Limited::new(Vec::new(), Limits::len(9));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(9));
+        let v_back: Option<bool> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = Some(true);
+        let mut buf = Limited::new(Vec::new(), Limits::len(7));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = Some(true);
+        let mut buf = Limited::new(Vec::new(), Limits::len(8));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(7));
+        assert_eq!(
+            <Option<bool> as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn length_limited_read_write_array_u8() {
+        // Exact limit, success
+        let v = [1u8, 2, 3];
+        let mut buf = Limited::new(Vec::new(), Limits::len(4));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(4));
+        let v_back: [u8; 3] = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
+
+        // Over limit, success
+        let v = [1u8, 2, 3];
+        let mut buf = Limited::new(Vec::new(), Limits::len(5));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(5));
+        let v_back: [u8; 3] = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = [1u8, 2, 3];
+        let mut buf = Limited::new(Vec::new(), Limits::len(3));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = [1u8, 2, 3];
+        let mut buf = Limited::new(Vec::new(), Limits::len(4));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(3));
+        assert_eq!(
+            <[u8; 3] as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn length_limited_read_write_array_type() {
+        // Exact limit, success
+        let v = [true, false, true];
+        let mut buf = Limited::new(Vec::new(), Limits::len(12));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(12));
+        let v_back: [bool; 3] = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
+
+        // Over limit, success
+        let v = [true, false, true];
+        let mut buf = Limited::new(Vec::new(), Limits::len(13));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(13));
+        let v_back: [bool; 3] = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = [true, false, true];
+        let mut buf = Limited::new(Vec::new(), Limits::len(11));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = [true, false, true];
+        let mut buf = Limited::new(Vec::new(), Limits::len(12));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(11));
+        assert_eq!(
+            <[bool; 3] as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn length_limited_read_write_vec() {
+        // Exact limit, success
+        let v = VecM::<i32, 3>::try_from([1i32, 2, 3]).unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(16));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(16));
+        let v_back: VecM<i32, 3> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
+
+        // Over limit, success
+        let v = VecM::<i32, 3>::try_from([1i32, 2, 3]).unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(17));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(17));
+        let v_back: VecM<i32, 3> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = VecM::<i32, 3>::try_from([1i32, 2, 3]).unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(15));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = VecM::<i32, 3>::try_from([1i32, 2, 3]).unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(16));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(15));
+        assert_eq!(
+            <VecM<i32, 3> as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn length_limited_read_write_bytes() {
+        // Exact limit, success
+        let v = BytesM::<3>::try_from([1u8, 2, 3]).unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(8));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(8));
+        let v_back: BytesM<3> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
+
+        // Over limit, success
+        let v = BytesM::<3>::try_from([1u8, 2, 3]).unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(9));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(9));
+        let v_back: BytesM<3> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = BytesM::<3>::try_from([1u8, 2, 3]).unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(7));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = BytesM::<3>::try_from([1u8, 2, 3]).unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(8));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(7));
+        assert_eq!(
+            <BytesM<3> as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn length_limited_read_write_string() {
+        // Exact limit, success
+        let v = StringM::<3>::try_from("123").unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(8));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(8));
+        let v_back: StringM<3> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        assert_eq!(v, v_back);
+
+        // Over limit, success
+        let v = StringM::<3>::try_from("123").unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(9));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(9));
+        let v_back: StringM<3> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(buf.limits.len, 1);
+        assert_eq!(v, v_back);
+
+        // Write under limit, failure
+        let v = StringM::<3>::try_from("123").unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(7));
+        assert_eq!(v.write_xdr(&mut buf), Err(Error::LengthLimitExceeded));
+
+        // Read under limit, failure
+        let v = StringM::<3>::try_from("123").unwrap();
+        let mut buf = Limited::new(Vec::new(), Limits::len(8));
+        v.write_xdr(&mut buf).unwrap();
+        assert_eq!(buf.limits.len, 0);
+        let mut lr = Limited::new(Cursor::new(buf.inner.as_slice()), Limits::len(7));
+        assert_eq!(
+            <StringM<3> as ReadXdr>::read_xdr(&mut lr),
+            Err(Error::LengthLimitExceeded)
+        );
     }
 }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -263,12 +263,12 @@ impl<L> Limited<L> {
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
+            let res = f(self);
+            self.limits.depth = self.limits.depth.saturating_add(1);
+            res
         } else {
-            return Err(Error::DepthLimitExceeded);
+            Err(Error::DepthLimitExceeded)
         }
-        let res = f(self);
-        self.limits.depth = self.limits.depth.saturating_add(1);
-        res
     }
 }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -209,21 +209,21 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
-    fn none() -> Self {
+    pub fn none() -> Self {
         Self {
             depth: u32::MAX,
             len: usize::MAX,
         }
     }
 
-    fn depth(depth: u32) -> Self {
+    pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
             ..Limits::none()
         }
     }
 
-    fn len(len: usize) -> Self {
+    pub fn len(len: usize) -> Self {
         Limits {
             len,
             ..Limits::none()

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -2188,7 +2188,7 @@ mod test {
             Vec::new(),
             Limits {
                 depth: 4,
-                len: usize::MAX,
+                ..Limits::default()
             },
         );
         a.write_xdr(&mut buf).unwrap();
@@ -2197,7 +2197,7 @@ mod test {
             Cursor::new(buf.inner.as_slice()),
             Limits {
                 depth: 4,
-                len: usize::MAX,
+                ..Limits::default()
             },
         );
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
@@ -2225,11 +2225,11 @@ mod test {
     fn read_over_depth_limit_fail() {
         let read_limits = Limits {
             depth: 3,
-            len: usize::MAX,
+            ..Limits::default()
         };
         let write_limits = Limits {
             depth: 5,
-            len: usize::MAX,
+            ..Limits::default()
         };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
         let mut buf = Limited::new(Vec::new(), read_limits);

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -209,6 +209,7 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
+    #[must_use]
     pub fn none() -> Self {
         Self {
             depth: u32::MAX,
@@ -216,6 +217,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
@@ -223,6 +225,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn len(len: usize) -> Self {
         Limits {
             len,

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -193,15 +193,17 @@ where
 #[cfg(feature = "std")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Limits {
-    /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+    /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to
+    /// prevent stack overflow.
     ///
-    /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
-    /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-    /// For more information about Rust's stack size limit, refer to the
-    /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+    /// The depth limit is akin to limiting stack depth. Its purpose is to
+    /// prevent the program from hitting the maximum stack size allowed by Rust,
+    /// which would result in an unrecoverable `SIGABRT`.  For more information
+    /// about Rust's stack size limit, refer to the [Rust
+    /// documentation](https://doc.rust-lang.org/std/thread/#stack-size).
     pub depth: u32,
 
-    /// Defines the maximum number of bytes that will be read or read.
+    /// Defines the maximum number of bytes that will be read or written.
     pub len: usize,
 }
 
@@ -216,6 +218,9 @@ impl Default for Limits {
 }
 
 /// `Limited` wraps an object and provides functions for enforcing limits.
+///
+/// Intended for use with readers and writers and limiting their reads and
+/// writes.
 #[cfg(feature = "std")]
 pub struct Limited<L> {
     pub inner: L,
@@ -226,12 +231,18 @@ pub struct Limited<L> {
 impl<L> Limited<L> {
     /// Constructs a new `Limited`.
     ///
-    /// - `inner`: The object implementing the `Read` trait.
-    /// - `depth_limit`: The maximum allowed recursion depth.
+    /// - `inner`: The value being limited.
+    /// - `limits`: The limits to enforce.
     pub fn new(inner: L, limits: Limits) -> Self {
         Limited { inner, limits }
     }
 
+    /// Consume the given length from the internal remaining length limit.
+    ///
+    /// ### Errors
+    ///
+    /// If the length would consume more length than the remaining length limit
+    /// allows.
     pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
@@ -241,6 +252,11 @@ impl<L> Limited<L> {
         }
     }
 
+    /// Consumes a single depth for the duration of the given function.
+    ///
+    /// ### Errors
+    ///
+    /// If the depth limit is already exhausted.
     pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
     where
         F: FnOnce(&mut Self) -> Result<T>,

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -219,21 +219,21 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
-    fn none() -> Self {
+    pub fn none() -> Self {
         Self {
             depth: u32::MAX,
             len: usize::MAX,
         }
     }
 
-    fn depth(depth: u32) -> Self {
+    pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
             ..Limits::none()
         }
     }
 
-    fn len(len: usize) -> Self {
+    pub fn len(len: usize) -> Self {
         Limits {
             len,
             ..Limits::none()

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -51,14 +51,6 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
-///
-/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
-/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the
-/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
-
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
 /// compared on their `ErrorKind`.
@@ -204,172 +196,71 @@ where
 {
 }
 
-/// `DepthLimiter` is a trait designed for managing the depth of recursive operations.
-/// It provides a mechanism to limit recursion depth, and defines the behavior upon
-/// entering and leaving a recursion level.
-pub trait DepthLimiter {
-    /// A general error type for any type implementing, or an operation under the guard of
-    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
-    /// which is returned from `enter`.
-    type DepthLimiterError;
+/// `Limits` contains the limits that a limited reader or writer will be
+/// constrained to.
+#[cfg(feature = "std")]
+pub struct Limits {
+    /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+    ///
+    /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+    /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+    /// For more information about Rust's stack size limit, refer to the
+    /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+    pub depth: u32,
+}
 
-    /// Defines the behavior for entering a new recursion level.
-    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
-    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Defines the behavior for leaving a recursion level.
-    /// A `DepthLimiterError` is returned if an error occurs.
-    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Wraps a given function `f` with depth limiting guards.
-    /// It triggers an `enter` before, and a `leave` after the execution of `f`.
-    ///
-    /// # Parameters
-    ///
-    /// - `f`: The function to be executed under depth limit constraints.
-    ///
-    /// # Returns
-    ///
-    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
-    ///         with an error 3. if error occurs on `leave`.
-    ///   `Ok` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
-    where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
-    {
-        self.enter()?;
-        let res = f(self);
-        self.leave()?;
-        res
+#[cfg(feature = "std")]
+impl Default for Limits {
+    fn default() -> Self {
+        Self { depth: 500 }
     }
 }
 
-/// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
+/// `Limited` wraps an object and provides functions for enforcing limits.
 #[cfg(feature = "std")]
-pub struct DepthLimitedRead<R: Read> {
-    pub inner: R,
-    pub(crate) depth_remaining: u32,
+pub struct Limited<L> {
+    pub inner: L,
+    pub(crate) limits: Limits,
 }
 
 #[cfg(feature = "std")]
-impl<R: Read> DepthLimitedRead<R> {
-    /// Constructs a new `DepthLimitedRead`.
+impl<L> Limited<L> {
+    /// Constructs a new `Limited`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
     /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth_limit: u32) -> Self {
-        DepthLimitedRead {
-            inner,
-            depth_remaining: depth_limit,
-        }
+    pub fn new(inner: L, limits: Limits) -> Self {
+        Limited { inner, limits }
     }
-}
 
-#[cfg(feature = "std")]
-impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> core::result::Result<(), Error> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
+    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut Self) -> Result<T>,
+    {
+        if let Some(depth) = self.limits.depth.checked_sub(1) {
+            self.limits.depth = depth;
         } else {
             return Err(Error::DepthLimitExceeded);
         }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<R: Read> Read for DepthLimitedRead<R> {
-    /// Forwards the read operation to the wrapped object.
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.inner.read(buf)
-    }
-}
-
-/// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
-#[cfg(feature = "std")]
-pub struct DepthLimitedWrite<W: Write> {
-    pub inner: W,
-    pub(crate) depth_remaining: u32,
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimitedWrite<W> {
-    /// Constructs a new `DepthLimitedWrite`.
-    ///
-    /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth_limit: u32) -> Self {
-        DepthLimitedWrite {
-            inner,
-            depth_remaining: depth_limit,
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> Result<()> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
-        } else {
-            return Err(Error::DepthLimitExceeded);
-        }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> Write for DepthLimitedWrite<W> {
-    /// Forwards the write operation to the wrapped object.
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.inner.write(buf)
-    }
-
-    /// Forwards the flush operation to the wrapped object.
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.inner.flush()
+        let res = f(self);
+        self.limits.depth = self.limits.depth.saturating_add(1);
+        res
     }
 }
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: DepthLimitedRead<BufReader<R>>,
+    reader: Limited<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth_limit: u32) -> Self {
+    fn new(r: R, limits: Limits) -> Self {
         Self {
-            reader: DepthLimitedRead {
+            reader: Limited {
                 inner: BufReader::new(r),
-                depth_remaining: depth_limit,
+                limits,
             },
             _s: PhantomData,
         }
@@ -431,17 +322,17 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -466,7 +357,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -482,10 +373,10 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -506,7 +397,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -530,7 +421,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -560,96 +451,68 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
+    fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
+        ReadXdrIter::new(&mut r.inner, r.limits.clone())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
     /// values that are read into the implementing type.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
-        r: &mut DepthLimitedRead<R>,
+        r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining)
+        ReadXdrIter::new(dec, r.limits.clone())
     }
 
-    /// Construct the type from the XDR bytes, specifying a depth limit.
+    /// Construct the type from the XDR bytes.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+        let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            depth_limit,
+            limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+        let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
     #[cfg(feature = "base64")]
-    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
-        let mut enc = DepthLimitedWrite::new(
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+        let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            depth_limit,
+            limits,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
-    }
-
-    #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -662,7 +525,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -673,7 +536,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -681,7 +544,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -692,7 +555,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -700,7 +563,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -711,7 +574,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -719,7 +582,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -730,7 +593,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -738,35 +601,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -777,7 +640,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -787,7 +650,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -804,7 +667,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -819,35 +682,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
@@ -863,7 +726,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             w.write_all(self)?;
             w.write_all(&[0u8; 3][..pad_len(N)])?;
@@ -874,7 +737,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -889,7 +752,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -1222,7 +1085,7 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1245,7 +1108,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1261,7 +1124,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1281,7 +1144,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1620,7 +1483,7 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1643,7 +1506,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2003,7 +1866,7 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2026,7 +1889,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2057,7 +1920,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2080,17 +1943,13 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use super::{
-        DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_XDR_RW_DEPTH_LIMIT,
-    };
+    use super::*;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
@@ -2098,16 +1957,14 @@ mod tests {
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2117,8 +1974,7 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2130,7 +1986,7 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2142,7 +1998,7 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2153,23 +2009,21 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2179,7 +2033,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2190,9 +2044,9 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2202,9 +2056,9 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2242,19 +2096,18 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
 
     #[test]
     fn write_over_depth_limit_fail() {
-        let depth_limit = 3;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), depth_limit);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2264,13 +2117,13 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_depth_limit = 3;
-        let write_depth_limit = 5;
+        let read_limits = Limits { depth: 3 };
+        let write_limits = Limits { depth: 5 };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), write_depth_limit);
+        let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), read_depth_limit);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
         let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2372,7 +2225,7 @@ impl From<AccountFlags> for i32 {
 
 impl ReadXdr for AccountFlags {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let e = i32::read_xdr(r)?;
             let v: Self = e.try_into()?;
@@ -2383,7 +2236,7 @@ impl ReadXdr for AccountFlags {
 
 impl WriteXdr for AccountFlags {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let i: i32 = (*self).into();
             i.write_xdr(w)
@@ -2461,21 +2314,21 @@ impl Type {
 
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
         match v {
             TypeVariant::AccountFlags => r.with_limited_depth(|r| Ok(Self::AccountFlags(Box::new(AccountFlags::read_xdr(r)?)))),
         }
     }
 
     #[cfg(feature = "base64")]
-    pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+    pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
         let t = Self::read_xdr(v, &mut dec)?;
         Ok(t)
     }
 
     #[cfg(feature = "std")]
-    pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
         let s = Self::read_xdr(v, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -2487,48 +2340,48 @@ impl Type {
     }
 
     #[cfg(feature = "base64")]
-    pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+    pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
     }
 
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+    pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
     }
 
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+    pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, Frame<AccountFlags>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::AccountFlags(Box::new(t.0))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, Frame<AccountFlags>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::AccountFlags(Box::new(t.0))))),
         }
     }
 
     #[cfg(feature = "base64")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+    pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec, r.limits).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
     }
 
     #[cfg(feature = "std")]
-    pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
+    pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+        let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(v, &mut cursor)?;
         Ok(t)
     }
 
     #[cfg(feature = "base64")]
-    pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+    pub fn from_xdr_base64(v: TypeVariant, b64: String, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
+        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
     }
@@ -2590,7 +2443,7 @@ impl Variants<TypeVariant> for Type {
 impl WriteXdr for Type {
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         match self {
             Self::AccountFlags(v) => v.write_xdr(w),
         }

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -69,6 +69,7 @@ pub enum Error {
     DepthLimitExceeded,
     #[cfg(feature = "serde_json")]
     Json(serde_json::Error),
+    LengthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -117,6 +118,7 @@ impl fmt::Display for Error {
             Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
             #[cfg(feature = "serde_json")]
             Error::Json(e) => write!(f, "{e}"),
+            Error::LengthLimitExceeded => write!(f, "length limit exceeded"),
         }
     }
 }
@@ -199,6 +201,7 @@ where
 /// `Limits` contains the limits that a limited reader or writer will be
 /// constrained to.
 #[cfg(feature = "std")]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Limits {
     /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
     ///
@@ -207,12 +210,18 @@ pub struct Limits {
     /// For more information about Rust's stack size limit, refer to the
     /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
     pub depth: u32,
+
+    /// Defines the maximum number of bytes that will be read or read.
+    pub len: usize,
 }
 
 #[cfg(feature = "std")]
 impl Default for Limits {
     fn default() -> Self {
-        Self { depth: 500 }
+        Self {
+            depth: 500,
+            len: usize::MAX,
+        }
     }
 }
 
@@ -233,7 +242,16 @@ impl<L> Limited<L> {
         Limited { inner, limits }
     }
 
-    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+        if let Some(len) = self.limits.len.checked_sub(len) {
+            self.limits.len = len;
+            Ok(())
+        } else {
+            Err(Error::LengthLimitExceeded)
+        }
+    }
+
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
     where
         F: FnOnce(&mut Self) -> Result<T>,
     {
@@ -245,6 +263,40 @@ impl<L> Limited<L> {
         let res = f(self);
         self.limits.depth = self.limits.depth.saturating_add(1);
         res
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: BufRead> BufRead for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        self.inner.fill_buf()
+    }
+
+    /// Forwards the read operation to the wrapped object.
+    fn consume(&mut self, amt: usize) {
+        self.inner.consume(amt);
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for Limited<W> {
+    /// Forwards the write operation to the wrapped object.
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    /// Forwards the flush operation to the wrapped object.
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
     }
 }
 
@@ -285,7 +337,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.inner.fill_buf() {
+        match self.reader.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -528,6 +580,7 @@ impl ReadXdr for i32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i32::from_be_bytes(b))
         })
@@ -538,7 +591,10 @@ impl WriteXdr for i32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -547,6 +603,7 @@ impl ReadXdr for u32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u32::from_be_bytes(b))
         })
@@ -557,7 +614,10 @@ impl WriteXdr for u32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -566,6 +626,7 @@ impl ReadXdr for i64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i64::from_be_bytes(b))
         })
@@ -576,7 +637,10 @@ impl WriteXdr for i64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -585,6 +649,7 @@ impl ReadXdr for u64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u64::from_be_bytes(b))
         })
@@ -595,7 +660,10 @@ impl WriteXdr for u64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -631,6 +699,7 @@ impl ReadXdr for bool {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             let b = i == 1;
             Ok(b)
@@ -642,6 +711,7 @@ impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
         })
@@ -652,6 +722,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             match i {
                 0 => Ok(None),
@@ -669,6 +740,7 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
                 t.write_xdr(w)?;
@@ -712,9 +784,12 @@ impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(N)?;
+            let padding = pad_len(N);
+            r.consume_len(padding)?;
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
-            let pad = &mut [0u8; 3][..pad_len(N)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -728,8 +803,11 @@ impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(N)?;
+            let padding = pad_len(N);
+            w.consume_len(padding)?;
             w.write_all(self)?;
-            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            w.write_all(&[0u8; 3][..padding])?;
             Ok(())
         })
     }
@@ -1087,15 +1165,20 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1110,12 +1193,17 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1126,6 +1214,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
@@ -1146,6 +1235,7 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1485,15 +1575,20 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1508,6 +1603,11 @@ impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1868,15 +1968,21 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
+
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1891,12 +1997,17 @@ impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1925,6 +2036,7 @@ where
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
         //  follow the frame header.
+        r.consume_len(core::mem::size_of::<u32>())?;
         let header = u32::read_xdr(r)?;
         // TODO: Use the length and cap the length we'll read from `r`.
         let last_record = header >> 31 == 1;
@@ -1948,16 +2060,14 @@ mod tests {
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
@@ -1986,11 +2096,8 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1998,11 +2105,8 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
@@ -2044,10 +2148,7 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -2056,10 +2157,7 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
@@ -2096,10 +2194,22 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
+        let mut dlr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
@@ -2107,7 +2217,13 @@ mod test {
     #[test]
     fn write_over_depth_limit_fail() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 3,
+                len: usize::MAX,
+            },
+        );
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2117,8 +2233,14 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_limits = Limits { depth: 3 };
-        let write_limits = Limits { depth: 5 };
+        let read_limits = Limits {
+            depth: 3,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            depth: 5,
+            ..Limits::default()
+        };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
         let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
@@ -2322,7 +2444,7 @@ impl Type {
 
     #[cfg(feature = "base64")]
     pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
         let t = Self::read_xdr(v, &mut dec)?;
         Ok(t)
     }
@@ -2341,7 +2463,7 @@ impl Type {
 
     #[cfg(feature = "base64")]
     pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
     }
@@ -2350,7 +2472,7 @@ impl Type {
     #[allow(clippy::too_many_lines)]
     pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
     }
 
@@ -2358,7 +2480,7 @@ impl Type {
     #[allow(clippy::too_many_lines)]
     pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, Frame<AccountFlags>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::AccountFlags(Box::new(t.0))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, Frame<AccountFlags>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t.0))))),
         }
     }
 
@@ -2367,7 +2489,7 @@ impl Type {
     pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec, r.limits).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
     }
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -2268,6 +2268,68 @@ mod test {
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
         }
     }
+
+    #[test]
+    fn length_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut lr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[test]
+    fn write_over_length_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 15,
+                ..Limits::default()
+            },
+        );
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected LengthLimitExceeded got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn read_over_length_limit_fail() {
+        let read_limits = Limits {
+            len: 15,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            len: 16,
+            ..Limits::default()
+        };
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(Vec::new(), read_limits);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
+    }
 }
 
 #[cfg(all(test, not(feature = "alloc")))]

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -273,12 +273,12 @@ impl<L> Limited<L> {
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
+            let res = f(self);
+            self.limits.depth = self.limits.depth.saturating_add(1);
+            res
         } else {
-            return Err(Error::DepthLimitExceeded);
+            Err(Error::DepthLimitExceeded)
         }
-        let res = f(self);
-        self.limits.depth = self.limits.depth.saturating_add(1);
-        res
     }
 }
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -219,6 +219,7 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
+    #[must_use]
     pub fn none() -> Self {
         Self {
             depth: u32::MAX,
@@ -226,6 +227,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
@@ -233,6 +235,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn len(len: usize) -> Self {
         Limits {
             len,

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -219,21 +219,21 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
-    fn none() -> Self {
+    pub fn none() -> Self {
         Self {
             depth: u32::MAX,
             len: usize::MAX,
         }
     }
 
-    fn depth(depth: u32) -> Self {
+    pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
             ..Limits::none()
         }
     }
 
-    fn len(len: usize) -> Self {
+    pub fn len(len: usize) -> Self {
         Limits {
             len,
             ..Limits::none()

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -69,6 +69,7 @@ pub enum Error {
     DepthLimitExceeded,
     #[cfg(feature = "serde_json")]
     Json(serde_json::Error),
+    LengthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -117,6 +118,7 @@ impl fmt::Display for Error {
             Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
             #[cfg(feature = "serde_json")]
             Error::Json(e) => write!(f, "{e}"),
+            Error::LengthLimitExceeded => write!(f, "length limit exceeded"),
         }
     }
 }
@@ -199,6 +201,7 @@ where
 /// `Limits` contains the limits that a limited reader or writer will be
 /// constrained to.
 #[cfg(feature = "std")]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Limits {
     /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
     ///
@@ -207,12 +210,18 @@ pub struct Limits {
     /// For more information about Rust's stack size limit, refer to the
     /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
     pub depth: u32,
+
+    /// Defines the maximum number of bytes that will be read or read.
+    pub len: usize,
 }
 
 #[cfg(feature = "std")]
 impl Default for Limits {
     fn default() -> Self {
-        Self { depth: 500 }
+        Self {
+            depth: 500,
+            len: usize::MAX,
+        }
     }
 }
 
@@ -233,7 +242,16 @@ impl<L> Limited<L> {
         Limited { inner, limits }
     }
 
-    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+        if let Some(len) = self.limits.len.checked_sub(len) {
+            self.limits.len = len;
+            Ok(())
+        } else {
+            Err(Error::LengthLimitExceeded)
+        }
+    }
+
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
     where
         F: FnOnce(&mut Self) -> Result<T>,
     {
@@ -245,6 +263,40 @@ impl<L> Limited<L> {
         let res = f(self);
         self.limits.depth = self.limits.depth.saturating_add(1);
         res
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: BufRead> BufRead for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        self.inner.fill_buf()
+    }
+
+    /// Forwards the read operation to the wrapped object.
+    fn consume(&mut self, amt: usize) {
+        self.inner.consume(amt);
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for Limited<W> {
+    /// Forwards the write operation to the wrapped object.
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    /// Forwards the flush operation to the wrapped object.
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
     }
 }
 
@@ -285,7 +337,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.inner.fill_buf() {
+        match self.reader.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -332,7 +384,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -376,7 +428,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -452,7 +504,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
+        ReadXdrIter::new(&mut r.inner, r.limits.clone())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -462,7 +514,7 @@ where
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining)
+        ReadXdrIter::new(dec, r.limits.clone())
     }
 
     /// Construct the type from the XDR bytes.
@@ -528,6 +580,7 @@ impl ReadXdr for i32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i32::from_be_bytes(b))
         })
@@ -538,7 +591,10 @@ impl WriteXdr for i32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -547,6 +603,7 @@ impl ReadXdr for u32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u32::from_be_bytes(b))
         })
@@ -557,7 +614,10 @@ impl WriteXdr for u32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -566,6 +626,7 @@ impl ReadXdr for i64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i64::from_be_bytes(b))
         })
@@ -576,7 +637,10 @@ impl WriteXdr for i64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -585,6 +649,7 @@ impl ReadXdr for u64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u64::from_be_bytes(b))
         })
@@ -595,7 +660,10 @@ impl WriteXdr for u64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -631,6 +699,7 @@ impl ReadXdr for bool {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             let b = i == 1;
             Ok(b)
@@ -642,6 +711,7 @@ impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
         })
@@ -652,6 +722,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             match i {
                 0 => Ok(None),
@@ -669,6 +740,7 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
                 t.write_xdr(w)?;
@@ -712,9 +784,12 @@ impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(N)?;
+            let padding = pad_len(N);
+            r.consume_len(padding)?;
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
-            let pad = &mut [0u8; 3][..pad_len(N)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -728,8 +803,11 @@ impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(N)?;
+            let padding = pad_len(N);
+            w.consume_len(padding)?;
             w.write_all(self)?;
-            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            w.write_all(&[0u8; 3][..padding])?;
             Ok(())
         })
     }
@@ -1087,15 +1165,20 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1110,12 +1193,17 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1126,6 +1214,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
@@ -1146,6 +1235,7 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1485,15 +1575,20 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1508,6 +1603,11 @@ impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1868,15 +1968,21 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
+
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1891,12 +1997,17 @@ impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1925,6 +2036,7 @@ where
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
         //  follow the frame header.
+        r.consume_len(core::mem::size_of::<u32>())?;
         let header = u32::read_xdr(r)?;
         // TODO: Use the length and cap the length we'll read from `r`.
         let last_record = header >> 31 == 1;
@@ -1948,16 +2060,14 @@ mod tests {
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
@@ -1986,11 +2096,8 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1998,11 +2105,8 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
@@ -2044,10 +2148,7 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -2056,10 +2157,7 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
@@ -2096,10 +2194,22 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
+        let mut dlr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
@@ -2107,7 +2217,13 @@ mod test {
     #[test]
     fn write_over_depth_limit_fail() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 3,
+                len: usize::MAX,
+            },
+        );
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2117,8 +2233,14 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_limits = Limits { depth: 3 };
-        let write_limits = Limits { depth: 5 };
+        let read_limits = Limits {
+            depth: 3,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            depth: 5,
+            ..Limits::default()
+        };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
         let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
@@ -2254,7 +2376,7 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2273,7 +2395,7 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2282,8 +2404,8 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
-TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
+                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
+TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
                 }
             }
 
@@ -2291,8 +2413,8 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inn
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, Frame<TestArray>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::TestArray(Box::new(t.0))))),
-TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::TestArray2(Box::new(t.0))))),
+                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, Frame<TestArray>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::TestArray(Box::new(t.0))))),
+TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::TestArray2(Box::new(t.0))))),
                 }
             }
 
@@ -2301,8 +2423,8 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mu
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(dec, r.limits).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
-TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.limits).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
+                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
+TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -51,14 +51,6 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
-///
-/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
-/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the
-/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
-
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
 /// compared on their `ErrorKind`.
@@ -204,172 +196,71 @@ where
 {
 }
 
-/// `DepthLimiter` is a trait designed for managing the depth of recursive operations.
-/// It provides a mechanism to limit recursion depth, and defines the behavior upon
-/// entering and leaving a recursion level.
-pub trait DepthLimiter {
-    /// A general error type for any type implementing, or an operation under the guard of
-    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
-    /// which is returned from `enter`.
-    type DepthLimiterError;
+/// `Limits` contains the limits that a limited reader or writer will be
+/// constrained to.
+#[cfg(feature = "std")]
+pub struct Limits {
+    /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+    ///
+    /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+    /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+    /// For more information about Rust's stack size limit, refer to the
+    /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+    pub depth: u32,
+}
 
-    /// Defines the behavior for entering a new recursion level.
-    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
-    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Defines the behavior for leaving a recursion level.
-    /// A `DepthLimiterError` is returned if an error occurs.
-    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Wraps a given function `f` with depth limiting guards.
-    /// It triggers an `enter` before, and a `leave` after the execution of `f`.
-    ///
-    /// # Parameters
-    ///
-    /// - `f`: The function to be executed under depth limit constraints.
-    ///
-    /// # Returns
-    ///
-    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
-    ///         with an error 3. if error occurs on `leave`.
-    ///   `Ok` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
-    where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
-    {
-        self.enter()?;
-        let res = f(self);
-        self.leave()?;
-        res
+#[cfg(feature = "std")]
+impl Default for Limits {
+    fn default() -> Self {
+        Self { depth: 500 }
     }
 }
 
-/// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
+/// `Limited` wraps an object and provides functions for enforcing limits.
 #[cfg(feature = "std")]
-pub struct DepthLimitedRead<R: Read> {
-    pub inner: R,
-    pub(crate) depth_remaining: u32,
+pub struct Limited<L> {
+    pub inner: L,
+    pub(crate) limits: Limits,
 }
 
 #[cfg(feature = "std")]
-impl<R: Read> DepthLimitedRead<R> {
-    /// Constructs a new `DepthLimitedRead`.
+impl<L> Limited<L> {
+    /// Constructs a new `Limited`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
     /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth_limit: u32) -> Self {
-        DepthLimitedRead {
-            inner,
-            depth_remaining: depth_limit,
-        }
+    pub fn new(inner: L, limits: Limits) -> Self {
+        Limited { inner, limits }
     }
-}
 
-#[cfg(feature = "std")]
-impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> core::result::Result<(), Error> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
+    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut Self) -> Result<T>,
+    {
+        if let Some(depth) = self.limits.depth.checked_sub(1) {
+            self.limits.depth = depth;
         } else {
             return Err(Error::DepthLimitExceeded);
         }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<R: Read> Read for DepthLimitedRead<R> {
-    /// Forwards the read operation to the wrapped object.
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.inner.read(buf)
-    }
-}
-
-/// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
-#[cfg(feature = "std")]
-pub struct DepthLimitedWrite<W: Write> {
-    pub inner: W,
-    pub(crate) depth_remaining: u32,
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimitedWrite<W> {
-    /// Constructs a new `DepthLimitedWrite`.
-    ///
-    /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth_limit: u32) -> Self {
-        DepthLimitedWrite {
-            inner,
-            depth_remaining: depth_limit,
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> Result<()> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
-        } else {
-            return Err(Error::DepthLimitExceeded);
-        }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> Write for DepthLimitedWrite<W> {
-    /// Forwards the write operation to the wrapped object.
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.inner.write(buf)
-    }
-
-    /// Forwards the flush operation to the wrapped object.
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.inner.flush()
+        let res = f(self);
+        self.limits.depth = self.limits.depth.saturating_add(1);
+        res
     }
 }
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: DepthLimitedRead<BufReader<R>>,
+    reader: Limited<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth_limit: u32) -> Self {
+    fn new(r: R, limits: Limits) -> Self {
         Self {
-            reader: DepthLimitedRead {
+            reader: Limited {
                 inner: BufReader::new(r),
-                depth_remaining: depth_limit,
+                limits,
             },
             _s: PhantomData,
         }
@@ -431,15 +322,15 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -466,7 +357,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -482,8 +373,8 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -506,7 +397,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -530,7 +421,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -560,7 +451,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
+    fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
         ReadXdrIter::new(&mut r.inner, r.depth_remaining)
     }
 
@@ -568,88 +459,60 @@ where
     /// values that are read into the implementing type.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
-        r: &mut DepthLimitedRead<R>,
+        r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         ReadXdrIter::new(dec, r.depth_remaining)
     }
 
-    /// Construct the type from the XDR bytes, specifying a depth limit.
+    /// Construct the type from the XDR bytes.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+        let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            depth_limit,
+            limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+        let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
     #[cfg(feature = "base64")]
-    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
-        let mut enc = DepthLimitedWrite::new(
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+        let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            depth_limit,
+            limits,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
-    }
-
-    #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -662,7 +525,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -673,7 +536,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -681,7 +544,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -692,7 +555,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -700,7 +563,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -711,7 +574,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -719,7 +582,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -730,7 +593,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -738,35 +601,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -777,7 +640,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -787,7 +650,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -804,7 +667,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -819,35 +682,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
@@ -863,7 +726,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             w.write_all(self)?;
             w.write_all(&[0u8; 3][..pad_len(N)])?;
@@ -874,7 +737,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -889,7 +752,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -1222,7 +1085,7 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1245,7 +1108,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1261,7 +1124,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1281,7 +1144,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1620,7 +1483,7 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1643,7 +1506,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2003,7 +1866,7 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2026,7 +1889,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2057,7 +1920,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2080,17 +1943,13 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use super::{
-        DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_XDR_RW_DEPTH_LIMIT,
-    };
+    use super::*;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
@@ -2098,16 +1957,14 @@ mod tests {
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2117,8 +1974,7 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2130,7 +1986,7 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2142,7 +1998,7 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2153,23 +2009,21 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2179,7 +2033,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2190,9 +2044,9 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2202,9 +2056,9 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2242,19 +2096,18 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
 
     #[test]
     fn write_over_depth_limit_fail() {
-        let depth_limit = 3;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), depth_limit);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2264,13 +2117,13 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_depth_limit = 3;
-        let write_depth_limit = 5;
+        let read_limits = Limits { depth: 3 };
+        let write_limits = Limits { depth: 5 };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), write_depth_limit);
+        let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), read_depth_limit);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
         let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2392,7 +2245,7 @@ TypeVariant::TestArray2, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 match v {
                     TypeVariant::TestArray => r.with_limited_depth(|r| Ok(Self::TestArray(Box::new(TestArray::read_xdr(r)?)))),
 TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new(TestArray2::read_xdr(r)?)))),
@@ -2400,14 +2253,14 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2419,51 +2272,51 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
-TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
+                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
+TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, Frame<TestArray>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::TestArray(Box::new(t.0))))),
-TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::TestArray2(Box::new(t.0))))),
+                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, Frame<TestArray>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::TestArray(Box::new(t.0))))),
+TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::TestArray2(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
-TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
+                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(dec, r.limits).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
+TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.limits).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+                let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String, limits: Limits) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2529,7 +2382,7 @@ Self::TestArray2(_) => TypeVariant::TestArray2,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 match self {
                     Self::TestArray(v) => v.write_xdr(w),
 Self::TestArray2(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -2268,6 +2268,68 @@ mod test {
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
         }
     }
+
+    #[test]
+    fn length_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut lr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[test]
+    fn write_over_length_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 15,
+                ..Limits::default()
+            },
+        );
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected LengthLimitExceeded got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn read_over_length_limit_fail() {
+        let read_limits = Limits {
+            len: 15,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            len: 16,
+            ..Limits::default()
+        };
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(Vec::new(), read_limits);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
+    }
 }
 
 #[cfg(all(test, not(feature = "alloc")))]

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -273,12 +273,12 @@ impl<L> Limited<L> {
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
+            let res = f(self);
+            self.limits.depth = self.limits.depth.saturating_add(1);
+            res
         } else {
-            return Err(Error::DepthLimitExceeded);
+            Err(Error::DepthLimitExceeded)
         }
-        let res = f(self);
-        self.limits.depth = self.limits.depth.saturating_add(1);
-        res
     }
 }
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -219,6 +219,7 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
+    #[must_use]
     pub fn none() -> Self {
         Self {
             depth: u32::MAX,
@@ -226,6 +227,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
@@ -233,6 +235,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn len(len: usize) -> Self {
         Limits {
             len,

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -219,21 +219,21 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
-    fn none() -> Self {
+    pub fn none() -> Self {
         Self {
             depth: u32::MAX,
             len: usize::MAX,
         }
     }
 
-    fn depth(depth: u32) -> Self {
+    pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
             ..Limits::none()
         }
     }
 
-    fn len(len: usize) -> Self {
+    pub fn len(len: usize) -> Self {
         Limits {
             len,
             ..Limits::none()

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -51,14 +51,6 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
-///
-/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
-/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the
-/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
-
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
 /// compared on their `ErrorKind`.
@@ -204,172 +196,71 @@ where
 {
 }
 
-/// `DepthLimiter` is a trait designed for managing the depth of recursive operations.
-/// It provides a mechanism to limit recursion depth, and defines the behavior upon
-/// entering and leaving a recursion level.
-pub trait DepthLimiter {
-    /// A general error type for any type implementing, or an operation under the guard of
-    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
-    /// which is returned from `enter`.
-    type DepthLimiterError;
+/// `Limits` contains the limits that a limited reader or writer will be
+/// constrained to.
+#[cfg(feature = "std")]
+pub struct Limits {
+    /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+    ///
+    /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+    /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+    /// For more information about Rust's stack size limit, refer to the
+    /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+    pub depth: u32,
+}
 
-    /// Defines the behavior for entering a new recursion level.
-    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
-    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Defines the behavior for leaving a recursion level.
-    /// A `DepthLimiterError` is returned if an error occurs.
-    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Wraps a given function `f` with depth limiting guards.
-    /// It triggers an `enter` before, and a `leave` after the execution of `f`.
-    ///
-    /// # Parameters
-    ///
-    /// - `f`: The function to be executed under depth limit constraints.
-    ///
-    /// # Returns
-    ///
-    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
-    ///         with an error 3. if error occurs on `leave`.
-    ///   `Ok` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
-    where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
-    {
-        self.enter()?;
-        let res = f(self);
-        self.leave()?;
-        res
+#[cfg(feature = "std")]
+impl Default for Limits {
+    fn default() -> Self {
+        Self { depth: 500 }
     }
 }
 
-/// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
+/// `Limited` wraps an object and provides functions for enforcing limits.
 #[cfg(feature = "std")]
-pub struct DepthLimitedRead<R: Read> {
-    pub inner: R,
-    pub(crate) depth_remaining: u32,
+pub struct Limited<L> {
+    pub inner: L,
+    pub(crate) limits: Limits,
 }
 
 #[cfg(feature = "std")]
-impl<R: Read> DepthLimitedRead<R> {
-    /// Constructs a new `DepthLimitedRead`.
+impl<L> Limited<L> {
+    /// Constructs a new `Limited`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
     /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth_limit: u32) -> Self {
-        DepthLimitedRead {
-            inner,
-            depth_remaining: depth_limit,
-        }
+    pub fn new(inner: L, limits: Limits) -> Self {
+        Limited { inner, limits }
     }
-}
 
-#[cfg(feature = "std")]
-impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> core::result::Result<(), Error> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
+    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut Self) -> Result<T>,
+    {
+        if let Some(depth) = self.limits.depth.checked_sub(1) {
+            self.limits.depth = depth;
         } else {
             return Err(Error::DepthLimitExceeded);
         }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<R: Read> Read for DepthLimitedRead<R> {
-    /// Forwards the read operation to the wrapped object.
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.inner.read(buf)
-    }
-}
-
-/// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
-#[cfg(feature = "std")]
-pub struct DepthLimitedWrite<W: Write> {
-    pub inner: W,
-    pub(crate) depth_remaining: u32,
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimitedWrite<W> {
-    /// Constructs a new `DepthLimitedWrite`.
-    ///
-    /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth_limit: u32) -> Self {
-        DepthLimitedWrite {
-            inner,
-            depth_remaining: depth_limit,
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> Result<()> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
-        } else {
-            return Err(Error::DepthLimitExceeded);
-        }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> Write for DepthLimitedWrite<W> {
-    /// Forwards the write operation to the wrapped object.
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.inner.write(buf)
-    }
-
-    /// Forwards the flush operation to the wrapped object.
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.inner.flush()
+        let res = f(self);
+        self.limits.depth = self.limits.depth.saturating_add(1);
+        res
     }
 }
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: DepthLimitedRead<BufReader<R>>,
+    reader: Limited<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth_limit: u32) -> Self {
+    fn new(r: R, limits: Limits) -> Self {
         Self {
-            reader: DepthLimitedRead {
+            reader: Limited {
                 inner: BufReader::new(r),
-                depth_remaining: depth_limit,
+                limits,
             },
             _s: PhantomData,
         }
@@ -431,15 +322,15 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -466,7 +357,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -482,8 +373,8 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -506,7 +397,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -530,7 +421,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -560,7 +451,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
+    fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
         ReadXdrIter::new(&mut r.inner, r.depth_remaining)
     }
 
@@ -568,88 +459,60 @@ where
     /// values that are read into the implementing type.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
-        r: &mut DepthLimitedRead<R>,
+        r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         ReadXdrIter::new(dec, r.depth_remaining)
     }
 
-    /// Construct the type from the XDR bytes, specifying a depth limit.
+    /// Construct the type from the XDR bytes.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+        let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            depth_limit,
+            limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+        let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
     #[cfg(feature = "base64")]
-    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
-        let mut enc = DepthLimitedWrite::new(
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+        let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            depth_limit,
+            limits,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
-    }
-
-    #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -662,7 +525,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -673,7 +536,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -681,7 +544,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -692,7 +555,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -700,7 +563,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -711,7 +574,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -719,7 +582,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -730,7 +593,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -738,35 +601,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -777,7 +640,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -787,7 +650,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -804,7 +667,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -819,35 +682,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
@@ -863,7 +726,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             w.write_all(self)?;
             w.write_all(&[0u8; 3][..pad_len(N)])?;
@@ -874,7 +737,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -889,7 +752,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -1222,7 +1085,7 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1245,7 +1108,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1261,7 +1124,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1281,7 +1144,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1620,7 +1483,7 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1643,7 +1506,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2003,7 +1866,7 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2026,7 +1889,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2057,7 +1920,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2080,17 +1943,13 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use super::{
-        DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_XDR_RW_DEPTH_LIMIT,
-    };
+    use super::*;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
@@ -2098,16 +1957,14 @@ mod tests {
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2117,8 +1974,7 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2130,7 +1986,7 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2142,7 +1998,7 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2153,23 +2009,21 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2179,7 +2033,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2190,9 +2044,9 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2202,9 +2056,9 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2242,19 +2096,18 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
 
     #[test]
     fn write_over_depth_limit_fail() {
-        let depth_limit = 3;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), depth_limit);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2264,13 +2117,13 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_depth_limit = 3;
-        let write_depth_limit = 5;
+        let read_limits = Limits { depth: 3 };
+        let write_limits = Limits { depth: 5 };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), write_depth_limit);
+        let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), read_depth_limit);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
         let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2456,7 +2309,7 @@ Self::FbaMessage => "FbaMessage",
 
         impl ReadXdr for MessageType {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -2467,7 +2320,7 @@ Self::FbaMessage => "FbaMessage",
 
         impl WriteXdr for MessageType {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -2562,7 +2415,7 @@ Self::Blue => "Blue",
 
         impl ReadXdr for Color {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -2573,7 +2426,7 @@ Self::Blue => "Blue",
 
         impl WriteXdr for Color {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -2668,7 +2521,7 @@ Self::Blue2 => "Blue2",
 
         impl ReadXdr for Color2 {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -2679,7 +2532,7 @@ Self::Blue2 => "Blue2",
 
         impl WriteXdr for Color2 {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -2773,7 +2626,7 @@ TypeVariant::Color2, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 match v {
                     TypeVariant::MessageType => r.with_limited_depth(|r| Ok(Self::MessageType(Box::new(MessageType::read_xdr(r)?)))),
 TypeVariant::Color => r.with_limited_depth(|r| Ok(Self::Color(Box::new(Color::read_xdr(r)?)))),
@@ -2782,14 +2635,14 @@ TypeVariant::Color2 => r.with_limited_depth(|r| Ok(Self::Color2(Box::new(Color2:
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2801,54 +2654,54 @@ TypeVariant::Color2 => r.with_limited_depth(|r| Ok(Self::Color2(Box::new(Color2:
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, Frame<MessageType>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MessageType(Box::new(t.0))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Frame<Color2>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Color2(Box::new(t.0))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, Frame<MessageType>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MessageType(Box::new(t.0))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Frame<Color2>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Color2(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(dec, r.limits).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, r.limits).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(dec, r.limits).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+                let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String, limits: Limits) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2918,7 +2771,7 @@ Self::Color2(_) => TypeVariant::Color2,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 match self {
                     Self::MessageType(v) => v.write_xdr(w),
 Self::Color(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -2268,6 +2268,68 @@ mod test {
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
         }
     }
+
+    #[test]
+    fn length_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut lr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[test]
+    fn write_over_length_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 15,
+                ..Limits::default()
+            },
+        );
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected LengthLimitExceeded got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn read_over_length_limit_fail() {
+        let read_limits = Limits {
+            len: 15,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            len: 16,
+            ..Limits::default()
+        };
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(Vec::new(), read_limits);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
+    }
 }
 
 #[cfg(all(test, not(feature = "alloc")))]

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -273,12 +273,12 @@ impl<L> Limited<L> {
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
+            let res = f(self);
+            self.limits.depth = self.limits.depth.saturating_add(1);
+            res
         } else {
-            return Err(Error::DepthLimitExceeded);
+            Err(Error::DepthLimitExceeded)
         }
-        let res = f(self);
-        self.limits.depth = self.limits.depth.saturating_add(1);
-        res
     }
 }
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -219,6 +219,7 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
+    #[must_use]
     pub fn none() -> Self {
         Self {
             depth: u32::MAX,
@@ -226,6 +227,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
@@ -233,6 +235,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn len(len: usize) -> Self {
         Limits {
             len,

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -69,6 +69,7 @@ pub enum Error {
     DepthLimitExceeded,
     #[cfg(feature = "serde_json")]
     Json(serde_json::Error),
+    LengthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -117,6 +118,7 @@ impl fmt::Display for Error {
             Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
             #[cfg(feature = "serde_json")]
             Error::Json(e) => write!(f, "{e}"),
+            Error::LengthLimitExceeded => write!(f, "length limit exceeded"),
         }
     }
 }
@@ -199,6 +201,7 @@ where
 /// `Limits` contains the limits that a limited reader or writer will be
 /// constrained to.
 #[cfg(feature = "std")]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Limits {
     /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
     ///
@@ -207,12 +210,18 @@ pub struct Limits {
     /// For more information about Rust's stack size limit, refer to the
     /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
     pub depth: u32,
+
+    /// Defines the maximum number of bytes that will be read or read.
+    pub len: usize,
 }
 
 #[cfg(feature = "std")]
 impl Default for Limits {
     fn default() -> Self {
-        Self { depth: 500 }
+        Self {
+            depth: 500,
+            len: usize::MAX,
+        }
     }
 }
 
@@ -233,7 +242,16 @@ impl<L> Limited<L> {
         Limited { inner, limits }
     }
 
-    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+        if let Some(len) = self.limits.len.checked_sub(len) {
+            self.limits.len = len;
+            Ok(())
+        } else {
+            Err(Error::LengthLimitExceeded)
+        }
+    }
+
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
     where
         F: FnOnce(&mut Self) -> Result<T>,
     {
@@ -245,6 +263,40 @@ impl<L> Limited<L> {
         let res = f(self);
         self.limits.depth = self.limits.depth.saturating_add(1);
         res
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: BufRead> BufRead for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        self.inner.fill_buf()
+    }
+
+    /// Forwards the read operation to the wrapped object.
+    fn consume(&mut self, amt: usize) {
+        self.inner.consume(amt);
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for Limited<W> {
+    /// Forwards the write operation to the wrapped object.
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    /// Forwards the flush operation to the wrapped object.
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
     }
 }
 
@@ -285,7 +337,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.inner.fill_buf() {
+        match self.reader.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -332,7 +384,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -376,7 +428,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -452,7 +504,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
+        ReadXdrIter::new(&mut r.inner, r.limits.clone())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -462,7 +514,7 @@ where
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining)
+        ReadXdrIter::new(dec, r.limits.clone())
     }
 
     /// Construct the type from the XDR bytes.
@@ -528,6 +580,7 @@ impl ReadXdr for i32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i32::from_be_bytes(b))
         })
@@ -538,7 +591,10 @@ impl WriteXdr for i32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -547,6 +603,7 @@ impl ReadXdr for u32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u32::from_be_bytes(b))
         })
@@ -557,7 +614,10 @@ impl WriteXdr for u32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -566,6 +626,7 @@ impl ReadXdr for i64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i64::from_be_bytes(b))
         })
@@ -576,7 +637,10 @@ impl WriteXdr for i64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -585,6 +649,7 @@ impl ReadXdr for u64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u64::from_be_bytes(b))
         })
@@ -595,7 +660,10 @@ impl WriteXdr for u64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -631,6 +699,7 @@ impl ReadXdr for bool {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             let b = i == 1;
             Ok(b)
@@ -642,6 +711,7 @@ impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
         })
@@ -652,6 +722,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             match i {
                 0 => Ok(None),
@@ -669,6 +740,7 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
                 t.write_xdr(w)?;
@@ -712,9 +784,12 @@ impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(N)?;
+            let padding = pad_len(N);
+            r.consume_len(padding)?;
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
-            let pad = &mut [0u8; 3][..pad_len(N)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -728,8 +803,11 @@ impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(N)?;
+            let padding = pad_len(N);
+            w.consume_len(padding)?;
             w.write_all(self)?;
-            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            w.write_all(&[0u8; 3][..padding])?;
             Ok(())
         })
     }
@@ -1087,15 +1165,20 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1110,12 +1193,17 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1126,6 +1214,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
@@ -1146,6 +1235,7 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1485,15 +1575,20 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1508,6 +1603,11 @@ impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1868,15 +1968,21 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
+
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1891,12 +1997,17 @@ impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1925,6 +2036,7 @@ where
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
         //  follow the frame header.
+        r.consume_len(core::mem::size_of::<u32>())?;
         let header = u32::read_xdr(r)?;
         // TODO: Use the length and cap the length we'll read from `r`.
         let last_record = header >> 31 == 1;
@@ -1948,16 +2060,14 @@ mod tests {
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
@@ -1986,11 +2096,8 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1998,11 +2105,8 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
@@ -2044,10 +2148,7 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -2056,10 +2157,7 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
@@ -2096,10 +2194,22 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
+        let mut dlr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
@@ -2107,7 +2217,13 @@ mod test {
     #[test]
     fn write_over_depth_limit_fail() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 3,
+                len: usize::MAX,
+            },
+        );
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2117,8 +2233,14 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_limits = Limits { depth: 3 };
-        let write_limits = Limits { depth: 5 };
+        let read_limits = Limits {
+            depth: 3,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            depth: 5,
+            ..Limits::default()
+        };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
         let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
@@ -2636,7 +2758,7 @@ TypeVariant::Color2 => r.with_limited_depth(|r| Ok(Self::Color2(Box::new(Color2:
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2655,7 +2777,7 @@ TypeVariant::Color2 => r.with_limited_depth(|r| Ok(Self::Color2(Box::new(Color2:
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2664,9 +2786,9 @@ TypeVariant::Color2 => r.with_limited_depth(|r| Ok(Self::Color2(Box::new(Color2:
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
                 }
             }
 
@@ -2674,9 +2796,9 @@ TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(&mut r.inner, r.li
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, Frame<MessageType>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MessageType(Box::new(t.0))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Frame<Color2>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Color2(Box::new(t.0))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, Frame<MessageType>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MessageType(Box::new(t.0))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Frame<Color2>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Color2(Box::new(t.0))))),
                 }
             }
 
@@ -2685,9 +2807,9 @@ TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Frame<Color2>>::new(&mut r.inne
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(dec, r.limits).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, r.limits).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(dec, r.limits).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -219,21 +219,21 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
-    fn none() -> Self {
+    pub fn none() -> Self {
         Self {
             depth: u32::MAX,
             len: usize::MAX,
         }
     }
 
-    fn depth(depth: u32) -> Self {
+    pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
             ..Limits::none()
         }
     }
 
-    fn len(len: usize) -> Self {
+    pub fn len(len: usize) -> Self {
         Limits {
             len,
             ..Limits::none()

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -51,14 +51,6 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
-///
-/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
-/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the
-/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
-
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
 /// compared on their `ErrorKind`.
@@ -204,172 +196,71 @@ where
 {
 }
 
-/// `DepthLimiter` is a trait designed for managing the depth of recursive operations.
-/// It provides a mechanism to limit recursion depth, and defines the behavior upon
-/// entering and leaving a recursion level.
-pub trait DepthLimiter {
-    /// A general error type for any type implementing, or an operation under the guard of
-    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
-    /// which is returned from `enter`.
-    type DepthLimiterError;
+/// `Limits` contains the limits that a limited reader or writer will be
+/// constrained to.
+#[cfg(feature = "std")]
+pub struct Limits {
+    /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+    ///
+    /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+    /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+    /// For more information about Rust's stack size limit, refer to the
+    /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+    pub depth: u32,
+}
 
-    /// Defines the behavior for entering a new recursion level.
-    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
-    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Defines the behavior for leaving a recursion level.
-    /// A `DepthLimiterError` is returned if an error occurs.
-    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Wraps a given function `f` with depth limiting guards.
-    /// It triggers an `enter` before, and a `leave` after the execution of `f`.
-    ///
-    /// # Parameters
-    ///
-    /// - `f`: The function to be executed under depth limit constraints.
-    ///
-    /// # Returns
-    ///
-    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
-    ///         with an error 3. if error occurs on `leave`.
-    ///   `Ok` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
-    where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
-    {
-        self.enter()?;
-        let res = f(self);
-        self.leave()?;
-        res
+#[cfg(feature = "std")]
+impl Default for Limits {
+    fn default() -> Self {
+        Self { depth: 500 }
     }
 }
 
-/// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
+/// `Limited` wraps an object and provides functions for enforcing limits.
 #[cfg(feature = "std")]
-pub struct DepthLimitedRead<R: Read> {
-    pub inner: R,
-    pub(crate) depth_remaining: u32,
+pub struct Limited<L> {
+    pub inner: L,
+    pub(crate) limits: Limits,
 }
 
 #[cfg(feature = "std")]
-impl<R: Read> DepthLimitedRead<R> {
-    /// Constructs a new `DepthLimitedRead`.
+impl<L> Limited<L> {
+    /// Constructs a new `Limited`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
     /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth_limit: u32) -> Self {
-        DepthLimitedRead {
-            inner,
-            depth_remaining: depth_limit,
-        }
+    pub fn new(inner: L, limits: Limits) -> Self {
+        Limited { inner, limits }
     }
-}
 
-#[cfg(feature = "std")]
-impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> core::result::Result<(), Error> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
+    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut Self) -> Result<T>,
+    {
+        if let Some(depth) = self.limits.depth.checked_sub(1) {
+            self.limits.depth = depth;
         } else {
             return Err(Error::DepthLimitExceeded);
         }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<R: Read> Read for DepthLimitedRead<R> {
-    /// Forwards the read operation to the wrapped object.
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.inner.read(buf)
-    }
-}
-
-/// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
-#[cfg(feature = "std")]
-pub struct DepthLimitedWrite<W: Write> {
-    pub inner: W,
-    pub(crate) depth_remaining: u32,
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimitedWrite<W> {
-    /// Constructs a new `DepthLimitedWrite`.
-    ///
-    /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth_limit: u32) -> Self {
-        DepthLimitedWrite {
-            inner,
-            depth_remaining: depth_limit,
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> Result<()> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
-        } else {
-            return Err(Error::DepthLimitExceeded);
-        }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> Write for DepthLimitedWrite<W> {
-    /// Forwards the write operation to the wrapped object.
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.inner.write(buf)
-    }
-
-    /// Forwards the flush operation to the wrapped object.
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.inner.flush()
+        let res = f(self);
+        self.limits.depth = self.limits.depth.saturating_add(1);
+        res
     }
 }
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: DepthLimitedRead<BufReader<R>>,
+    reader: Limited<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth_limit: u32) -> Self {
+    fn new(r: R, limits: Limits) -> Self {
         Self {
-            reader: DepthLimitedRead {
+            reader: Limited {
                 inner: BufReader::new(r),
-                depth_remaining: depth_limit,
+                limits,
             },
             _s: PhantomData,
         }
@@ -431,15 +322,15 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -466,7 +357,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -482,8 +373,8 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -506,7 +397,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -530,7 +421,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -560,7 +451,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
+    fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
         ReadXdrIter::new(&mut r.inner, r.depth_remaining)
     }
 
@@ -568,88 +459,60 @@ where
     /// values that are read into the implementing type.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
-        r: &mut DepthLimitedRead<R>,
+        r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         ReadXdrIter::new(dec, r.depth_remaining)
     }
 
-    /// Construct the type from the XDR bytes, specifying a depth limit.
+    /// Construct the type from the XDR bytes.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+        let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            depth_limit,
+            limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+        let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
     #[cfg(feature = "base64")]
-    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
-        let mut enc = DepthLimitedWrite::new(
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+        let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            depth_limit,
+            limits,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
-    }
-
-    #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -662,7 +525,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -673,7 +536,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -681,7 +544,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -692,7 +555,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -700,7 +563,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -711,7 +574,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -719,7 +582,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -730,7 +593,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -738,35 +601,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -777,7 +640,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -787,7 +650,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -804,7 +667,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -819,35 +682,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
@@ -863,7 +726,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             w.write_all(self)?;
             w.write_all(&[0u8; 3][..pad_len(N)])?;
@@ -874,7 +737,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -889,7 +752,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -1222,7 +1085,7 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1245,7 +1108,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1261,7 +1124,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1281,7 +1144,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1620,7 +1483,7 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1643,7 +1506,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2003,7 +1866,7 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2026,7 +1889,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2057,7 +1920,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2080,17 +1943,13 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use super::{
-        DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_XDR_RW_DEPTH_LIMIT,
-    };
+    use super::*;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
@@ -2098,16 +1957,14 @@ mod tests {
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2117,8 +1974,7 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2130,7 +1986,7 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2142,7 +1998,7 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2153,23 +2009,21 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2179,7 +2033,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2190,9 +2044,9 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2202,9 +2056,9 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2242,19 +2096,18 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
 
     #[test]
     fn write_over_depth_limit_fail() {
-        let depth_limit = 3;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), depth_limit);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2264,13 +2117,13 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_depth_limit = 3;
-        let write_depth_limit = 5;
+        let read_limits = Limits { depth: 3 };
+        let write_limits = Limits { depth: 5 };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), write_depth_limit);
+        let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), read_depth_limit);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
         let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2383,7 +2236,7 @@ Self::Offer => "Offer",
 
         impl ReadXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -2394,7 +2247,7 @@ Self::Offer => "Offer",
 
         impl WriteXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -2423,7 +2276,7 @@ pub struct MyUnionOne {
 
 impl ReadXdr for MyUnionOne {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             Ok(Self{
               some_int: i32::read_xdr(r)?,
@@ -2434,7 +2287,7 @@ impl ReadXdr for MyUnionOne {
 
 impl WriteXdr for MyUnionOne {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             self.some_int.write_xdr(w)?;
             Ok(())
@@ -2459,7 +2312,7 @@ pub struct MyUnionTwo {
 
         impl ReadXdr for MyUnionTwo {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       some_int: i32::read_xdr(r)?,
@@ -2471,7 +2324,7 @@ foo: i32::read_xdr(r)?,
 
         impl WriteXdr for MyUnionTwo {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     self.some_int.write_xdr(w)?;
 self.foo.write_xdr(w)?;
@@ -2571,7 +2424,7 @@ Self::Offer => UnionKey::Offer,
 
         impl ReadXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     let dv: UnionKey = <UnionKey as ReadXdr>::read_xdr(r)?;
                     #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
@@ -2589,7 +2442,7 @@ UnionKey::Offer => Self::Offer,
 
         impl WriteXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     self.discriminant().write_xdr(w)?;
                     #[allow(clippy::match_same_arms)]
@@ -2705,7 +2558,7 @@ TypeVariant::MyUnionTwo, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 match v {
                     TypeVariant::UnionKey => r.with_limited_depth(|r| Ok(Self::UnionKey(Box::new(UnionKey::read_xdr(r)?)))),
 TypeVariant::Foo => r.with_limited_depth(|r| Ok(Self::Foo(Box::new(Foo::read_xdr(r)?)))),
@@ -2716,14 +2569,14 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2735,60 +2588,60 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
-TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
+                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
+TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
-TypeVariant::Foo => Box::new(ReadXdrIter::<_, Frame<Foo>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Foo(Box::new(t.0))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
-TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, Frame<MyUnionOne>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t.0))))),
-TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t.0))))),
+                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
+TypeVariant::Foo => Box::new(ReadXdrIter::<_, Frame<Foo>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Foo(Box::new(t.0))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
+TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, Frame<MyUnionOne>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t.0))))),
+TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
-TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
+                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.limits).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(dec, r.limits).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, r.limits).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(dec, r.limits).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
+TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.limits).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+                let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String, limits: Limits) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2866,7 +2719,7 @@ Self::MyUnionTwo(_) => TypeVariant::MyUnionTwo,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 match self {
                     Self::UnionKey(v) => v.write_xdr(w),
 Self::Foo(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -2268,6 +2268,68 @@ mod test {
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
         }
     }
+
+    #[test]
+    fn length_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut lr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[test]
+    fn write_over_length_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 15,
+                ..Limits::default()
+            },
+        );
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected LengthLimitExceeded got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn read_over_length_limit_fail() {
+        let read_limits = Limits {
+            len: 15,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            len: 16,
+            ..Limits::default()
+        };
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(Vec::new(), read_limits);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
+    }
 }
 
 #[cfg(all(test, not(feature = "alloc")))]

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -273,12 +273,12 @@ impl<L> Limited<L> {
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
+            let res = f(self);
+            self.limits.depth = self.limits.depth.saturating_add(1);
+            res
         } else {
-            return Err(Error::DepthLimitExceeded);
+            Err(Error::DepthLimitExceeded)
         }
-        let res = f(self);
-        self.limits.depth = self.limits.depth.saturating_add(1);
-        res
     }
 }
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -219,6 +219,7 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
+    #[must_use]
     pub fn none() -> Self {
         Self {
             depth: u32::MAX,
@@ -226,6 +227,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
@@ -233,6 +235,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn len(len: usize) -> Self {
         Limits {
             len,

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -69,6 +69,7 @@ pub enum Error {
     DepthLimitExceeded,
     #[cfg(feature = "serde_json")]
     Json(serde_json::Error),
+    LengthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -117,6 +118,7 @@ impl fmt::Display for Error {
             Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
             #[cfg(feature = "serde_json")]
             Error::Json(e) => write!(f, "{e}"),
+            Error::LengthLimitExceeded => write!(f, "length limit exceeded"),
         }
     }
 }
@@ -199,6 +201,7 @@ where
 /// `Limits` contains the limits that a limited reader or writer will be
 /// constrained to.
 #[cfg(feature = "std")]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Limits {
     /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
     ///
@@ -207,12 +210,18 @@ pub struct Limits {
     /// For more information about Rust's stack size limit, refer to the
     /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
     pub depth: u32,
+
+    /// Defines the maximum number of bytes that will be read or read.
+    pub len: usize,
 }
 
 #[cfg(feature = "std")]
 impl Default for Limits {
     fn default() -> Self {
-        Self { depth: 500 }
+        Self {
+            depth: 500,
+            len: usize::MAX,
+        }
     }
 }
 
@@ -233,7 +242,16 @@ impl<L> Limited<L> {
         Limited { inner, limits }
     }
 
-    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+        if let Some(len) = self.limits.len.checked_sub(len) {
+            self.limits.len = len;
+            Ok(())
+        } else {
+            Err(Error::LengthLimitExceeded)
+        }
+    }
+
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
     where
         F: FnOnce(&mut Self) -> Result<T>,
     {
@@ -245,6 +263,40 @@ impl<L> Limited<L> {
         let res = f(self);
         self.limits.depth = self.limits.depth.saturating_add(1);
         res
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: BufRead> BufRead for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        self.inner.fill_buf()
+    }
+
+    /// Forwards the read operation to the wrapped object.
+    fn consume(&mut self, amt: usize) {
+        self.inner.consume(amt);
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for Limited<W> {
+    /// Forwards the write operation to the wrapped object.
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    /// Forwards the flush operation to the wrapped object.
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
     }
 }
 
@@ -285,7 +337,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.inner.fill_buf() {
+        match self.reader.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -332,7 +384,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -376,7 +428,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -452,7 +504,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
+        ReadXdrIter::new(&mut r.inner, r.limits.clone())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -462,7 +514,7 @@ where
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining)
+        ReadXdrIter::new(dec, r.limits.clone())
     }
 
     /// Construct the type from the XDR bytes.
@@ -528,6 +580,7 @@ impl ReadXdr for i32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i32::from_be_bytes(b))
         })
@@ -538,7 +591,10 @@ impl WriteXdr for i32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -547,6 +603,7 @@ impl ReadXdr for u32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u32::from_be_bytes(b))
         })
@@ -557,7 +614,10 @@ impl WriteXdr for u32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -566,6 +626,7 @@ impl ReadXdr for i64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i64::from_be_bytes(b))
         })
@@ -576,7 +637,10 @@ impl WriteXdr for i64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -585,6 +649,7 @@ impl ReadXdr for u64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u64::from_be_bytes(b))
         })
@@ -595,7 +660,10 @@ impl WriteXdr for u64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -631,6 +699,7 @@ impl ReadXdr for bool {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             let b = i == 1;
             Ok(b)
@@ -642,6 +711,7 @@ impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
         })
@@ -652,6 +722,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             match i {
                 0 => Ok(None),
@@ -669,6 +740,7 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
                 t.write_xdr(w)?;
@@ -712,9 +784,12 @@ impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(N)?;
+            let padding = pad_len(N);
+            r.consume_len(padding)?;
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
-            let pad = &mut [0u8; 3][..pad_len(N)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -728,8 +803,11 @@ impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(N)?;
+            let padding = pad_len(N);
+            w.consume_len(padding)?;
             w.write_all(self)?;
-            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            w.write_all(&[0u8; 3][..padding])?;
             Ok(())
         })
     }
@@ -1087,15 +1165,20 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1110,12 +1193,17 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1126,6 +1214,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
@@ -1146,6 +1235,7 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1485,15 +1575,20 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1508,6 +1603,11 @@ impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1868,15 +1968,21 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
+
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1891,12 +1997,17 @@ impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1925,6 +2036,7 @@ where
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
         //  follow the frame header.
+        r.consume_len(core::mem::size_of::<u32>())?;
         let header = u32::read_xdr(r)?;
         // TODO: Use the length and cap the length we'll read from `r`.
         let last_record = header >> 31 == 1;
@@ -1948,16 +2060,14 @@ mod tests {
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
@@ -1986,11 +2096,8 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1998,11 +2105,8 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
@@ -2044,10 +2148,7 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -2056,10 +2157,7 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
@@ -2096,10 +2194,22 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
+        let mut dlr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
@@ -2107,7 +2217,13 @@ mod test {
     #[test]
     fn write_over_depth_limit_fail() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 3,
+                len: usize::MAX,
+            },
+        );
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2117,8 +2233,14 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_limits = Limits { depth: 3 };
-        let write_limits = Limits { depth: 5 };
+        let read_limits = Limits {
+            depth: 3,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            depth: 5,
+            ..Limits::default()
+        };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
         let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
@@ -2570,7 +2692,7 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2589,7 +2711,7 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2598,11 +2720,11 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
-TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
+                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
+TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
                 }
             }
 
@@ -2610,11 +2732,11 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(&mut r.inn
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
-TypeVariant::Foo => Box::new(ReadXdrIter::<_, Frame<Foo>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Foo(Box::new(t.0))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
-TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, Frame<MyUnionOne>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t.0))))),
-TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t.0))))),
+                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
+TypeVariant::Foo => Box::new(ReadXdrIter::<_, Frame<Foo>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Foo(Box::new(t.0))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
+TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, Frame<MyUnionOne>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t.0))))),
+TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t.0))))),
                 }
             }
 
@@ -2623,11 +2745,11 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(&mu
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.limits).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(dec, r.limits).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, r.limits).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(dec, r.limits).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
-TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.limits).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
+                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
+TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -219,21 +219,21 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
-    fn none() -> Self {
+    pub fn none() -> Self {
         Self {
             depth: u32::MAX,
             len: usize::MAX,
         }
     }
 
-    fn depth(depth: u32) -> Self {
+    pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
             ..Limits::none()
         }
     }
 
-    fn len(len: usize) -> Self {
+    pub fn len(len: usize) -> Self {
         Limits {
             len,
             ..Limits::none()

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -69,6 +69,7 @@ pub enum Error {
     DepthLimitExceeded,
     #[cfg(feature = "serde_json")]
     Json(serde_json::Error),
+    LengthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -117,6 +118,7 @@ impl fmt::Display for Error {
             Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
             #[cfg(feature = "serde_json")]
             Error::Json(e) => write!(f, "{e}"),
+            Error::LengthLimitExceeded => write!(f, "length limit exceeded"),
         }
     }
 }
@@ -199,6 +201,7 @@ where
 /// `Limits` contains the limits that a limited reader or writer will be
 /// constrained to.
 #[cfg(feature = "std")]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Limits {
     /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
     ///
@@ -207,12 +210,18 @@ pub struct Limits {
     /// For more information about Rust's stack size limit, refer to the
     /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
     pub depth: u32,
+
+    /// Defines the maximum number of bytes that will be read or read.
+    pub len: usize,
 }
 
 #[cfg(feature = "std")]
 impl Default for Limits {
     fn default() -> Self {
-        Self { depth: 500 }
+        Self {
+            depth: 500,
+            len: usize::MAX,
+        }
     }
 }
 
@@ -233,7 +242,16 @@ impl<L> Limited<L> {
         Limited { inner, limits }
     }
 
-    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+        if let Some(len) = self.limits.len.checked_sub(len) {
+            self.limits.len = len;
+            Ok(())
+        } else {
+            Err(Error::LengthLimitExceeded)
+        }
+    }
+
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
     where
         F: FnOnce(&mut Self) -> Result<T>,
     {
@@ -245,6 +263,40 @@ impl<L> Limited<L> {
         let res = f(self);
         self.limits.depth = self.limits.depth.saturating_add(1);
         res
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: BufRead> BufRead for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        self.inner.fill_buf()
+    }
+
+    /// Forwards the read operation to the wrapped object.
+    fn consume(&mut self, amt: usize) {
+        self.inner.consume(amt);
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for Limited<W> {
+    /// Forwards the write operation to the wrapped object.
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    /// Forwards the flush operation to the wrapped object.
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
     }
 }
 
@@ -285,7 +337,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.inner.fill_buf() {
+        match self.reader.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -332,7 +384,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -376,7 +428,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -452,7 +504,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
+        ReadXdrIter::new(&mut r.inner, r.limits.clone())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -462,7 +514,7 @@ where
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining)
+        ReadXdrIter::new(dec, r.limits.clone())
     }
 
     /// Construct the type from the XDR bytes.
@@ -528,6 +580,7 @@ impl ReadXdr for i32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i32::from_be_bytes(b))
         })
@@ -538,7 +591,10 @@ impl WriteXdr for i32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -547,6 +603,7 @@ impl ReadXdr for u32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u32::from_be_bytes(b))
         })
@@ -557,7 +614,10 @@ impl WriteXdr for u32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -566,6 +626,7 @@ impl ReadXdr for i64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i64::from_be_bytes(b))
         })
@@ -576,7 +637,10 @@ impl WriteXdr for i64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -585,6 +649,7 @@ impl ReadXdr for u64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u64::from_be_bytes(b))
         })
@@ -595,7 +660,10 @@ impl WriteXdr for u64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -631,6 +699,7 @@ impl ReadXdr for bool {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             let b = i == 1;
             Ok(b)
@@ -642,6 +711,7 @@ impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
         })
@@ -652,6 +722,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             match i {
                 0 => Ok(None),
@@ -669,6 +740,7 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
                 t.write_xdr(w)?;
@@ -712,9 +784,12 @@ impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(N)?;
+            let padding = pad_len(N);
+            r.consume_len(padding)?;
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
-            let pad = &mut [0u8; 3][..pad_len(N)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -728,8 +803,11 @@ impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(N)?;
+            let padding = pad_len(N);
+            w.consume_len(padding)?;
             w.write_all(self)?;
-            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            w.write_all(&[0u8; 3][..padding])?;
             Ok(())
         })
     }
@@ -1087,15 +1165,20 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1110,12 +1193,17 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1126,6 +1214,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
@@ -1146,6 +1235,7 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1485,15 +1575,20 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1508,6 +1603,11 @@ impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1868,15 +1968,21 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
+
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1891,12 +1997,17 @@ impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1925,6 +2036,7 @@ where
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
         //  follow the frame header.
+        r.consume_len(core::mem::size_of::<u32>())?;
         let header = u32::read_xdr(r)?;
         // TODO: Use the length and cap the length we'll read from `r`.
         let last_record = header >> 31 == 1;
@@ -1948,16 +2060,14 @@ mod tests {
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
@@ -1986,11 +2096,8 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1998,11 +2105,8 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
@@ -2044,10 +2148,7 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -2056,10 +2157,7 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
@@ -2096,10 +2194,22 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
+        let mut dlr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
@@ -2107,7 +2217,13 @@ mod test {
     #[test]
     fn write_over_depth_limit_fail() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 3,
+                len: usize::MAX,
+            },
+        );
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2117,8 +2233,14 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_limits = Limits { depth: 3 };
-        let write_limits = Limits { depth: 5 };
+        let read_limits = Limits {
+            depth: 3,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            depth: 5,
+            ..Limits::default()
+        };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
         let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
@@ -2285,7 +2407,7 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2304,7 +2426,7 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2313,8 +2435,8 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
                 }
             }
 
@@ -2322,8 +2444,8 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inn
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Frame<Arr>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Arr(Box::new(t.0))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::HasOptions(Box::new(t.0))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Frame<Arr>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Arr(Box::new(t.0))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::HasOptions(Box::new(t.0))))),
                 }
             }
 
@@ -2332,8 +2454,8 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mu
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec, r.limits).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.limits).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -2268,6 +2268,68 @@ mod test {
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
         }
     }
+
+    #[test]
+    fn length_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut lr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[test]
+    fn write_over_length_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 15,
+                ..Limits::default()
+            },
+        );
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected LengthLimitExceeded got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn read_over_length_limit_fail() {
+        let read_limits = Limits {
+            len: 15,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            len: 16,
+            ..Limits::default()
+        };
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(Vec::new(), read_limits);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
+    }
 }
 
 #[cfg(all(test, not(feature = "alloc")))]

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -273,12 +273,12 @@ impl<L> Limited<L> {
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
+            let res = f(self);
+            self.limits.depth = self.limits.depth.saturating_add(1);
+            res
         } else {
-            return Err(Error::DepthLimitExceeded);
+            Err(Error::DepthLimitExceeded)
         }
-        let res = f(self);
-        self.limits.depth = self.limits.depth.saturating_add(1);
-        res
     }
 }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -219,6 +219,7 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
+    #[must_use]
     pub fn none() -> Self {
         Self {
             depth: u32::MAX,
@@ -226,6 +227,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
@@ -233,6 +235,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn len(len: usize) -> Self {
         Limits {
             len,

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -51,14 +51,6 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
-///
-/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
-/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the
-/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
-
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
 /// compared on their `ErrorKind`.
@@ -204,172 +196,71 @@ where
 {
 }
 
-/// `DepthLimiter` is a trait designed for managing the depth of recursive operations.
-/// It provides a mechanism to limit recursion depth, and defines the behavior upon
-/// entering and leaving a recursion level.
-pub trait DepthLimiter {
-    /// A general error type for any type implementing, or an operation under the guard of
-    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
-    /// which is returned from `enter`.
-    type DepthLimiterError;
+/// `Limits` contains the limits that a limited reader or writer will be
+/// constrained to.
+#[cfg(feature = "std")]
+pub struct Limits {
+    /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+    ///
+    /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+    /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+    /// For more information about Rust's stack size limit, refer to the
+    /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+    pub depth: u32,
+}
 
-    /// Defines the behavior for entering a new recursion level.
-    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
-    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Defines the behavior for leaving a recursion level.
-    /// A `DepthLimiterError` is returned if an error occurs.
-    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Wraps a given function `f` with depth limiting guards.
-    /// It triggers an `enter` before, and a `leave` after the execution of `f`.
-    ///
-    /// # Parameters
-    ///
-    /// - `f`: The function to be executed under depth limit constraints.
-    ///
-    /// # Returns
-    ///
-    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
-    ///         with an error 3. if error occurs on `leave`.
-    ///   `Ok` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
-    where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
-    {
-        self.enter()?;
-        let res = f(self);
-        self.leave()?;
-        res
+#[cfg(feature = "std")]
+impl Default for Limits {
+    fn default() -> Self {
+        Self { depth: 500 }
     }
 }
 
-/// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
+/// `Limited` wraps an object and provides functions for enforcing limits.
 #[cfg(feature = "std")]
-pub struct DepthLimitedRead<R: Read> {
-    pub inner: R,
-    pub(crate) depth_remaining: u32,
+pub struct Limited<L> {
+    pub inner: L,
+    pub(crate) limits: Limits,
 }
 
 #[cfg(feature = "std")]
-impl<R: Read> DepthLimitedRead<R> {
-    /// Constructs a new `DepthLimitedRead`.
+impl<L> Limited<L> {
+    /// Constructs a new `Limited`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
     /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth_limit: u32) -> Self {
-        DepthLimitedRead {
-            inner,
-            depth_remaining: depth_limit,
-        }
+    pub fn new(inner: L, limits: Limits) -> Self {
+        Limited { inner, limits }
     }
-}
 
-#[cfg(feature = "std")]
-impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> core::result::Result<(), Error> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
+    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut Self) -> Result<T>,
+    {
+        if let Some(depth) = self.limits.depth.checked_sub(1) {
+            self.limits.depth = depth;
         } else {
             return Err(Error::DepthLimitExceeded);
         }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<R: Read> Read for DepthLimitedRead<R> {
-    /// Forwards the read operation to the wrapped object.
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.inner.read(buf)
-    }
-}
-
-/// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
-#[cfg(feature = "std")]
-pub struct DepthLimitedWrite<W: Write> {
-    pub inner: W,
-    pub(crate) depth_remaining: u32,
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimitedWrite<W> {
-    /// Constructs a new `DepthLimitedWrite`.
-    ///
-    /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth_limit: u32) -> Self {
-        DepthLimitedWrite {
-            inner,
-            depth_remaining: depth_limit,
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> Result<()> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
-        } else {
-            return Err(Error::DepthLimitExceeded);
-        }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> Write for DepthLimitedWrite<W> {
-    /// Forwards the write operation to the wrapped object.
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.inner.write(buf)
-    }
-
-    /// Forwards the flush operation to the wrapped object.
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.inner.flush()
+        let res = f(self);
+        self.limits.depth = self.limits.depth.saturating_add(1);
+        res
     }
 }
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: DepthLimitedRead<BufReader<R>>,
+    reader: Limited<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth_limit: u32) -> Self {
+    fn new(r: R, limits: Limits) -> Self {
         Self {
-            reader: DepthLimitedRead {
+            reader: Limited {
                 inner: BufReader::new(r),
-                depth_remaining: depth_limit,
+                limits,
             },
             _s: PhantomData,
         }
@@ -431,15 +322,15 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -466,7 +357,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -482,8 +373,8 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -506,7 +397,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -530,7 +421,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -560,7 +451,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
+    fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
         ReadXdrIter::new(&mut r.inner, r.depth_remaining)
     }
 
@@ -568,88 +459,60 @@ where
     /// values that are read into the implementing type.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
-        r: &mut DepthLimitedRead<R>,
+        r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         ReadXdrIter::new(dec, r.depth_remaining)
     }
 
-    /// Construct the type from the XDR bytes, specifying a depth limit.
+    /// Construct the type from the XDR bytes.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+        let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            depth_limit,
+            limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+        let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
     #[cfg(feature = "base64")]
-    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
-        let mut enc = DepthLimitedWrite::new(
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+        let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            depth_limit,
+            limits,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
-    }
-
-    #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -662,7 +525,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -673,7 +536,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -681,7 +544,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -692,7 +555,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -700,7 +563,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -711,7 +574,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -719,7 +582,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -730,7 +593,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -738,35 +601,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -777,7 +640,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -787,7 +650,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -804,7 +667,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -819,35 +682,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
@@ -863,7 +726,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             w.write_all(self)?;
             w.write_all(&[0u8; 3][..pad_len(N)])?;
@@ -874,7 +737,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -889,7 +752,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -1222,7 +1085,7 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1245,7 +1108,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1261,7 +1124,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1281,7 +1144,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1620,7 +1483,7 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1643,7 +1506,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2003,7 +1866,7 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2026,7 +1889,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2057,7 +1920,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2080,17 +1943,13 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use super::{
-        DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_XDR_RW_DEPTH_LIMIT,
-    };
+    use super::*;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
@@ -2098,16 +1957,14 @@ mod tests {
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2117,8 +1974,7 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2130,7 +1986,7 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2142,7 +1998,7 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2153,23 +2009,21 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2179,7 +2033,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2190,9 +2044,9 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2202,9 +2056,9 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2242,19 +2096,18 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
 
     #[test]
     fn write_over_depth_limit_fail() {
-        let depth_limit = 3;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), depth_limit);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2264,13 +2117,13 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_depth_limit = 3;
-        let write_depth_limit = 5;
+        let read_limits = Limits { depth: 3 };
+        let write_limits = Limits { depth: 5 };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), write_depth_limit);
+        let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), read_depth_limit);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
         let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2322,7 +2175,7 @@ pub struct HasOptions {
 
         impl ReadXdr for HasOptions {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       first_option: Option::<i32>::read_xdr(r)?,
@@ -2335,7 +2188,7 @@ third_option: Option::<i32>::read_xdr(r)?,
 
         impl WriteXdr for HasOptions {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     self.first_option.write_xdr(w)?;
 self.second_option.write_xdr(w)?;
@@ -2423,7 +2276,7 @@ TypeVariant::HasOptions, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 match v {
                     TypeVariant::Arr => r.with_limited_depth(|r| Ok(Self::Arr(Box::new(Arr::read_xdr(r)?)))),
 TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new(HasOptions::read_xdr(r)?)))),
@@ -2431,14 +2284,14 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2450,51 +2303,51 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Frame<Arr>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Arr(Box::new(t.0))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::HasOptions(Box::new(t.0))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Frame<Arr>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Arr(Box::new(t.0))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::HasOptions(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec, r.limits).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.limits).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+                let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String, limits: Limits) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2560,7 +2413,7 @@ Self::HasOptions(_) => TypeVariant::HasOptions,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 match self {
                     Self::Arr(v) => v.write_xdr(w),
 Self::HasOptions(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -219,21 +219,21 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
-    fn none() -> Self {
+    pub fn none() -> Self {
         Self {
             depth: u32::MAX,
             len: usize::MAX,
         }
     }
 
-    fn depth(depth: u32) -> Self {
+    pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
             ..Limits::none()
         }
     }
 
-    fn len(len: usize) -> Self {
+    pub fn len(len: usize) -> Self {
         Limits {
             len,
             ..Limits::none()

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -2268,6 +2268,68 @@ mod test {
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
         }
     }
+
+    #[test]
+    fn length_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut lr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[test]
+    fn write_over_length_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 15,
+                ..Limits::default()
+            },
+        );
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected LengthLimitExceeded got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn read_over_length_limit_fail() {
+        let read_limits = Limits {
+            len: 15,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            len: 16,
+            ..Limits::default()
+        };
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(Vec::new(), read_limits);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
+    }
 }
 
 #[cfg(all(test, not(feature = "alloc")))]

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -273,12 +273,12 @@ impl<L> Limited<L> {
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
+            let res = f(self);
+            self.limits.depth = self.limits.depth.saturating_add(1);
+            res
         } else {
-            return Err(Error::DepthLimitExceeded);
+            Err(Error::DepthLimitExceeded)
         }
-        let res = f(self);
-        self.limits.depth = self.limits.depth.saturating_add(1);
-        res
     }
 }
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -219,6 +219,7 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
+    #[must_use]
     pub fn none() -> Self {
         Self {
             depth: u32::MAX,
@@ -226,6 +227,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
@@ -233,6 +235,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn len(len: usize) -> Self {
         Limits {
             len,

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -51,14 +51,6 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
-///
-/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
-/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the
-/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
-
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
 /// compared on their `ErrorKind`.
@@ -204,172 +196,71 @@ where
 {
 }
 
-/// `DepthLimiter` is a trait designed for managing the depth of recursive operations.
-/// It provides a mechanism to limit recursion depth, and defines the behavior upon
-/// entering and leaving a recursion level.
-pub trait DepthLimiter {
-    /// A general error type for any type implementing, or an operation under the guard of
-    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
-    /// which is returned from `enter`.
-    type DepthLimiterError;
+/// `Limits` contains the limits that a limited reader or writer will be
+/// constrained to.
+#[cfg(feature = "std")]
+pub struct Limits {
+    /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+    ///
+    /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+    /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+    /// For more information about Rust's stack size limit, refer to the
+    /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+    pub depth: u32,
+}
 
-    /// Defines the behavior for entering a new recursion level.
-    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
-    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Defines the behavior for leaving a recursion level.
-    /// A `DepthLimiterError` is returned if an error occurs.
-    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Wraps a given function `f` with depth limiting guards.
-    /// It triggers an `enter` before, and a `leave` after the execution of `f`.
-    ///
-    /// # Parameters
-    ///
-    /// - `f`: The function to be executed under depth limit constraints.
-    ///
-    /// # Returns
-    ///
-    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
-    ///         with an error 3. if error occurs on `leave`.
-    ///   `Ok` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
-    where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
-    {
-        self.enter()?;
-        let res = f(self);
-        self.leave()?;
-        res
+#[cfg(feature = "std")]
+impl Default for Limits {
+    fn default() -> Self {
+        Self { depth: 500 }
     }
 }
 
-/// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
+/// `Limited` wraps an object and provides functions for enforcing limits.
 #[cfg(feature = "std")]
-pub struct DepthLimitedRead<R: Read> {
-    pub inner: R,
-    pub(crate) depth_remaining: u32,
+pub struct Limited<L> {
+    pub inner: L,
+    pub(crate) limits: Limits,
 }
 
 #[cfg(feature = "std")]
-impl<R: Read> DepthLimitedRead<R> {
-    /// Constructs a new `DepthLimitedRead`.
+impl<L> Limited<L> {
+    /// Constructs a new `Limited`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
     /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth_limit: u32) -> Self {
-        DepthLimitedRead {
-            inner,
-            depth_remaining: depth_limit,
-        }
+    pub fn new(inner: L, limits: Limits) -> Self {
+        Limited { inner, limits }
     }
-}
 
-#[cfg(feature = "std")]
-impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> core::result::Result<(), Error> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
+    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut Self) -> Result<T>,
+    {
+        if let Some(depth) = self.limits.depth.checked_sub(1) {
+            self.limits.depth = depth;
         } else {
             return Err(Error::DepthLimitExceeded);
         }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<R: Read> Read for DepthLimitedRead<R> {
-    /// Forwards the read operation to the wrapped object.
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.inner.read(buf)
-    }
-}
-
-/// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
-#[cfg(feature = "std")]
-pub struct DepthLimitedWrite<W: Write> {
-    pub inner: W,
-    pub(crate) depth_remaining: u32,
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimitedWrite<W> {
-    /// Constructs a new `DepthLimitedWrite`.
-    ///
-    /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth_limit: u32) -> Self {
-        DepthLimitedWrite {
-            inner,
-            depth_remaining: depth_limit,
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> Result<()> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
-        } else {
-            return Err(Error::DepthLimitExceeded);
-        }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> Write for DepthLimitedWrite<W> {
-    /// Forwards the write operation to the wrapped object.
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.inner.write(buf)
-    }
-
-    /// Forwards the flush operation to the wrapped object.
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.inner.flush()
+        let res = f(self);
+        self.limits.depth = self.limits.depth.saturating_add(1);
+        res
     }
 }
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: DepthLimitedRead<BufReader<R>>,
+    reader: Limited<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth_limit: u32) -> Self {
+    fn new(r: R, limits: Limits) -> Self {
         Self {
-            reader: DepthLimitedRead {
+            reader: Limited {
                 inner: BufReader::new(r),
-                depth_remaining: depth_limit,
+                limits,
             },
             _s: PhantomData,
         }
@@ -431,15 +322,15 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -466,7 +357,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -482,8 +373,8 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -506,7 +397,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -530,7 +421,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -560,7 +451,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
+    fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
         ReadXdrIter::new(&mut r.inner, r.depth_remaining)
     }
 
@@ -568,88 +459,60 @@ where
     /// values that are read into the implementing type.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
-        r: &mut DepthLimitedRead<R>,
+        r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         ReadXdrIter::new(dec, r.depth_remaining)
     }
 
-    /// Construct the type from the XDR bytes, specifying a depth limit.
+    /// Construct the type from the XDR bytes.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+        let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            depth_limit,
+            limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+        let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
     #[cfg(feature = "base64")]
-    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
-        let mut enc = DepthLimitedWrite::new(
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+        let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            depth_limit,
+            limits,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
-    }
-
-    #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -662,7 +525,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -673,7 +536,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -681,7 +544,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -692,7 +555,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -700,7 +563,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -711,7 +574,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -719,7 +582,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -730,7 +593,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -738,35 +601,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -777,7 +640,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -787,7 +650,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -804,7 +667,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -819,35 +682,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
@@ -863,7 +726,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             w.write_all(self)?;
             w.write_all(&[0u8; 3][..pad_len(N)])?;
@@ -874,7 +737,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -889,7 +752,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -1222,7 +1085,7 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1245,7 +1108,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1261,7 +1124,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1281,7 +1144,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1620,7 +1483,7 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1643,7 +1506,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2003,7 +1866,7 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2026,7 +1889,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2057,7 +1920,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2080,17 +1943,13 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use super::{
-        DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_XDR_RW_DEPTH_LIMIT,
-    };
+    use super::*;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
@@ -2098,16 +1957,14 @@ mod tests {
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2117,8 +1974,7 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2130,7 +1986,7 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2142,7 +1998,7 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2153,23 +2009,21 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2179,7 +2033,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2190,9 +2044,9 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2202,9 +2056,9 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2242,19 +2096,18 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
 
     #[test]
     fn write_over_depth_limit_fail() {
-        let depth_limit = 3;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), depth_limit);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2264,13 +2117,13 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_depth_limit = 3;
-        let write_depth_limit = 5;
+        let read_limits = Limits { depth: 3 };
+        let write_limits = Limits { depth: 5 };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), write_depth_limit);
+        let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), read_depth_limit);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
         let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2326,7 +2179,7 @@ pub struct MyStruct {
 
         impl ReadXdr for MyStruct {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       some_int: i32::read_xdr(r)?,
@@ -2341,7 +2194,7 @@ max_string: StringM::<100>::read_xdr(r)?,
 
         impl WriteXdr for MyStruct {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     self.some_int.write_xdr(w)?;
 self.a_big_int.write_xdr(w)?;
@@ -2431,7 +2284,7 @@ TypeVariant::MyStruct, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 match v {
                     TypeVariant::Int64 => r.with_limited_depth(|r| Ok(Self::Int64(Box::new(Int64::read_xdr(r)?)))),
 TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyStruct::read_xdr(r)?)))),
@@ -2439,14 +2292,14 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2458,51 +2311,51 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Frame<Int64>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Int64(Box::new(t.0))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
+                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Frame<Int64>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int64(Box::new(t.0))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(dec, r.limits).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+                let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String, limits: Limits) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2568,7 +2421,7 @@ Self::MyStruct(_) => TypeVariant::MyStruct,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 match self {
                     Self::Int64(v) => v.write_xdr(w),
 Self::MyStruct(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -69,6 +69,7 @@ pub enum Error {
     DepthLimitExceeded,
     #[cfg(feature = "serde_json")]
     Json(serde_json::Error),
+    LengthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -117,6 +118,7 @@ impl fmt::Display for Error {
             Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
             #[cfg(feature = "serde_json")]
             Error::Json(e) => write!(f, "{e}"),
+            Error::LengthLimitExceeded => write!(f, "length limit exceeded"),
         }
     }
 }
@@ -199,6 +201,7 @@ where
 /// `Limits` contains the limits that a limited reader or writer will be
 /// constrained to.
 #[cfg(feature = "std")]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Limits {
     /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
     ///
@@ -207,12 +210,18 @@ pub struct Limits {
     /// For more information about Rust's stack size limit, refer to the
     /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
     pub depth: u32,
+
+    /// Defines the maximum number of bytes that will be read or read.
+    pub len: usize,
 }
 
 #[cfg(feature = "std")]
 impl Default for Limits {
     fn default() -> Self {
-        Self { depth: 500 }
+        Self {
+            depth: 500,
+            len: usize::MAX,
+        }
     }
 }
 
@@ -233,7 +242,16 @@ impl<L> Limited<L> {
         Limited { inner, limits }
     }
 
-    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+        if let Some(len) = self.limits.len.checked_sub(len) {
+            self.limits.len = len;
+            Ok(())
+        } else {
+            Err(Error::LengthLimitExceeded)
+        }
+    }
+
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
     where
         F: FnOnce(&mut Self) -> Result<T>,
     {
@@ -245,6 +263,40 @@ impl<L> Limited<L> {
         let res = f(self);
         self.limits.depth = self.limits.depth.saturating_add(1);
         res
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: BufRead> BufRead for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        self.inner.fill_buf()
+    }
+
+    /// Forwards the read operation to the wrapped object.
+    fn consume(&mut self, amt: usize) {
+        self.inner.consume(amt);
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for Limited<W> {
+    /// Forwards the write operation to the wrapped object.
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    /// Forwards the flush operation to the wrapped object.
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
     }
 }
 
@@ -285,7 +337,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.inner.fill_buf() {
+        match self.reader.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -332,7 +384,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -376,7 +428,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -452,7 +504,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
+        ReadXdrIter::new(&mut r.inner, r.limits.clone())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -462,7 +514,7 @@ where
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining)
+        ReadXdrIter::new(dec, r.limits.clone())
     }
 
     /// Construct the type from the XDR bytes.
@@ -528,6 +580,7 @@ impl ReadXdr for i32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i32::from_be_bytes(b))
         })
@@ -538,7 +591,10 @@ impl WriteXdr for i32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -547,6 +603,7 @@ impl ReadXdr for u32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u32::from_be_bytes(b))
         })
@@ -557,7 +614,10 @@ impl WriteXdr for u32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -566,6 +626,7 @@ impl ReadXdr for i64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i64::from_be_bytes(b))
         })
@@ -576,7 +637,10 @@ impl WriteXdr for i64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -585,6 +649,7 @@ impl ReadXdr for u64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u64::from_be_bytes(b))
         })
@@ -595,7 +660,10 @@ impl WriteXdr for u64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -631,6 +699,7 @@ impl ReadXdr for bool {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             let b = i == 1;
             Ok(b)
@@ -642,6 +711,7 @@ impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
         })
@@ -652,6 +722,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             match i {
                 0 => Ok(None),
@@ -669,6 +740,7 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
                 t.write_xdr(w)?;
@@ -712,9 +784,12 @@ impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(N)?;
+            let padding = pad_len(N);
+            r.consume_len(padding)?;
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
-            let pad = &mut [0u8; 3][..pad_len(N)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -728,8 +803,11 @@ impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(N)?;
+            let padding = pad_len(N);
+            w.consume_len(padding)?;
             w.write_all(self)?;
-            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            w.write_all(&[0u8; 3][..padding])?;
             Ok(())
         })
     }
@@ -1087,15 +1165,20 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1110,12 +1193,17 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1126,6 +1214,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
@@ -1146,6 +1235,7 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1485,15 +1575,20 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1508,6 +1603,11 @@ impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1868,15 +1968,21 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
+
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1891,12 +1997,17 @@ impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1925,6 +2036,7 @@ where
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
         //  follow the frame header.
+        r.consume_len(core::mem::size_of::<u32>())?;
         let header = u32::read_xdr(r)?;
         // TODO: Use the length and cap the length we'll read from `r`.
         let last_record = header >> 31 == 1;
@@ -1948,16 +2060,14 @@ mod tests {
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
@@ -1986,11 +2096,8 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1998,11 +2105,8 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
@@ -2044,10 +2148,7 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -2056,10 +2157,7 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
@@ -2096,10 +2194,22 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
+        let mut dlr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
@@ -2107,7 +2217,13 @@ mod test {
     #[test]
     fn write_over_depth_limit_fail() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 3,
+                len: usize::MAX,
+            },
+        );
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2117,8 +2233,14 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_limits = Limits { depth: 3 };
-        let write_limits = Limits { depth: 5 };
+        let read_limits = Limits {
+            depth: 3,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            depth: 5,
+            ..Limits::default()
+        };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
         let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
@@ -2293,7 +2415,7 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2312,7 +2434,7 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2321,8 +2443,8 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
                 }
             }
 
@@ -2330,8 +2452,8 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, 
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Frame<Int64>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int64(Box::new(t.0))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
+                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Frame<Int64>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int64(Box::new(t.0))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
                 }
             }
 
@@ -2340,8 +2462,8 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(dec, r.limits).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -219,21 +219,21 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
-    fn none() -> Self {
+    pub fn none() -> Self {
         Self {
             depth: u32::MAX,
             len: usize::MAX,
         }
     }
 
-    fn depth(depth: u32) -> Self {
+    pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
             ..Limits::none()
         }
     }
 
-    fn len(len: usize) -> Self {
+    pub fn len(len: usize) -> Self {
         Limits {
             len,
             ..Limits::none()

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -69,6 +69,7 @@ pub enum Error {
     DepthLimitExceeded,
     #[cfg(feature = "serde_json")]
     Json(serde_json::Error),
+    LengthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -117,6 +118,7 @@ impl fmt::Display for Error {
             Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
             #[cfg(feature = "serde_json")]
             Error::Json(e) => write!(f, "{e}"),
+            Error::LengthLimitExceeded => write!(f, "length limit exceeded"),
         }
     }
 }
@@ -199,6 +201,7 @@ where
 /// `Limits` contains the limits that a limited reader or writer will be
 /// constrained to.
 #[cfg(feature = "std")]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Limits {
     /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
     ///
@@ -207,12 +210,18 @@ pub struct Limits {
     /// For more information about Rust's stack size limit, refer to the
     /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
     pub depth: u32,
+
+    /// Defines the maximum number of bytes that will be read or read.
+    pub len: usize,
 }
 
 #[cfg(feature = "std")]
 impl Default for Limits {
     fn default() -> Self {
-        Self { depth: 500 }
+        Self {
+            depth: 500,
+            len: usize::MAX,
+        }
     }
 }
 
@@ -233,7 +242,16 @@ impl<L> Limited<L> {
         Limited { inner, limits }
     }
 
-    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+        if let Some(len) = self.limits.len.checked_sub(len) {
+            self.limits.len = len;
+            Ok(())
+        } else {
+            Err(Error::LengthLimitExceeded)
+        }
+    }
+
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
     where
         F: FnOnce(&mut Self) -> Result<T>,
     {
@@ -245,6 +263,40 @@ impl<L> Limited<L> {
         let res = f(self);
         self.limits.depth = self.limits.depth.saturating_add(1);
         res
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: BufRead> BufRead for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        self.inner.fill_buf()
+    }
+
+    /// Forwards the read operation to the wrapped object.
+    fn consume(&mut self, amt: usize) {
+        self.inner.consume(amt);
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for Limited<W> {
+    /// Forwards the write operation to the wrapped object.
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    /// Forwards the flush operation to the wrapped object.
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
     }
 }
 
@@ -285,7 +337,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.inner.fill_buf() {
+        match self.reader.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -332,7 +384,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -376,7 +428,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -452,7 +504,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
+        ReadXdrIter::new(&mut r.inner, r.limits.clone())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -462,7 +514,7 @@ where
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining)
+        ReadXdrIter::new(dec, r.limits.clone())
     }
 
     /// Construct the type from the XDR bytes.
@@ -528,6 +580,7 @@ impl ReadXdr for i32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i32::from_be_bytes(b))
         })
@@ -538,7 +591,10 @@ impl WriteXdr for i32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -547,6 +603,7 @@ impl ReadXdr for u32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u32::from_be_bytes(b))
         })
@@ -557,7 +614,10 @@ impl WriteXdr for u32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -566,6 +626,7 @@ impl ReadXdr for i64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i64::from_be_bytes(b))
         })
@@ -576,7 +637,10 @@ impl WriteXdr for i64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -585,6 +649,7 @@ impl ReadXdr for u64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u64::from_be_bytes(b))
         })
@@ -595,7 +660,10 @@ impl WriteXdr for u64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -631,6 +699,7 @@ impl ReadXdr for bool {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             let b = i == 1;
             Ok(b)
@@ -642,6 +711,7 @@ impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
         })
@@ -652,6 +722,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             match i {
                 0 => Ok(None),
@@ -669,6 +740,7 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
                 t.write_xdr(w)?;
@@ -712,9 +784,12 @@ impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(N)?;
+            let padding = pad_len(N);
+            r.consume_len(padding)?;
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
-            let pad = &mut [0u8; 3][..pad_len(N)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -728,8 +803,11 @@ impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(N)?;
+            let padding = pad_len(N);
+            w.consume_len(padding)?;
             w.write_all(self)?;
-            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            w.write_all(&[0u8; 3][..padding])?;
             Ok(())
         })
     }
@@ -1087,15 +1165,20 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1110,12 +1193,17 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1126,6 +1214,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
@@ -1146,6 +1235,7 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1485,15 +1575,20 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1508,6 +1603,11 @@ impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1868,15 +1968,21 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
+
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1891,12 +1997,17 @@ impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1925,6 +2036,7 @@ where
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
         //  follow the frame header.
+        r.consume_len(core::mem::size_of::<u32>())?;
         let header = u32::read_xdr(r)?;
         // TODO: Use the length and cap the length we'll read from `r`.
         let last_record = header >> 31 == 1;
@@ -1948,16 +2060,14 @@ mod tests {
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
@@ -1986,11 +2096,8 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1998,11 +2105,8 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
@@ -2044,10 +2148,7 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -2056,10 +2157,7 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
@@ -2096,10 +2194,22 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
+        let mut dlr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
@@ -2107,7 +2217,13 @@ mod test {
     #[test]
     fn write_over_depth_limit_fail() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 3,
+                len: usize::MAX,
+            },
+        );
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2117,8 +2233,14 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_limits = Limits { depth: 3 };
-        let write_limits = Limits { depth: 5 };
+        let read_limits = Limits {
+            depth: 3,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            depth: 5,
+            ..Limits::default()
+        };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
         let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
@@ -3990,7 +4112,7 @@ TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNested
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -4009,7 +4131,7 @@ TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNested
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -4018,29 +4140,29 @@ TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNested
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
-TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Uint513>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Uint513(Box::new(t))))),
-TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Uint514>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Uint514(Box::new(t))))),
-TypeVariant::Str => Box::new(ReadXdrIter::<_, Str>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Str(Box::new(t))))),
-TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Str2>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Str2(Box::new(t))))),
-TypeVariant::Hash => Box::new(ReadXdrIter::<_, Hash>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Hash(Box::new(t))))),
-TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Hashes1>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Hashes1(Box::new(t))))),
-TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Hashes2>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Hashes2(Box::new(t))))),
-TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Hashes3>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Hashes3(Box::new(t))))),
-TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, OptHash1>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::OptHash1(Box::new(t))))),
-TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, OptHash2>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::OptHash2(Box::new(t))))),
-TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Int1>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int1(Box::new(t))))),
-TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Int2>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int2(Box::new(t))))),
-TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Int3>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int3(Box::new(t))))),
-TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Int4>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int4(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
-TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, LotsOfMyStructs>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t))))),
-TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, HasStuff>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::HasStuff(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Nester => Box::new(ReadXdrIter::<_, Nester>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Nester(Box::new(t))))),
-TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, NesterNestedEnum>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t))))),
-TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, NesterNestedStruct>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t))))),
-TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t))))),
+                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
+TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Uint513>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Uint513(Box::new(t))))),
+TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Uint514>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Uint514(Box::new(t))))),
+TypeVariant::Str => Box::new(ReadXdrIter::<_, Str>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Str(Box::new(t))))),
+TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Str2>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Str2(Box::new(t))))),
+TypeVariant::Hash => Box::new(ReadXdrIter::<_, Hash>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Hash(Box::new(t))))),
+TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Hashes1>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Hashes1(Box::new(t))))),
+TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Hashes2>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Hashes2(Box::new(t))))),
+TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Hashes3>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Hashes3(Box::new(t))))),
+TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, OptHash1>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::OptHash1(Box::new(t))))),
+TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, OptHash2>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::OptHash2(Box::new(t))))),
+TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Int1>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int1(Box::new(t))))),
+TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Int2>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int2(Box::new(t))))),
+TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Int3>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int3(Box::new(t))))),
+TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Int4>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int4(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, LotsOfMyStructs>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t))))),
+TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, HasStuff>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::HasStuff(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Nester => Box::new(ReadXdrIter::<_, Nester>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Nester(Box::new(t))))),
+TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, NesterNestedEnum>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t))))),
+TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, NesterNestedStruct>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t))))),
+TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t))))),
                 }
             }
 
@@ -4048,29 +4170,29 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Frame<Uint512>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Uint512(Box::new(t.0))))),
-TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Frame<Uint513>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Uint513(Box::new(t.0))))),
-TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Frame<Uint514>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Uint514(Box::new(t.0))))),
-TypeVariant::Str => Box::new(ReadXdrIter::<_, Frame<Str>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Str(Box::new(t.0))))),
-TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Frame<Str2>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Str2(Box::new(t.0))))),
-TypeVariant::Hash => Box::new(ReadXdrIter::<_, Frame<Hash>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Hash(Box::new(t.0))))),
-TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Frame<Hashes1>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Hashes1(Box::new(t.0))))),
-TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Frame<Hashes2>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Hashes2(Box::new(t.0))))),
-TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Frame<Hashes3>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Hashes3(Box::new(t.0))))),
-TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, Frame<OptHash1>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::OptHash1(Box::new(t.0))))),
-TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, Frame<OptHash2>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::OptHash2(Box::new(t.0))))),
-TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Frame<Int1>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int1(Box::new(t.0))))),
-TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Frame<Int2>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int2(Box::new(t.0))))),
-TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Frame<Int3>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int3(Box::new(t.0))))),
-TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Frame<Int4>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int4(Box::new(t.0))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
-TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, Frame<LotsOfMyStructs>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t.0))))),
-TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, Frame<HasStuff>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::HasStuff(Box::new(t.0))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
-TypeVariant::Nester => Box::new(ReadXdrIter::<_, Frame<Nester>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Nester(Box::new(t.0))))),
-TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, Frame<NesterNestedEnum>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t.0))))),
-TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, Frame<NesterNestedStruct>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t.0))))),
-TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, Frame<NesterNestedUnion>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t.0))))),
+                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Frame<Uint512>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Uint512(Box::new(t.0))))),
+TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Frame<Uint513>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Uint513(Box::new(t.0))))),
+TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Frame<Uint514>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Uint514(Box::new(t.0))))),
+TypeVariant::Str => Box::new(ReadXdrIter::<_, Frame<Str>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Str(Box::new(t.0))))),
+TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Frame<Str2>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Str2(Box::new(t.0))))),
+TypeVariant::Hash => Box::new(ReadXdrIter::<_, Frame<Hash>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Hash(Box::new(t.0))))),
+TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Frame<Hashes1>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Hashes1(Box::new(t.0))))),
+TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Frame<Hashes2>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Hashes2(Box::new(t.0))))),
+TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Frame<Hashes3>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Hashes3(Box::new(t.0))))),
+TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, Frame<OptHash1>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::OptHash1(Box::new(t.0))))),
+TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, Frame<OptHash2>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::OptHash2(Box::new(t.0))))),
+TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Frame<Int1>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int1(Box::new(t.0))))),
+TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Frame<Int2>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int2(Box::new(t.0))))),
+TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Frame<Int3>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int3(Box::new(t.0))))),
+TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Frame<Int4>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int4(Box::new(t.0))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
+TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, Frame<LotsOfMyStructs>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t.0))))),
+TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, Frame<HasStuff>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::HasStuff(Box::new(t.0))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
+TypeVariant::Nester => Box::new(ReadXdrIter::<_, Frame<Nester>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Nester(Box::new(t.0))))),
+TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, Frame<NesterNestedEnum>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t.0))))),
+TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, Frame<NesterNestedStruct>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t.0))))),
+TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, Frame<NesterNestedUnion>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t.0))))),
                 }
             }
 
@@ -4079,29 +4201,29 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, Frame<NesterNestedUn
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(dec, r.limits).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
-TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Uint513>::new(dec, r.limits).map(|r| r.map(|t| Self::Uint513(Box::new(t))))),
-TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Uint514>::new(dec, r.limits).map(|r| r.map(|t| Self::Uint514(Box::new(t))))),
-TypeVariant::Str => Box::new(ReadXdrIter::<_, Str>::new(dec, r.limits).map(|r| r.map(|t| Self::Str(Box::new(t))))),
-TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Str2>::new(dec, r.limits).map(|r| r.map(|t| Self::Str2(Box::new(t))))),
-TypeVariant::Hash => Box::new(ReadXdrIter::<_, Hash>::new(dec, r.limits).map(|r| r.map(|t| Self::Hash(Box::new(t))))),
-TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Hashes1>::new(dec, r.limits).map(|r| r.map(|t| Self::Hashes1(Box::new(t))))),
-TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Hashes2>::new(dec, r.limits).map(|r| r.map(|t| Self::Hashes2(Box::new(t))))),
-TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Hashes3>::new(dec, r.limits).map(|r| r.map(|t| Self::Hashes3(Box::new(t))))),
-TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, OptHash1>::new(dec, r.limits).map(|r| r.map(|t| Self::OptHash1(Box::new(t))))),
-TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, OptHash2>::new(dec, r.limits).map(|r| r.map(|t| Self::OptHash2(Box::new(t))))),
-TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Int1>::new(dec, r.limits).map(|r| r.map(|t| Self::Int1(Box::new(t))))),
-TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Int2>::new(dec, r.limits).map(|r| r.map(|t| Self::Int2(Box::new(t))))),
-TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Int3>::new(dec, r.limits).map(|r| r.map(|t| Self::Int3(Box::new(t))))),
-TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Int4>::new(dec, r.limits).map(|r| r.map(|t| Self::Int4(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
-TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, LotsOfMyStructs>::new(dec, r.limits).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t))))),
-TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, HasStuff>::new(dec, r.limits).map(|r| r.map(|t| Self::HasStuff(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, r.limits).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Nester => Box::new(ReadXdrIter::<_, Nester>::new(dec, r.limits).map(|r| r.map(|t| Self::Nester(Box::new(t))))),
-TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, NesterNestedEnum>::new(dec, r.limits).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t))))),
-TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, NesterNestedStruct>::new(dec, r.limits).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t))))),
-TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::new(dec, r.limits).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t))))),
+                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
+TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Uint513>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Uint513(Box::new(t))))),
+TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Uint514>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Uint514(Box::new(t))))),
+TypeVariant::Str => Box::new(ReadXdrIter::<_, Str>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Str(Box::new(t))))),
+TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Str2>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Str2(Box::new(t))))),
+TypeVariant::Hash => Box::new(ReadXdrIter::<_, Hash>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Hash(Box::new(t))))),
+TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Hashes1>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Hashes1(Box::new(t))))),
+TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Hashes2>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Hashes2(Box::new(t))))),
+TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Hashes3>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Hashes3(Box::new(t))))),
+TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, OptHash1>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::OptHash1(Box::new(t))))),
+TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, OptHash2>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::OptHash2(Box::new(t))))),
+TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Int1>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Int1(Box::new(t))))),
+TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Int2>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Int2(Box::new(t))))),
+TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Int3>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Int3(Box::new(t))))),
+TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Int4>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Int4(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, LotsOfMyStructs>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t))))),
+TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, HasStuff>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::HasStuff(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Nester => Box::new(ReadXdrIter::<_, Nester>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Nester(Box::new(t))))),
+TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, NesterNestedEnum>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t))))),
+TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, NesterNestedStruct>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t))))),
+TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -2268,6 +2268,68 @@ mod test {
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
         }
     }
+
+    #[test]
+    fn length_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut lr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[test]
+    fn write_over_length_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 15,
+                ..Limits::default()
+            },
+        );
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected LengthLimitExceeded got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn read_over_length_limit_fail() {
+        let read_limits = Limits {
+            len: 15,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            len: 16,
+            ..Limits::default()
+        };
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(Vec::new(), read_limits);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
+    }
 }
 
 #[cfg(all(test, not(feature = "alloc")))]

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -273,12 +273,12 @@ impl<L> Limited<L> {
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
+            let res = f(self);
+            self.limits.depth = self.limits.depth.saturating_add(1);
+            res
         } else {
-            return Err(Error::DepthLimitExceeded);
+            Err(Error::DepthLimitExceeded)
         }
-        let res = f(self);
-        self.limits.depth = self.limits.depth.saturating_add(1);
-        res
     }
 }
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -219,6 +219,7 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
+    #[must_use]
     pub fn none() -> Self {
         Self {
             depth: u32::MAX,
@@ -226,6 +227,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
@@ -233,6 +235,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn len(len: usize) -> Self {
         Limits {
             len,

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -219,21 +219,21 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
-    fn none() -> Self {
+    pub fn none() -> Self {
         Self {
             depth: u32::MAX,
             len: usize::MAX,
         }
     }
 
-    fn depth(depth: u32) -> Self {
+    pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
             ..Limits::none()
         }
     }
 
-    fn len(len: usize) -> Self {
+    pub fn len(len: usize) -> Self {
         Limits {
             len,
             ..Limits::none()

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -2268,6 +2268,68 @@ mod test {
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
         }
     }
+
+    #[test]
+    fn length_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut lr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[test]
+    fn write_over_length_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 15,
+                ..Limits::default()
+            },
+        );
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected LengthLimitExceeded got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn read_over_length_limit_fail() {
+        let read_limits = Limits {
+            len: 15,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            len: 16,
+            ..Limits::default()
+        };
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(Vec::new(), read_limits);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
+    }
 }
 
 #[cfg(all(test, not(feature = "alloc")))]

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -273,12 +273,12 @@ impl<L> Limited<L> {
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
+            let res = f(self);
+            self.limits.depth = self.limits.depth.saturating_add(1);
+            res
         } else {
-            return Err(Error::DepthLimitExceeded);
+            Err(Error::DepthLimitExceeded)
         }
-        let res = f(self);
-        self.limits.depth = self.limits.depth.saturating_add(1);
-        res
     }
 }
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -219,6 +219,7 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
+    #[must_use]
     pub fn none() -> Self {
         Self {
             depth: u32::MAX,
@@ -226,6 +227,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
@@ -233,6 +235,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn len(len: usize) -> Self {
         Limits {
             len,

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -51,14 +51,6 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
-///
-/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
-/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the
-/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
-
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
 /// compared on their `ErrorKind`.
@@ -204,172 +196,71 @@ where
 {
 }
 
-/// `DepthLimiter` is a trait designed for managing the depth of recursive operations.
-/// It provides a mechanism to limit recursion depth, and defines the behavior upon
-/// entering and leaving a recursion level.
-pub trait DepthLimiter {
-    /// A general error type for any type implementing, or an operation under the guard of
-    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
-    /// which is returned from `enter`.
-    type DepthLimiterError;
+/// `Limits` contains the limits that a limited reader or writer will be
+/// constrained to.
+#[cfg(feature = "std")]
+pub struct Limits {
+    /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+    ///
+    /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+    /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+    /// For more information about Rust's stack size limit, refer to the
+    /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+    pub depth: u32,
+}
 
-    /// Defines the behavior for entering a new recursion level.
-    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
-    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Defines the behavior for leaving a recursion level.
-    /// A `DepthLimiterError` is returned if an error occurs.
-    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Wraps a given function `f` with depth limiting guards.
-    /// It triggers an `enter` before, and a `leave` after the execution of `f`.
-    ///
-    /// # Parameters
-    ///
-    /// - `f`: The function to be executed under depth limit constraints.
-    ///
-    /// # Returns
-    ///
-    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
-    ///         with an error 3. if error occurs on `leave`.
-    ///   `Ok` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
-    where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
-    {
-        self.enter()?;
-        let res = f(self);
-        self.leave()?;
-        res
+#[cfg(feature = "std")]
+impl Default for Limits {
+    fn default() -> Self {
+        Self { depth: 500 }
     }
 }
 
-/// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
+/// `Limited` wraps an object and provides functions for enforcing limits.
 #[cfg(feature = "std")]
-pub struct DepthLimitedRead<R: Read> {
-    pub inner: R,
-    pub(crate) depth_remaining: u32,
+pub struct Limited<L> {
+    pub inner: L,
+    pub(crate) limits: Limits,
 }
 
 #[cfg(feature = "std")]
-impl<R: Read> DepthLimitedRead<R> {
-    /// Constructs a new `DepthLimitedRead`.
+impl<L> Limited<L> {
+    /// Constructs a new `Limited`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
     /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth_limit: u32) -> Self {
-        DepthLimitedRead {
-            inner,
-            depth_remaining: depth_limit,
-        }
+    pub fn new(inner: L, limits: Limits) -> Self {
+        Limited { inner, limits }
     }
-}
 
-#[cfg(feature = "std")]
-impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> core::result::Result<(), Error> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
+    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut Self) -> Result<T>,
+    {
+        if let Some(depth) = self.limits.depth.checked_sub(1) {
+            self.limits.depth = depth;
         } else {
             return Err(Error::DepthLimitExceeded);
         }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<R: Read> Read for DepthLimitedRead<R> {
-    /// Forwards the read operation to the wrapped object.
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.inner.read(buf)
-    }
-}
-
-/// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
-#[cfg(feature = "std")]
-pub struct DepthLimitedWrite<W: Write> {
-    pub inner: W,
-    pub(crate) depth_remaining: u32,
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimitedWrite<W> {
-    /// Constructs a new `DepthLimitedWrite`.
-    ///
-    /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth_limit: u32) -> Self {
-        DepthLimitedWrite {
-            inner,
-            depth_remaining: depth_limit,
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> Result<()> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
-        } else {
-            return Err(Error::DepthLimitExceeded);
-        }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> Write for DepthLimitedWrite<W> {
-    /// Forwards the write operation to the wrapped object.
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.inner.write(buf)
-    }
-
-    /// Forwards the flush operation to the wrapped object.
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.inner.flush()
+        let res = f(self);
+        self.limits.depth = self.limits.depth.saturating_add(1);
+        res
     }
 }
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: DepthLimitedRead<BufReader<R>>,
+    reader: Limited<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth_limit: u32) -> Self {
+    fn new(r: R, limits: Limits) -> Self {
         Self {
-            reader: DepthLimitedRead {
+            reader: Limited {
                 inner: BufReader::new(r),
-                depth_remaining: depth_limit,
+                limits,
             },
             _s: PhantomData,
         }
@@ -431,15 +322,15 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -466,7 +357,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -482,8 +373,8 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -506,7 +397,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -530,7 +421,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -560,7 +451,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
+    fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
         ReadXdrIter::new(&mut r.inner, r.depth_remaining)
     }
 
@@ -568,88 +459,60 @@ where
     /// values that are read into the implementing type.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
-        r: &mut DepthLimitedRead<R>,
+        r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         ReadXdrIter::new(dec, r.depth_remaining)
     }
 
-    /// Construct the type from the XDR bytes, specifying a depth limit.
+    /// Construct the type from the XDR bytes.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+        let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            depth_limit,
+            limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+        let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
     #[cfg(feature = "base64")]
-    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
-        let mut enc = DepthLimitedWrite::new(
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+        let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            depth_limit,
+            limits,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
-    }
-
-    #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -662,7 +525,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -673,7 +536,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -681,7 +544,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -692,7 +555,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -700,7 +563,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -711,7 +574,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -719,7 +582,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -730,7 +593,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -738,35 +601,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -777,7 +640,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -787,7 +650,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -804,7 +667,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -819,35 +682,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
@@ -863,7 +726,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             w.write_all(self)?;
             w.write_all(&[0u8; 3][..pad_len(N)])?;
@@ -874,7 +737,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -889,7 +752,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -1222,7 +1085,7 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1245,7 +1108,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1261,7 +1124,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1281,7 +1144,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1620,7 +1483,7 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1643,7 +1506,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2003,7 +1866,7 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2026,7 +1889,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2057,7 +1920,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2080,17 +1943,13 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use super::{
-        DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_XDR_RW_DEPTH_LIMIT,
-    };
+    use super::*;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
@@ -2098,16 +1957,14 @@ mod tests {
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2117,8 +1974,7 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2130,7 +1986,7 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2142,7 +1998,7 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2153,23 +2009,21 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2179,7 +2033,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2190,9 +2044,9 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2202,9 +2056,9 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2242,19 +2096,18 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
 
     #[test]
     fn write_over_depth_limit_fail() {
-        let depth_limit = 3;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), depth_limit);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2264,13 +2117,13 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_depth_limit = 3;
-        let write_depth_limit = 5;
+        let read_limits = Limits { depth: 3 };
+        let write_limits = Limits { depth: 5 };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), write_depth_limit);
+        let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), read_depth_limit);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
         let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2389,7 +2242,7 @@ Self::Multi => "Multi",
 
         impl ReadXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -2400,7 +2253,7 @@ Self::Multi => "Multi",
 
         impl WriteXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -2487,7 +2340,7 @@ Self::Multi(_) => UnionKey::Multi,
 
         impl ReadXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     let dv: UnionKey = <UnionKey as ReadXdr>::read_xdr(r)?;
                     #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
@@ -2504,7 +2357,7 @@ UnionKey::Multi => Self::Multi(VecM::<i32>::read_xdr(r)?),
 
         impl WriteXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     self.discriminant().write_xdr(w)?;
                     #[allow(clippy::match_same_arms)]
@@ -2595,7 +2448,7 @@ Self::V1(_) => 1,
 
         impl ReadXdr for IntUnion {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     let dv: i32 = <i32 as ReadXdr>::read_xdr(r)?;
                     #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
@@ -2612,7 +2465,7 @@ Self::V1(_) => 1,
 
         impl WriteXdr for IntUnion {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     self.discriminant().write_xdr(w)?;
                     #[allow(clippy::match_same_arms)]
@@ -2658,7 +2511,7 @@ impl AsRef<IntUnion> for IntUnion2 {
 
 impl ReadXdr for IntUnion2 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = IntUnion::read_xdr(r)?;
             let v = IntUnion2(i);
@@ -2669,7 +2522,7 @@ impl ReadXdr for IntUnion2 {
 
 impl WriteXdr for IntUnion2 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -2784,7 +2637,7 @@ TypeVariant::IntUnion2, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 match v {
                     TypeVariant::SError => r.with_limited_depth(|r| Ok(Self::SError(Box::new(SError::read_xdr(r)?)))),
 TypeVariant::Multi => r.with_limited_depth(|r| Ok(Self::Multi(Box::new(Multi::read_xdr(r)?)))),
@@ -2796,14 +2649,14 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2815,63 +2668,63 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::SError(Box::new(t))))),
-TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
-TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
-TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
+                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::SError(Box::new(t))))),
+TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
+TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
+TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::SError => Box::new(ReadXdrIter::<_, Frame<SError>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::SError(Box::new(t.0))))),
-TypeVariant::Multi => Box::new(ReadXdrIter::<_, Frame<Multi>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Multi(Box::new(t.0))))),
-TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
-TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, Frame<IntUnion>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::IntUnion(Box::new(t.0))))),
-TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, Frame<IntUnion2>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::IntUnion2(Box::new(t.0))))),
+                    TypeVariant::SError => Box::new(ReadXdrIter::<_, Frame<SError>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::SError(Box::new(t.0))))),
+TypeVariant::Multi => Box::new(ReadXdrIter::<_, Frame<Multi>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Multi(Box::new(t.0))))),
+TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
+TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, Frame<IntUnion>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::IntUnion(Box::new(t.0))))),
+TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, Frame<IntUnion2>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::IntUnion2(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::SError(Box::new(t))))),
-TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
-TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
-TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
+                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(dec, r.limits).map(|r| r.map(|t| Self::SError(Box::new(t))))),
+TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(dec, r.limits).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
+TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.limits).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, r.limits).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(dec, r.limits).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
+TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.limits).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+                let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String, limits: Limits) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2953,7 +2806,7 @@ Self::IntUnion2(_) => TypeVariant::IntUnion2,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 match self {
                     Self::SError(v) => v.write_xdr(w),
 Self::Multi(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -219,21 +219,21 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
-    fn none() -> Self {
+    pub fn none() -> Self {
         Self {
             depth: u32::MAX,
             len: usize::MAX,
         }
     }
 
-    fn depth(depth: u32) -> Self {
+    pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
             ..Limits::none()
         }
     }
 
-    fn len(len: usize) -> Self {
+    pub fn len(len: usize) -> Self {
         Limits {
             len,
             ..Limits::none()

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -69,6 +69,7 @@ pub enum Error {
     DepthLimitExceeded,
     #[cfg(feature = "serde_json")]
     Json(serde_json::Error),
+    LengthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -117,6 +118,7 @@ impl fmt::Display for Error {
             Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
             #[cfg(feature = "serde_json")]
             Error::Json(e) => write!(f, "{e}"),
+            Error::LengthLimitExceeded => write!(f, "length limit exceeded"),
         }
     }
 }
@@ -199,6 +201,7 @@ where
 /// `Limits` contains the limits that a limited reader or writer will be
 /// constrained to.
 #[cfg(feature = "std")]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Limits {
     /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
     ///
@@ -207,12 +210,18 @@ pub struct Limits {
     /// For more information about Rust's stack size limit, refer to the
     /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
     pub depth: u32,
+
+    /// Defines the maximum number of bytes that will be read or read.
+    pub len: usize,
 }
 
 #[cfg(feature = "std")]
 impl Default for Limits {
     fn default() -> Self {
-        Self { depth: 500 }
+        Self {
+            depth: 500,
+            len: usize::MAX,
+        }
     }
 }
 
@@ -233,7 +242,16 @@ impl<L> Limited<L> {
         Limited { inner, limits }
     }
 
-    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+        if let Some(len) = self.limits.len.checked_sub(len) {
+            self.limits.len = len;
+            Ok(())
+        } else {
+            Err(Error::LengthLimitExceeded)
+        }
+    }
+
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
     where
         F: FnOnce(&mut Self) -> Result<T>,
     {
@@ -245,6 +263,40 @@ impl<L> Limited<L> {
         let res = f(self);
         self.limits.depth = self.limits.depth.saturating_add(1);
         res
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: BufRead> BufRead for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        self.inner.fill_buf()
+    }
+
+    /// Forwards the read operation to the wrapped object.
+    fn consume(&mut self, amt: usize) {
+        self.inner.consume(amt);
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for Limited<W> {
+    /// Forwards the write operation to the wrapped object.
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    /// Forwards the flush operation to the wrapped object.
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
     }
 }
 
@@ -285,7 +337,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.inner.fill_buf() {
+        match self.reader.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -332,7 +384,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -376,7 +428,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -452,7 +504,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
+        ReadXdrIter::new(&mut r.inner, r.limits.clone())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -462,7 +514,7 @@ where
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining)
+        ReadXdrIter::new(dec, r.limits.clone())
     }
 
     /// Construct the type from the XDR bytes.
@@ -528,6 +580,7 @@ impl ReadXdr for i32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i32::from_be_bytes(b))
         })
@@ -538,7 +591,10 @@ impl WriteXdr for i32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -547,6 +603,7 @@ impl ReadXdr for u32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u32::from_be_bytes(b))
         })
@@ -557,7 +614,10 @@ impl WriteXdr for u32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -566,6 +626,7 @@ impl ReadXdr for i64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i64::from_be_bytes(b))
         })
@@ -576,7 +637,10 @@ impl WriteXdr for i64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -585,6 +649,7 @@ impl ReadXdr for u64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u64::from_be_bytes(b))
         })
@@ -595,7 +660,10 @@ impl WriteXdr for u64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -631,6 +699,7 @@ impl ReadXdr for bool {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             let b = i == 1;
             Ok(b)
@@ -642,6 +711,7 @@ impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
         })
@@ -652,6 +722,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             match i {
                 0 => Ok(None),
@@ -669,6 +740,7 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
                 t.write_xdr(w)?;
@@ -712,9 +784,12 @@ impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(N)?;
+            let padding = pad_len(N);
+            r.consume_len(padding)?;
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
-            let pad = &mut [0u8; 3][..pad_len(N)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -728,8 +803,11 @@ impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(N)?;
+            let padding = pad_len(N);
+            w.consume_len(padding)?;
             w.write_all(self)?;
-            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            w.write_all(&[0u8; 3][..padding])?;
             Ok(())
         })
     }
@@ -1087,15 +1165,20 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1110,12 +1193,17 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1126,6 +1214,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
@@ -1146,6 +1235,7 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1485,15 +1575,20 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1508,6 +1603,11 @@ impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1868,15 +1968,21 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
+
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1891,12 +1997,17 @@ impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1925,6 +2036,7 @@ where
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
         //  follow the frame header.
+        r.consume_len(core::mem::size_of::<u32>())?;
         let header = u32::read_xdr(r)?;
         // TODO: Use the length and cap the length we'll read from `r`.
         let last_record = header >> 31 == 1;
@@ -1948,16 +2060,14 @@ mod tests {
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
@@ -1986,11 +2096,8 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1998,11 +2105,8 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
@@ -2044,10 +2148,7 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -2056,10 +2157,7 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
@@ -2096,10 +2194,22 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
+        let mut dlr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
@@ -2107,7 +2217,13 @@ mod test {
     #[test]
     fn write_over_depth_limit_fail() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 3,
+                len: usize::MAX,
+            },
+        );
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2117,8 +2233,14 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_limits = Limits { depth: 3 };
-        let write_limits = Limits { depth: 5 };
+        let read_limits = Limits {
+            depth: 3,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            depth: 5,
+            ..Limits::default()
+        };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
         let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
@@ -2322,7 +2444,7 @@ impl Type {
 
     #[cfg(feature = "base64")]
     pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
         let t = Self::read_xdr(v, &mut dec)?;
         Ok(t)
     }
@@ -2341,7 +2463,7 @@ impl Type {
 
     #[cfg(feature = "base64")]
     pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
     }
@@ -2350,7 +2472,7 @@ impl Type {
     #[allow(clippy::too_many_lines)]
     pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
     }
 
@@ -2358,7 +2480,7 @@ impl Type {
     #[allow(clippy::too_many_lines)]
     pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, Frame<AccountFlags>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::AccountFlags(Box::new(t.0))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, Frame<AccountFlags>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t.0))))),
         }
     }
 
@@ -2367,7 +2489,7 @@ impl Type {
     pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec, r.limits).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
     }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -2268,6 +2268,68 @@ mod test {
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
         }
     }
+
+    #[test]
+    fn length_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut lr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[test]
+    fn write_over_length_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 15,
+                ..Limits::default()
+            },
+        );
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected LengthLimitExceeded got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn read_over_length_limit_fail() {
+        let read_limits = Limits {
+            len: 15,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            len: 16,
+            ..Limits::default()
+        };
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(Vec::new(), read_limits);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
+    }
 }
 
 #[cfg(all(test, not(feature = "alloc")))]

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -273,12 +273,12 @@ impl<L> Limited<L> {
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
+            let res = f(self);
+            self.limits.depth = self.limits.depth.saturating_add(1);
+            res
         } else {
-            return Err(Error::DepthLimitExceeded);
+            Err(Error::DepthLimitExceeded)
         }
-        let res = f(self);
-        self.limits.depth = self.limits.depth.saturating_add(1);
-        res
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -219,6 +219,7 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
+    #[must_use]
     pub fn none() -> Self {
         Self {
             depth: u32::MAX,
@@ -226,6 +227,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
@@ -233,6 +235,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn len(len: usize) -> Self {
         Limits {
             len,

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -51,14 +51,6 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
-///
-/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
-/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the
-/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
-
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
 /// compared on their `ErrorKind`.
@@ -204,172 +196,71 @@ where
 {
 }
 
-/// `DepthLimiter` is a trait designed for managing the depth of recursive operations.
-/// It provides a mechanism to limit recursion depth, and defines the behavior upon
-/// entering and leaving a recursion level.
-pub trait DepthLimiter {
-    /// A general error type for any type implementing, or an operation under the guard of
-    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
-    /// which is returned from `enter`.
-    type DepthLimiterError;
+/// `Limits` contains the limits that a limited reader or writer will be
+/// constrained to.
+#[cfg(feature = "std")]
+pub struct Limits {
+    /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+    ///
+    /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+    /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+    /// For more information about Rust's stack size limit, refer to the
+    /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+    pub depth: u32,
+}
 
-    /// Defines the behavior for entering a new recursion level.
-    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
-    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Defines the behavior for leaving a recursion level.
-    /// A `DepthLimiterError` is returned if an error occurs.
-    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Wraps a given function `f` with depth limiting guards.
-    /// It triggers an `enter` before, and a `leave` after the execution of `f`.
-    ///
-    /// # Parameters
-    ///
-    /// - `f`: The function to be executed under depth limit constraints.
-    ///
-    /// # Returns
-    ///
-    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
-    ///         with an error 3. if error occurs on `leave`.
-    ///   `Ok` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
-    where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
-    {
-        self.enter()?;
-        let res = f(self);
-        self.leave()?;
-        res
+#[cfg(feature = "std")]
+impl Default for Limits {
+    fn default() -> Self {
+        Self { depth: 500 }
     }
 }
 
-/// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
+/// `Limited` wraps an object and provides functions for enforcing limits.
 #[cfg(feature = "std")]
-pub struct DepthLimitedRead<R: Read> {
-    pub inner: R,
-    pub(crate) depth_remaining: u32,
+pub struct Limited<L> {
+    pub inner: L,
+    pub(crate) limits: Limits,
 }
 
 #[cfg(feature = "std")]
-impl<R: Read> DepthLimitedRead<R> {
-    /// Constructs a new `DepthLimitedRead`.
+impl<L> Limited<L> {
+    /// Constructs a new `Limited`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
     /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth_limit: u32) -> Self {
-        DepthLimitedRead {
-            inner,
-            depth_remaining: depth_limit,
-        }
+    pub fn new(inner: L, limits: Limits) -> Self {
+        Limited { inner, limits }
     }
-}
 
-#[cfg(feature = "std")]
-impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> core::result::Result<(), Error> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
+    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut Self) -> Result<T>,
+    {
+        if let Some(depth) = self.limits.depth.checked_sub(1) {
+            self.limits.depth = depth;
         } else {
             return Err(Error::DepthLimitExceeded);
         }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<R: Read> Read for DepthLimitedRead<R> {
-    /// Forwards the read operation to the wrapped object.
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.inner.read(buf)
-    }
-}
-
-/// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
-#[cfg(feature = "std")]
-pub struct DepthLimitedWrite<W: Write> {
-    pub inner: W,
-    pub(crate) depth_remaining: u32,
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimitedWrite<W> {
-    /// Constructs a new `DepthLimitedWrite`.
-    ///
-    /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth_limit: u32) -> Self {
-        DepthLimitedWrite {
-            inner,
-            depth_remaining: depth_limit,
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> Result<()> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
-        } else {
-            return Err(Error::DepthLimitExceeded);
-        }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> Write for DepthLimitedWrite<W> {
-    /// Forwards the write operation to the wrapped object.
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.inner.write(buf)
-    }
-
-    /// Forwards the flush operation to the wrapped object.
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.inner.flush()
+        let res = f(self);
+        self.limits.depth = self.limits.depth.saturating_add(1);
+        res
     }
 }
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: DepthLimitedRead<BufReader<R>>,
+    reader: Limited<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth_limit: u32) -> Self {
+    fn new(r: R, limits: Limits) -> Self {
         Self {
-            reader: DepthLimitedRead {
+            reader: Limited {
                 inner: BufReader::new(r),
-                depth_remaining: depth_limit,
+                limits,
             },
             _s: PhantomData,
         }
@@ -431,15 +322,15 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -466,7 +357,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -482,8 +373,8 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -506,7 +397,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -530,7 +421,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -560,7 +451,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
+    fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
         ReadXdrIter::new(&mut r.inner, r.depth_remaining)
     }
 
@@ -568,88 +459,60 @@ where
     /// values that are read into the implementing type.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
-        r: &mut DepthLimitedRead<R>,
+        r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         ReadXdrIter::new(dec, r.depth_remaining)
     }
 
-    /// Construct the type from the XDR bytes, specifying a depth limit.
+    /// Construct the type from the XDR bytes.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+        let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            depth_limit,
+            limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+        let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
     #[cfg(feature = "base64")]
-    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
-        let mut enc = DepthLimitedWrite::new(
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+        let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            depth_limit,
+            limits,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
-    }
-
-    #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -662,7 +525,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -673,7 +536,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -681,7 +544,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -692,7 +555,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -700,7 +563,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -711,7 +574,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -719,7 +582,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -730,7 +593,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -738,35 +601,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -777,7 +640,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -787,7 +650,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -804,7 +667,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -819,35 +682,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
@@ -863,7 +726,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             w.write_all(self)?;
             w.write_all(&[0u8; 3][..pad_len(N)])?;
@@ -874,7 +737,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -889,7 +752,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -1222,7 +1085,7 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1245,7 +1108,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1261,7 +1124,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1281,7 +1144,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1620,7 +1483,7 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1643,7 +1506,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2003,7 +1866,7 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2026,7 +1889,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2057,7 +1920,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2080,17 +1943,13 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use super::{
-        DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_XDR_RW_DEPTH_LIMIT,
-    };
+    use super::*;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
@@ -2098,16 +1957,14 @@ mod tests {
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2117,8 +1974,7 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2130,7 +1986,7 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2142,7 +1998,7 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2153,23 +2009,21 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2179,7 +2033,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2190,9 +2044,9 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2202,9 +2056,9 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2242,19 +2096,18 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
 
     #[test]
     fn write_over_depth_limit_fail() {
-        let depth_limit = 3;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), depth_limit);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2264,13 +2117,13 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_depth_limit = 3;
-        let write_depth_limit = 5;
+        let read_limits = Limits { depth: 3 };
+        let write_limits = Limits { depth: 5 };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), write_depth_limit);
+        let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), read_depth_limit);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
         let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2372,7 +2225,7 @@ impl From<AccountFlags> for i32 {
 
 impl ReadXdr for AccountFlags {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let e = i32::read_xdr(r)?;
             let v: Self = e.try_into()?;
@@ -2383,7 +2236,7 @@ impl ReadXdr for AccountFlags {
 
 impl WriteXdr for AccountFlags {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let i: i32 = (*self).into();
             i.write_xdr(w)
@@ -2461,21 +2314,21 @@ impl Type {
 
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
         match v {
             TypeVariant::AccountFlags => r.with_limited_depth(|r| Ok(Self::AccountFlags(Box::new(AccountFlags::read_xdr(r)?)))),
         }
     }
 
     #[cfg(feature = "base64")]
-    pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+    pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
         let t = Self::read_xdr(v, &mut dec)?;
         Ok(t)
     }
 
     #[cfg(feature = "std")]
-    pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
         let s = Self::read_xdr(v, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -2487,48 +2340,48 @@ impl Type {
     }
 
     #[cfg(feature = "base64")]
-    pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+    pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
     }
 
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+    pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
     }
 
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+    pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, Frame<AccountFlags>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::AccountFlags(Box::new(t.0))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, Frame<AccountFlags>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::AccountFlags(Box::new(t.0))))),
         }
     }
 
     #[cfg(feature = "base64")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+    pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         match v {
-            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
+            TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec, r.limits).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
     }
 
     #[cfg(feature = "std")]
-    pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
+    pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+        let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(v, &mut cursor)?;
         Ok(t)
     }
 
     #[cfg(feature = "base64")]
-    pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+    pub fn from_xdr_base64(v: TypeVariant, b64: String, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
+        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
     }
@@ -2590,7 +2443,7 @@ impl Variants<TypeVariant> for Type {
 impl WriteXdr for Type {
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         match self {
             Self::AccountFlags(v) => v.write_xdr(w),
         }

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -219,21 +219,21 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
-    fn none() -> Self {
+    pub fn none() -> Self {
         Self {
             depth: u32::MAX,
             len: usize::MAX,
         }
     }
 
-    fn depth(depth: u32) -> Self {
+    pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
             ..Limits::none()
         }
     }
 
-    fn len(len: usize) -> Self {
+    pub fn len(len: usize) -> Self {
         Limits {
             len,
             ..Limits::none()

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -69,6 +69,7 @@ pub enum Error {
     DepthLimitExceeded,
     #[cfg(feature = "serde_json")]
     Json(serde_json::Error),
+    LengthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -117,6 +118,7 @@ impl fmt::Display for Error {
             Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
             #[cfg(feature = "serde_json")]
             Error::Json(e) => write!(f, "{e}"),
+            Error::LengthLimitExceeded => write!(f, "length limit exceeded"),
         }
     }
 }
@@ -199,6 +201,7 @@ where
 /// `Limits` contains the limits that a limited reader or writer will be
 /// constrained to.
 #[cfg(feature = "std")]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Limits {
     /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
     ///
@@ -207,12 +210,18 @@ pub struct Limits {
     /// For more information about Rust's stack size limit, refer to the
     /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
     pub depth: u32,
+
+    /// Defines the maximum number of bytes that will be read or read.
+    pub len: usize,
 }
 
 #[cfg(feature = "std")]
 impl Default for Limits {
     fn default() -> Self {
-        Self { depth: 500 }
+        Self {
+            depth: 500,
+            len: usize::MAX,
+        }
     }
 }
 
@@ -233,7 +242,16 @@ impl<L> Limited<L> {
         Limited { inner, limits }
     }
 
-    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+        if let Some(len) = self.limits.len.checked_sub(len) {
+            self.limits.len = len;
+            Ok(())
+        } else {
+            Err(Error::LengthLimitExceeded)
+        }
+    }
+
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
     where
         F: FnOnce(&mut Self) -> Result<T>,
     {
@@ -245,6 +263,40 @@ impl<L> Limited<L> {
         let res = f(self);
         self.limits.depth = self.limits.depth.saturating_add(1);
         res
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: BufRead> BufRead for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        self.inner.fill_buf()
+    }
+
+    /// Forwards the read operation to the wrapped object.
+    fn consume(&mut self, amt: usize) {
+        self.inner.consume(amt);
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for Limited<W> {
+    /// Forwards the write operation to the wrapped object.
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    /// Forwards the flush operation to the wrapped object.
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
     }
 }
 
@@ -285,7 +337,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.inner.fill_buf() {
+        match self.reader.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -332,7 +384,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -376,7 +428,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -452,7 +504,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
+        ReadXdrIter::new(&mut r.inner, r.limits.clone())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -462,7 +514,7 @@ where
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining)
+        ReadXdrIter::new(dec, r.limits.clone())
     }
 
     /// Construct the type from the XDR bytes.
@@ -528,6 +580,7 @@ impl ReadXdr for i32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i32::from_be_bytes(b))
         })
@@ -538,7 +591,10 @@ impl WriteXdr for i32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -547,6 +603,7 @@ impl ReadXdr for u32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u32::from_be_bytes(b))
         })
@@ -557,7 +614,10 @@ impl WriteXdr for u32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -566,6 +626,7 @@ impl ReadXdr for i64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i64::from_be_bytes(b))
         })
@@ -576,7 +637,10 @@ impl WriteXdr for i64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -585,6 +649,7 @@ impl ReadXdr for u64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u64::from_be_bytes(b))
         })
@@ -595,7 +660,10 @@ impl WriteXdr for u64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -631,6 +699,7 @@ impl ReadXdr for bool {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             let b = i == 1;
             Ok(b)
@@ -642,6 +711,7 @@ impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
         })
@@ -652,6 +722,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             match i {
                 0 => Ok(None),
@@ -669,6 +740,7 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
                 t.write_xdr(w)?;
@@ -712,9 +784,12 @@ impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(N)?;
+            let padding = pad_len(N);
+            r.consume_len(padding)?;
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
-            let pad = &mut [0u8; 3][..pad_len(N)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -728,8 +803,11 @@ impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(N)?;
+            let padding = pad_len(N);
+            w.consume_len(padding)?;
             w.write_all(self)?;
-            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            w.write_all(&[0u8; 3][..padding])?;
             Ok(())
         })
     }
@@ -1087,15 +1165,20 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1110,12 +1193,17 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1126,6 +1214,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
@@ -1146,6 +1235,7 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1485,15 +1575,20 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1508,6 +1603,11 @@ impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1868,15 +1968,21 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
+
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1891,12 +1997,17 @@ impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1925,6 +2036,7 @@ where
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
         //  follow the frame header.
+        r.consume_len(core::mem::size_of::<u32>())?;
         let header = u32::read_xdr(r)?;
         // TODO: Use the length and cap the length we'll read from `r`.
         let last_record = header >> 31 == 1;
@@ -1948,16 +2060,14 @@ mod tests {
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
@@ -1986,11 +2096,8 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1998,11 +2105,8 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
@@ -2044,10 +2148,7 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -2056,10 +2157,7 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
@@ -2096,10 +2194,22 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
+        let mut dlr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
@@ -2107,7 +2217,13 @@ mod test {
     #[test]
     fn write_over_depth_limit_fail() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 3,
+                len: usize::MAX,
+            },
+        );
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2117,8 +2233,14 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_limits = Limits { depth: 3 };
-        let write_limits = Limits { depth: 5 };
+        let read_limits = Limits {
+            depth: 3,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            depth: 5,
+            ..Limits::default()
+        };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
         let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
@@ -2254,7 +2376,7 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2273,7 +2395,7 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2282,8 +2404,8 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
-TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
+                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
+TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
                 }
             }
 
@@ -2291,8 +2413,8 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inn
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, Frame<TestArray>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::TestArray(Box::new(t.0))))),
-TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::TestArray2(Box::new(t.0))))),
+                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, Frame<TestArray>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::TestArray(Box::new(t.0))))),
+TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::TestArray2(Box::new(t.0))))),
                 }
             }
 
@@ -2301,8 +2423,8 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mu
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(dec, r.limits).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
-TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.limits).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
+                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
+TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -51,14 +51,6 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
-///
-/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
-/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the
-/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
-
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
 /// compared on their `ErrorKind`.
@@ -204,172 +196,71 @@ where
 {
 }
 
-/// `DepthLimiter` is a trait designed for managing the depth of recursive operations.
-/// It provides a mechanism to limit recursion depth, and defines the behavior upon
-/// entering and leaving a recursion level.
-pub trait DepthLimiter {
-    /// A general error type for any type implementing, or an operation under the guard of
-    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
-    /// which is returned from `enter`.
-    type DepthLimiterError;
+/// `Limits` contains the limits that a limited reader or writer will be
+/// constrained to.
+#[cfg(feature = "std")]
+pub struct Limits {
+    /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+    ///
+    /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+    /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+    /// For more information about Rust's stack size limit, refer to the
+    /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+    pub depth: u32,
+}
 
-    /// Defines the behavior for entering a new recursion level.
-    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
-    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Defines the behavior for leaving a recursion level.
-    /// A `DepthLimiterError` is returned if an error occurs.
-    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Wraps a given function `f` with depth limiting guards.
-    /// It triggers an `enter` before, and a `leave` after the execution of `f`.
-    ///
-    /// # Parameters
-    ///
-    /// - `f`: The function to be executed under depth limit constraints.
-    ///
-    /// # Returns
-    ///
-    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
-    ///         with an error 3. if error occurs on `leave`.
-    ///   `Ok` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
-    where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
-    {
-        self.enter()?;
-        let res = f(self);
-        self.leave()?;
-        res
+#[cfg(feature = "std")]
+impl Default for Limits {
+    fn default() -> Self {
+        Self { depth: 500 }
     }
 }
 
-/// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
+/// `Limited` wraps an object and provides functions for enforcing limits.
 #[cfg(feature = "std")]
-pub struct DepthLimitedRead<R: Read> {
-    pub inner: R,
-    pub(crate) depth_remaining: u32,
+pub struct Limited<L> {
+    pub inner: L,
+    pub(crate) limits: Limits,
 }
 
 #[cfg(feature = "std")]
-impl<R: Read> DepthLimitedRead<R> {
-    /// Constructs a new `DepthLimitedRead`.
+impl<L> Limited<L> {
+    /// Constructs a new `Limited`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
     /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth_limit: u32) -> Self {
-        DepthLimitedRead {
-            inner,
-            depth_remaining: depth_limit,
-        }
+    pub fn new(inner: L, limits: Limits) -> Self {
+        Limited { inner, limits }
     }
-}
 
-#[cfg(feature = "std")]
-impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> core::result::Result<(), Error> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
+    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut Self) -> Result<T>,
+    {
+        if let Some(depth) = self.limits.depth.checked_sub(1) {
+            self.limits.depth = depth;
         } else {
             return Err(Error::DepthLimitExceeded);
         }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<R: Read> Read for DepthLimitedRead<R> {
-    /// Forwards the read operation to the wrapped object.
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.inner.read(buf)
-    }
-}
-
-/// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
-#[cfg(feature = "std")]
-pub struct DepthLimitedWrite<W: Write> {
-    pub inner: W,
-    pub(crate) depth_remaining: u32,
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimitedWrite<W> {
-    /// Constructs a new `DepthLimitedWrite`.
-    ///
-    /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth_limit: u32) -> Self {
-        DepthLimitedWrite {
-            inner,
-            depth_remaining: depth_limit,
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> Result<()> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
-        } else {
-            return Err(Error::DepthLimitExceeded);
-        }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> Write for DepthLimitedWrite<W> {
-    /// Forwards the write operation to the wrapped object.
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.inner.write(buf)
-    }
-
-    /// Forwards the flush operation to the wrapped object.
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.inner.flush()
+        let res = f(self);
+        self.limits.depth = self.limits.depth.saturating_add(1);
+        res
     }
 }
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: DepthLimitedRead<BufReader<R>>,
+    reader: Limited<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth_limit: u32) -> Self {
+    fn new(r: R, limits: Limits) -> Self {
         Self {
-            reader: DepthLimitedRead {
+            reader: Limited {
                 inner: BufReader::new(r),
-                depth_remaining: depth_limit,
+                limits,
             },
             _s: PhantomData,
         }
@@ -431,15 +322,15 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -466,7 +357,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -482,8 +373,8 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -506,7 +397,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -530,7 +421,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -560,7 +451,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
+    fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
         ReadXdrIter::new(&mut r.inner, r.depth_remaining)
     }
 
@@ -568,88 +459,60 @@ where
     /// values that are read into the implementing type.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
-        r: &mut DepthLimitedRead<R>,
+        r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         ReadXdrIter::new(dec, r.depth_remaining)
     }
 
-    /// Construct the type from the XDR bytes, specifying a depth limit.
+    /// Construct the type from the XDR bytes.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+        let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            depth_limit,
+            limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+        let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
     #[cfg(feature = "base64")]
-    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
-        let mut enc = DepthLimitedWrite::new(
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+        let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            depth_limit,
+            limits,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
-    }
-
-    #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -662,7 +525,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -673,7 +536,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -681,7 +544,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -692,7 +555,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -700,7 +563,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -711,7 +574,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -719,7 +582,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -730,7 +593,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -738,35 +601,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -777,7 +640,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -787,7 +650,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -804,7 +667,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -819,35 +682,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
@@ -863,7 +726,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             w.write_all(self)?;
             w.write_all(&[0u8; 3][..pad_len(N)])?;
@@ -874,7 +737,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -889,7 +752,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -1222,7 +1085,7 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1245,7 +1108,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1261,7 +1124,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1281,7 +1144,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1620,7 +1483,7 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1643,7 +1506,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2003,7 +1866,7 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2026,7 +1889,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2057,7 +1920,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2080,17 +1943,13 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use super::{
-        DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_XDR_RW_DEPTH_LIMIT,
-    };
+    use super::*;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
@@ -2098,16 +1957,14 @@ mod tests {
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2117,8 +1974,7 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2130,7 +1986,7 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2142,7 +1998,7 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2153,23 +2009,21 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2179,7 +2033,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2190,9 +2044,9 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2202,9 +2056,9 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2242,19 +2096,18 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
 
     #[test]
     fn write_over_depth_limit_fail() {
-        let depth_limit = 3;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), depth_limit);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2264,13 +2117,13 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_depth_limit = 3;
-        let write_depth_limit = 5;
+        let read_limits = Limits { depth: 3 };
+        let write_limits = Limits { depth: 5 };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), write_depth_limit);
+        let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), read_depth_limit);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
         let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2392,7 +2245,7 @@ TypeVariant::TestArray2, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 match v {
                     TypeVariant::TestArray => r.with_limited_depth(|r| Ok(Self::TestArray(Box::new(TestArray::read_xdr(r)?)))),
 TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new(TestArray2::read_xdr(r)?)))),
@@ -2400,14 +2253,14 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2419,51 +2272,51 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
-TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
+                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
+TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, Frame<TestArray>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::TestArray(Box::new(t.0))))),
-TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::TestArray2(Box::new(t.0))))),
+                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, Frame<TestArray>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::TestArray(Box::new(t.0))))),
+TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::TestArray2(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
-TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
+                    TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(dec, r.limits).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
+TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.limits).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+                let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String, limits: Limits) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2529,7 +2382,7 @@ Self::TestArray2(_) => TypeVariant::TestArray2,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 match self {
                     Self::TestArray(v) => v.write_xdr(w),
 Self::TestArray2(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -2268,6 +2268,68 @@ mod test {
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
         }
     }
+
+    #[test]
+    fn length_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut lr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[test]
+    fn write_over_length_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 15,
+                ..Limits::default()
+            },
+        );
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected LengthLimitExceeded got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn read_over_length_limit_fail() {
+        let read_limits = Limits {
+            len: 15,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            len: 16,
+            ..Limits::default()
+        };
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(Vec::new(), read_limits);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
+    }
 }
 
 #[cfg(all(test, not(feature = "alloc")))]

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -273,12 +273,12 @@ impl<L> Limited<L> {
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
+            let res = f(self);
+            self.limits.depth = self.limits.depth.saturating_add(1);
+            res
         } else {
-            return Err(Error::DepthLimitExceeded);
+            Err(Error::DepthLimitExceeded)
         }
-        let res = f(self);
-        self.limits.depth = self.limits.depth.saturating_add(1);
-        res
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -219,6 +219,7 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
+    #[must_use]
     pub fn none() -> Self {
         Self {
             depth: u32::MAX,
@@ -226,6 +227,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
@@ -233,6 +235,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn len(len: usize) -> Self {
         Limits {
             len,

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -219,21 +219,21 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
-    fn none() -> Self {
+    pub fn none() -> Self {
         Self {
             depth: u32::MAX,
             len: usize::MAX,
         }
     }
 
-    fn depth(depth: u32) -> Self {
+    pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
             ..Limits::none()
         }
     }
 
-    fn len(len: usize) -> Self {
+    pub fn len(len: usize) -> Self {
         Limits {
             len,
             ..Limits::none()

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -51,14 +51,6 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
-///
-/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
-/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the
-/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
-
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
 /// compared on their `ErrorKind`.
@@ -204,172 +196,71 @@ where
 {
 }
 
-/// `DepthLimiter` is a trait designed for managing the depth of recursive operations.
-/// It provides a mechanism to limit recursion depth, and defines the behavior upon
-/// entering and leaving a recursion level.
-pub trait DepthLimiter {
-    /// A general error type for any type implementing, or an operation under the guard of
-    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
-    /// which is returned from `enter`.
-    type DepthLimiterError;
+/// `Limits` contains the limits that a limited reader or writer will be
+/// constrained to.
+#[cfg(feature = "std")]
+pub struct Limits {
+    /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+    ///
+    /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+    /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+    /// For more information about Rust's stack size limit, refer to the
+    /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+    pub depth: u32,
+}
 
-    /// Defines the behavior for entering a new recursion level.
-    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
-    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Defines the behavior for leaving a recursion level.
-    /// A `DepthLimiterError` is returned if an error occurs.
-    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Wraps a given function `f` with depth limiting guards.
-    /// It triggers an `enter` before, and a `leave` after the execution of `f`.
-    ///
-    /// # Parameters
-    ///
-    /// - `f`: The function to be executed under depth limit constraints.
-    ///
-    /// # Returns
-    ///
-    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
-    ///         with an error 3. if error occurs on `leave`.
-    ///   `Ok` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
-    where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
-    {
-        self.enter()?;
-        let res = f(self);
-        self.leave()?;
-        res
+#[cfg(feature = "std")]
+impl Default for Limits {
+    fn default() -> Self {
+        Self { depth: 500 }
     }
 }
 
-/// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
+/// `Limited` wraps an object and provides functions for enforcing limits.
 #[cfg(feature = "std")]
-pub struct DepthLimitedRead<R: Read> {
-    pub inner: R,
-    pub(crate) depth_remaining: u32,
+pub struct Limited<L> {
+    pub inner: L,
+    pub(crate) limits: Limits,
 }
 
 #[cfg(feature = "std")]
-impl<R: Read> DepthLimitedRead<R> {
-    /// Constructs a new `DepthLimitedRead`.
+impl<L> Limited<L> {
+    /// Constructs a new `Limited`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
     /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth_limit: u32) -> Self {
-        DepthLimitedRead {
-            inner,
-            depth_remaining: depth_limit,
-        }
+    pub fn new(inner: L, limits: Limits) -> Self {
+        Limited { inner, limits }
     }
-}
 
-#[cfg(feature = "std")]
-impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> core::result::Result<(), Error> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
+    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut Self) -> Result<T>,
+    {
+        if let Some(depth) = self.limits.depth.checked_sub(1) {
+            self.limits.depth = depth;
         } else {
             return Err(Error::DepthLimitExceeded);
         }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<R: Read> Read for DepthLimitedRead<R> {
-    /// Forwards the read operation to the wrapped object.
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.inner.read(buf)
-    }
-}
-
-/// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
-#[cfg(feature = "std")]
-pub struct DepthLimitedWrite<W: Write> {
-    pub inner: W,
-    pub(crate) depth_remaining: u32,
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimitedWrite<W> {
-    /// Constructs a new `DepthLimitedWrite`.
-    ///
-    /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth_limit: u32) -> Self {
-        DepthLimitedWrite {
-            inner,
-            depth_remaining: depth_limit,
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> Result<()> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
-        } else {
-            return Err(Error::DepthLimitExceeded);
-        }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> Write for DepthLimitedWrite<W> {
-    /// Forwards the write operation to the wrapped object.
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.inner.write(buf)
-    }
-
-    /// Forwards the flush operation to the wrapped object.
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.inner.flush()
+        let res = f(self);
+        self.limits.depth = self.limits.depth.saturating_add(1);
+        res
     }
 }
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: DepthLimitedRead<BufReader<R>>,
+    reader: Limited<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth_limit: u32) -> Self {
+    fn new(r: R, limits: Limits) -> Self {
         Self {
-            reader: DepthLimitedRead {
+            reader: Limited {
                 inner: BufReader::new(r),
-                depth_remaining: depth_limit,
+                limits,
             },
             _s: PhantomData,
         }
@@ -431,15 +322,15 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -466,7 +357,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -482,8 +373,8 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -506,7 +397,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -530,7 +421,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -560,7 +451,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
+    fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
         ReadXdrIter::new(&mut r.inner, r.depth_remaining)
     }
 
@@ -568,88 +459,60 @@ where
     /// values that are read into the implementing type.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
-        r: &mut DepthLimitedRead<R>,
+        r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         ReadXdrIter::new(dec, r.depth_remaining)
     }
 
-    /// Construct the type from the XDR bytes, specifying a depth limit.
+    /// Construct the type from the XDR bytes.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+        let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            depth_limit,
+            limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+        let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
     #[cfg(feature = "base64")]
-    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
-        let mut enc = DepthLimitedWrite::new(
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+        let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            depth_limit,
+            limits,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
-    }
-
-    #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -662,7 +525,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -673,7 +536,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -681,7 +544,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -692,7 +555,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -700,7 +563,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -711,7 +574,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -719,7 +582,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -730,7 +593,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -738,35 +601,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -777,7 +640,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -787,7 +650,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -804,7 +667,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -819,35 +682,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
@@ -863,7 +726,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             w.write_all(self)?;
             w.write_all(&[0u8; 3][..pad_len(N)])?;
@@ -874,7 +737,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -889,7 +752,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -1222,7 +1085,7 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1245,7 +1108,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1261,7 +1124,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1281,7 +1144,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1620,7 +1483,7 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1643,7 +1506,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2003,7 +1866,7 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2026,7 +1889,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2057,7 +1920,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2080,17 +1943,13 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use super::{
-        DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_XDR_RW_DEPTH_LIMIT,
-    };
+    use super::*;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
@@ -2098,16 +1957,14 @@ mod tests {
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2117,8 +1974,7 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2130,7 +1986,7 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2142,7 +1998,7 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2153,23 +2009,21 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2179,7 +2033,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2190,9 +2044,9 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2202,9 +2056,9 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2242,19 +2096,18 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
 
     #[test]
     fn write_over_depth_limit_fail() {
-        let depth_limit = 3;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), depth_limit);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2264,13 +2117,13 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_depth_limit = 3;
-        let write_depth_limit = 5;
+        let read_limits = Limits { depth: 3 };
+        let write_limits = Limits { depth: 5 };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), write_depth_limit);
+        let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), read_depth_limit);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
         let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2456,7 +2309,7 @@ Self::FbaMessage => "FbaMessage",
 
         impl ReadXdr for MessageType {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -2467,7 +2320,7 @@ Self::FbaMessage => "FbaMessage",
 
         impl WriteXdr for MessageType {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -2562,7 +2415,7 @@ Self::Blue => "Blue",
 
         impl ReadXdr for Color {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -2573,7 +2426,7 @@ Self::Blue => "Blue",
 
         impl WriteXdr for Color {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -2668,7 +2521,7 @@ Self::Blue2 => "Blue2",
 
         impl ReadXdr for Color2 {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -2679,7 +2532,7 @@ Self::Blue2 => "Blue2",
 
         impl WriteXdr for Color2 {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -2773,7 +2626,7 @@ TypeVariant::Color2, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 match v {
                     TypeVariant::MessageType => r.with_limited_depth(|r| Ok(Self::MessageType(Box::new(MessageType::read_xdr(r)?)))),
 TypeVariant::Color => r.with_limited_depth(|r| Ok(Self::Color(Box::new(Color::read_xdr(r)?)))),
@@ -2782,14 +2635,14 @@ TypeVariant::Color2 => r.with_limited_depth(|r| Ok(Self::Color2(Box::new(Color2:
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2801,54 +2654,54 @@ TypeVariant::Color2 => r.with_limited_depth(|r| Ok(Self::Color2(Box::new(Color2:
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, Frame<MessageType>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MessageType(Box::new(t.0))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Frame<Color2>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Color2(Box::new(t.0))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, Frame<MessageType>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MessageType(Box::new(t.0))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Frame<Color2>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Color2(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(dec, r.limits).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, r.limits).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(dec, r.limits).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+                let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String, limits: Limits) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2918,7 +2771,7 @@ Self::Color2(_) => TypeVariant::Color2,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 match self {
                     Self::MessageType(v) => v.write_xdr(w),
 Self::Color(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -2268,6 +2268,68 @@ mod test {
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
         }
     }
+
+    #[test]
+    fn length_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut lr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[test]
+    fn write_over_length_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 15,
+                ..Limits::default()
+            },
+        );
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected LengthLimitExceeded got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn read_over_length_limit_fail() {
+        let read_limits = Limits {
+            len: 15,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            len: 16,
+            ..Limits::default()
+        };
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(Vec::new(), read_limits);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
+    }
 }
 
 #[cfg(all(test, not(feature = "alloc")))]

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -273,12 +273,12 @@ impl<L> Limited<L> {
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
+            let res = f(self);
+            self.limits.depth = self.limits.depth.saturating_add(1);
+            res
         } else {
-            return Err(Error::DepthLimitExceeded);
+            Err(Error::DepthLimitExceeded)
         }
-        let res = f(self);
-        self.limits.depth = self.limits.depth.saturating_add(1);
-        res
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -219,6 +219,7 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
+    #[must_use]
     pub fn none() -> Self {
         Self {
             depth: u32::MAX,
@@ -226,6 +227,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
@@ -233,6 +235,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn len(len: usize) -> Self {
         Limits {
             len,

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -69,6 +69,7 @@ pub enum Error {
     DepthLimitExceeded,
     #[cfg(feature = "serde_json")]
     Json(serde_json::Error),
+    LengthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -117,6 +118,7 @@ impl fmt::Display for Error {
             Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
             #[cfg(feature = "serde_json")]
             Error::Json(e) => write!(f, "{e}"),
+            Error::LengthLimitExceeded => write!(f, "length limit exceeded"),
         }
     }
 }
@@ -199,6 +201,7 @@ where
 /// `Limits` contains the limits that a limited reader or writer will be
 /// constrained to.
 #[cfg(feature = "std")]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Limits {
     /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
     ///
@@ -207,12 +210,18 @@ pub struct Limits {
     /// For more information about Rust's stack size limit, refer to the
     /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
     pub depth: u32,
+
+    /// Defines the maximum number of bytes that will be read or read.
+    pub len: usize,
 }
 
 #[cfg(feature = "std")]
 impl Default for Limits {
     fn default() -> Self {
-        Self { depth: 500 }
+        Self {
+            depth: 500,
+            len: usize::MAX,
+        }
     }
 }
 
@@ -233,7 +242,16 @@ impl<L> Limited<L> {
         Limited { inner, limits }
     }
 
-    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+        if let Some(len) = self.limits.len.checked_sub(len) {
+            self.limits.len = len;
+            Ok(())
+        } else {
+            Err(Error::LengthLimitExceeded)
+        }
+    }
+
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
     where
         F: FnOnce(&mut Self) -> Result<T>,
     {
@@ -245,6 +263,40 @@ impl<L> Limited<L> {
         let res = f(self);
         self.limits.depth = self.limits.depth.saturating_add(1);
         res
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: BufRead> BufRead for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        self.inner.fill_buf()
+    }
+
+    /// Forwards the read operation to the wrapped object.
+    fn consume(&mut self, amt: usize) {
+        self.inner.consume(amt);
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for Limited<W> {
+    /// Forwards the write operation to the wrapped object.
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    /// Forwards the flush operation to the wrapped object.
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
     }
 }
 
@@ -285,7 +337,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.inner.fill_buf() {
+        match self.reader.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -332,7 +384,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -376,7 +428,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -452,7 +504,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
+        ReadXdrIter::new(&mut r.inner, r.limits.clone())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -462,7 +514,7 @@ where
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining)
+        ReadXdrIter::new(dec, r.limits.clone())
     }
 
     /// Construct the type from the XDR bytes.
@@ -528,6 +580,7 @@ impl ReadXdr for i32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i32::from_be_bytes(b))
         })
@@ -538,7 +591,10 @@ impl WriteXdr for i32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -547,6 +603,7 @@ impl ReadXdr for u32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u32::from_be_bytes(b))
         })
@@ -557,7 +614,10 @@ impl WriteXdr for u32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -566,6 +626,7 @@ impl ReadXdr for i64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i64::from_be_bytes(b))
         })
@@ -576,7 +637,10 @@ impl WriteXdr for i64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -585,6 +649,7 @@ impl ReadXdr for u64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u64::from_be_bytes(b))
         })
@@ -595,7 +660,10 @@ impl WriteXdr for u64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -631,6 +699,7 @@ impl ReadXdr for bool {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             let b = i == 1;
             Ok(b)
@@ -642,6 +711,7 @@ impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
         })
@@ -652,6 +722,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             match i {
                 0 => Ok(None),
@@ -669,6 +740,7 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
                 t.write_xdr(w)?;
@@ -712,9 +784,12 @@ impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(N)?;
+            let padding = pad_len(N);
+            r.consume_len(padding)?;
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
-            let pad = &mut [0u8; 3][..pad_len(N)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -728,8 +803,11 @@ impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(N)?;
+            let padding = pad_len(N);
+            w.consume_len(padding)?;
             w.write_all(self)?;
-            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            w.write_all(&[0u8; 3][..padding])?;
             Ok(())
         })
     }
@@ -1087,15 +1165,20 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1110,12 +1193,17 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1126,6 +1214,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
@@ -1146,6 +1235,7 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1485,15 +1575,20 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1508,6 +1603,11 @@ impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1868,15 +1968,21 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
+
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1891,12 +1997,17 @@ impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1925,6 +2036,7 @@ where
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
         //  follow the frame header.
+        r.consume_len(core::mem::size_of::<u32>())?;
         let header = u32::read_xdr(r)?;
         // TODO: Use the length and cap the length we'll read from `r`.
         let last_record = header >> 31 == 1;
@@ -1948,16 +2060,14 @@ mod tests {
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
@@ -1986,11 +2096,8 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1998,11 +2105,8 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
@@ -2044,10 +2148,7 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -2056,10 +2157,7 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
@@ -2096,10 +2194,22 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
+        let mut dlr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
@@ -2107,7 +2217,13 @@ mod test {
     #[test]
     fn write_over_depth_limit_fail() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 3,
+                len: usize::MAX,
+            },
+        );
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2117,8 +2233,14 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_limits = Limits { depth: 3 };
-        let write_limits = Limits { depth: 5 };
+        let read_limits = Limits {
+            depth: 3,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            depth: 5,
+            ..Limits::default()
+        };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
         let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
@@ -2636,7 +2758,7 @@ TypeVariant::Color2 => r.with_limited_depth(|r| Ok(Self::Color2(Box::new(Color2:
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2655,7 +2777,7 @@ TypeVariant::Color2 => r.with_limited_depth(|r| Ok(Self::Color2(Box::new(Color2:
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2664,9 +2786,9 @@ TypeVariant::Color2 => r.with_limited_depth(|r| Ok(Self::Color2(Box::new(Color2:
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
                 }
             }
 
@@ -2674,9 +2796,9 @@ TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(&mut r.inner, r.li
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, Frame<MessageType>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MessageType(Box::new(t.0))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Frame<Color2>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Color2(Box::new(t.0))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, Frame<MessageType>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MessageType(Box::new(t.0))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Frame<Color2>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Color2(Box::new(t.0))))),
                 }
             }
 
@@ -2685,9 +2807,9 @@ TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Frame<Color2>>::new(&mut r.inne
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(dec, r.limits).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, r.limits).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(dec, r.limits).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
+                    TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Color2 => Box::new(ReadXdrIter::<_, Color2>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Color2(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -219,21 +219,21 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
-    fn none() -> Self {
+    pub fn none() -> Self {
         Self {
             depth: u32::MAX,
             len: usize::MAX,
         }
     }
 
-    fn depth(depth: u32) -> Self {
+    pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
             ..Limits::none()
         }
     }
 
-    fn len(len: usize) -> Self {
+    pub fn len(len: usize) -> Self {
         Limits {
             len,
             ..Limits::none()

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -51,14 +51,6 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
-///
-/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
-/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the
-/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
-
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
 /// compared on their `ErrorKind`.
@@ -204,172 +196,71 @@ where
 {
 }
 
-/// `DepthLimiter` is a trait designed for managing the depth of recursive operations.
-/// It provides a mechanism to limit recursion depth, and defines the behavior upon
-/// entering and leaving a recursion level.
-pub trait DepthLimiter {
-    /// A general error type for any type implementing, or an operation under the guard of
-    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
-    /// which is returned from `enter`.
-    type DepthLimiterError;
+/// `Limits` contains the limits that a limited reader or writer will be
+/// constrained to.
+#[cfg(feature = "std")]
+pub struct Limits {
+    /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+    ///
+    /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+    /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+    /// For more information about Rust's stack size limit, refer to the
+    /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+    pub depth: u32,
+}
 
-    /// Defines the behavior for entering a new recursion level.
-    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
-    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Defines the behavior for leaving a recursion level.
-    /// A `DepthLimiterError` is returned if an error occurs.
-    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Wraps a given function `f` with depth limiting guards.
-    /// It triggers an `enter` before, and a `leave` after the execution of `f`.
-    ///
-    /// # Parameters
-    ///
-    /// - `f`: The function to be executed under depth limit constraints.
-    ///
-    /// # Returns
-    ///
-    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
-    ///         with an error 3. if error occurs on `leave`.
-    ///   `Ok` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
-    where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
-    {
-        self.enter()?;
-        let res = f(self);
-        self.leave()?;
-        res
+#[cfg(feature = "std")]
+impl Default for Limits {
+    fn default() -> Self {
+        Self { depth: 500 }
     }
 }
 
-/// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
+/// `Limited` wraps an object and provides functions for enforcing limits.
 #[cfg(feature = "std")]
-pub struct DepthLimitedRead<R: Read> {
-    pub inner: R,
-    pub(crate) depth_remaining: u32,
+pub struct Limited<L> {
+    pub inner: L,
+    pub(crate) limits: Limits,
 }
 
 #[cfg(feature = "std")]
-impl<R: Read> DepthLimitedRead<R> {
-    /// Constructs a new `DepthLimitedRead`.
+impl<L> Limited<L> {
+    /// Constructs a new `Limited`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
     /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth_limit: u32) -> Self {
-        DepthLimitedRead {
-            inner,
-            depth_remaining: depth_limit,
-        }
+    pub fn new(inner: L, limits: Limits) -> Self {
+        Limited { inner, limits }
     }
-}
 
-#[cfg(feature = "std")]
-impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> core::result::Result<(), Error> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
+    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut Self) -> Result<T>,
+    {
+        if let Some(depth) = self.limits.depth.checked_sub(1) {
+            self.limits.depth = depth;
         } else {
             return Err(Error::DepthLimitExceeded);
         }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<R: Read> Read for DepthLimitedRead<R> {
-    /// Forwards the read operation to the wrapped object.
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.inner.read(buf)
-    }
-}
-
-/// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
-#[cfg(feature = "std")]
-pub struct DepthLimitedWrite<W: Write> {
-    pub inner: W,
-    pub(crate) depth_remaining: u32,
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimitedWrite<W> {
-    /// Constructs a new `DepthLimitedWrite`.
-    ///
-    /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth_limit: u32) -> Self {
-        DepthLimitedWrite {
-            inner,
-            depth_remaining: depth_limit,
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> Result<()> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
-        } else {
-            return Err(Error::DepthLimitExceeded);
-        }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> Write for DepthLimitedWrite<W> {
-    /// Forwards the write operation to the wrapped object.
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.inner.write(buf)
-    }
-
-    /// Forwards the flush operation to the wrapped object.
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.inner.flush()
+        let res = f(self);
+        self.limits.depth = self.limits.depth.saturating_add(1);
+        res
     }
 }
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: DepthLimitedRead<BufReader<R>>,
+    reader: Limited<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth_limit: u32) -> Self {
+    fn new(r: R, limits: Limits) -> Self {
         Self {
-            reader: DepthLimitedRead {
+            reader: Limited {
                 inner: BufReader::new(r),
-                depth_remaining: depth_limit,
+                limits,
             },
             _s: PhantomData,
         }
@@ -431,15 +322,15 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -466,7 +357,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -482,8 +373,8 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -506,7 +397,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -530,7 +421,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -560,7 +451,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
+    fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
         ReadXdrIter::new(&mut r.inner, r.depth_remaining)
     }
 
@@ -568,88 +459,60 @@ where
     /// values that are read into the implementing type.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
-        r: &mut DepthLimitedRead<R>,
+        r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         ReadXdrIter::new(dec, r.depth_remaining)
     }
 
-    /// Construct the type from the XDR bytes, specifying a depth limit.
+    /// Construct the type from the XDR bytes.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+        let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            depth_limit,
+            limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+        let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
     #[cfg(feature = "base64")]
-    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
-        let mut enc = DepthLimitedWrite::new(
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+        let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            depth_limit,
+            limits,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
-    }
-
-    #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -662,7 +525,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -673,7 +536,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -681,7 +544,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -692,7 +555,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -700,7 +563,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -711,7 +574,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -719,7 +582,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -730,7 +593,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -738,35 +601,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -777,7 +640,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -787,7 +650,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -804,7 +667,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -819,35 +682,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
@@ -863,7 +726,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             w.write_all(self)?;
             w.write_all(&[0u8; 3][..pad_len(N)])?;
@@ -874,7 +737,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -889,7 +752,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -1222,7 +1085,7 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1245,7 +1108,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1261,7 +1124,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1281,7 +1144,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1620,7 +1483,7 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1643,7 +1506,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2003,7 +1866,7 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2026,7 +1889,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2057,7 +1920,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2080,17 +1943,13 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use super::{
-        DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_XDR_RW_DEPTH_LIMIT,
-    };
+    use super::*;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
@@ -2098,16 +1957,14 @@ mod tests {
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2117,8 +1974,7 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2130,7 +1986,7 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2142,7 +1998,7 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2153,23 +2009,21 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2179,7 +2033,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2190,9 +2044,9 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2202,9 +2056,9 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2242,19 +2096,18 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
 
     #[test]
     fn write_over_depth_limit_fail() {
-        let depth_limit = 3;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), depth_limit);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2264,13 +2117,13 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_depth_limit = 3;
-        let write_depth_limit = 5;
+        let read_limits = Limits { depth: 3 };
+        let write_limits = Limits { depth: 5 };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), write_depth_limit);
+        let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), read_depth_limit);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
         let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2383,7 +2236,7 @@ Self::Offer => "Offer",
 
         impl ReadXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -2394,7 +2247,7 @@ Self::Offer => "Offer",
 
         impl WriteXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -2423,7 +2276,7 @@ pub struct MyUnionOne {
 
 impl ReadXdr for MyUnionOne {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             Ok(Self{
               some_int: i32::read_xdr(r)?,
@@ -2434,7 +2287,7 @@ impl ReadXdr for MyUnionOne {
 
 impl WriteXdr for MyUnionOne {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             self.some_int.write_xdr(w)?;
             Ok(())
@@ -2459,7 +2312,7 @@ pub struct MyUnionTwo {
 
         impl ReadXdr for MyUnionTwo {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       some_int: i32::read_xdr(r)?,
@@ -2471,7 +2324,7 @@ foo: i32::read_xdr(r)?,
 
         impl WriteXdr for MyUnionTwo {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     self.some_int.write_xdr(w)?;
 self.foo.write_xdr(w)?;
@@ -2571,7 +2424,7 @@ Self::Offer => UnionKey::Offer,
 
         impl ReadXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     let dv: UnionKey = <UnionKey as ReadXdr>::read_xdr(r)?;
                     #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
@@ -2589,7 +2442,7 @@ UnionKey::Offer => Self::Offer,
 
         impl WriteXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     self.discriminant().write_xdr(w)?;
                     #[allow(clippy::match_same_arms)]
@@ -2705,7 +2558,7 @@ TypeVariant::MyUnionTwo, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 match v {
                     TypeVariant::UnionKey => r.with_limited_depth(|r| Ok(Self::UnionKey(Box::new(UnionKey::read_xdr(r)?)))),
 TypeVariant::Foo => r.with_limited_depth(|r| Ok(Self::Foo(Box::new(Foo::read_xdr(r)?)))),
@@ -2716,14 +2569,14 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2735,60 +2588,60 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
-TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
+                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
+TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
-TypeVariant::Foo => Box::new(ReadXdrIter::<_, Frame<Foo>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Foo(Box::new(t.0))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
-TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, Frame<MyUnionOne>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t.0))))),
-TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t.0))))),
+                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
+TypeVariant::Foo => Box::new(ReadXdrIter::<_, Frame<Foo>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Foo(Box::new(t.0))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
+TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, Frame<MyUnionOne>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t.0))))),
+TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
-TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
+                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.limits).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(dec, r.limits).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, r.limits).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(dec, r.limits).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
+TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.limits).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+                let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String, limits: Limits) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2866,7 +2719,7 @@ Self::MyUnionTwo(_) => TypeVariant::MyUnionTwo,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 match self {
                     Self::UnionKey(v) => v.write_xdr(w),
 Self::Foo(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -2268,6 +2268,68 @@ mod test {
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
         }
     }
+
+    #[test]
+    fn length_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut lr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[test]
+    fn write_over_length_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 15,
+                ..Limits::default()
+            },
+        );
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected LengthLimitExceeded got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn read_over_length_limit_fail() {
+        let read_limits = Limits {
+            len: 15,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            len: 16,
+            ..Limits::default()
+        };
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(Vec::new(), read_limits);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
+    }
 }
 
 #[cfg(all(test, not(feature = "alloc")))]

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -273,12 +273,12 @@ impl<L> Limited<L> {
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
+            let res = f(self);
+            self.limits.depth = self.limits.depth.saturating_add(1);
+            res
         } else {
-            return Err(Error::DepthLimitExceeded);
+            Err(Error::DepthLimitExceeded)
         }
-        let res = f(self);
-        self.limits.depth = self.limits.depth.saturating_add(1);
-        res
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -219,6 +219,7 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
+    #[must_use]
     pub fn none() -> Self {
         Self {
             depth: u32::MAX,
@@ -226,6 +227,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
@@ -233,6 +235,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn len(len: usize) -> Self {
         Limits {
             len,

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -69,6 +69,7 @@ pub enum Error {
     DepthLimitExceeded,
     #[cfg(feature = "serde_json")]
     Json(serde_json::Error),
+    LengthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -117,6 +118,7 @@ impl fmt::Display for Error {
             Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
             #[cfg(feature = "serde_json")]
             Error::Json(e) => write!(f, "{e}"),
+            Error::LengthLimitExceeded => write!(f, "length limit exceeded"),
         }
     }
 }
@@ -199,6 +201,7 @@ where
 /// `Limits` contains the limits that a limited reader or writer will be
 /// constrained to.
 #[cfg(feature = "std")]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Limits {
     /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
     ///
@@ -207,12 +210,18 @@ pub struct Limits {
     /// For more information about Rust's stack size limit, refer to the
     /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
     pub depth: u32,
+
+    /// Defines the maximum number of bytes that will be read or read.
+    pub len: usize,
 }
 
 #[cfg(feature = "std")]
 impl Default for Limits {
     fn default() -> Self {
-        Self { depth: 500 }
+        Self {
+            depth: 500,
+            len: usize::MAX,
+        }
     }
 }
 
@@ -233,7 +242,16 @@ impl<L> Limited<L> {
         Limited { inner, limits }
     }
 
-    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+        if let Some(len) = self.limits.len.checked_sub(len) {
+            self.limits.len = len;
+            Ok(())
+        } else {
+            Err(Error::LengthLimitExceeded)
+        }
+    }
+
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
     where
         F: FnOnce(&mut Self) -> Result<T>,
     {
@@ -245,6 +263,40 @@ impl<L> Limited<L> {
         let res = f(self);
         self.limits.depth = self.limits.depth.saturating_add(1);
         res
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: BufRead> BufRead for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        self.inner.fill_buf()
+    }
+
+    /// Forwards the read operation to the wrapped object.
+    fn consume(&mut self, amt: usize) {
+        self.inner.consume(amt);
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for Limited<W> {
+    /// Forwards the write operation to the wrapped object.
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    /// Forwards the flush operation to the wrapped object.
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
     }
 }
 
@@ -285,7 +337,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.inner.fill_buf() {
+        match self.reader.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -332,7 +384,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -376,7 +428,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -452,7 +504,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
+        ReadXdrIter::new(&mut r.inner, r.limits.clone())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -462,7 +514,7 @@ where
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining)
+        ReadXdrIter::new(dec, r.limits.clone())
     }
 
     /// Construct the type from the XDR bytes.
@@ -528,6 +580,7 @@ impl ReadXdr for i32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i32::from_be_bytes(b))
         })
@@ -538,7 +591,10 @@ impl WriteXdr for i32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -547,6 +603,7 @@ impl ReadXdr for u32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u32::from_be_bytes(b))
         })
@@ -557,7 +614,10 @@ impl WriteXdr for u32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -566,6 +626,7 @@ impl ReadXdr for i64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i64::from_be_bytes(b))
         })
@@ -576,7 +637,10 @@ impl WriteXdr for i64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -585,6 +649,7 @@ impl ReadXdr for u64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u64::from_be_bytes(b))
         })
@@ -595,7 +660,10 @@ impl WriteXdr for u64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -631,6 +699,7 @@ impl ReadXdr for bool {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             let b = i == 1;
             Ok(b)
@@ -642,6 +711,7 @@ impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
         })
@@ -652,6 +722,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             match i {
                 0 => Ok(None),
@@ -669,6 +740,7 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
                 t.write_xdr(w)?;
@@ -712,9 +784,12 @@ impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(N)?;
+            let padding = pad_len(N);
+            r.consume_len(padding)?;
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
-            let pad = &mut [0u8; 3][..pad_len(N)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -728,8 +803,11 @@ impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(N)?;
+            let padding = pad_len(N);
+            w.consume_len(padding)?;
             w.write_all(self)?;
-            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            w.write_all(&[0u8; 3][..padding])?;
             Ok(())
         })
     }
@@ -1087,15 +1165,20 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1110,12 +1193,17 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1126,6 +1214,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
@@ -1146,6 +1235,7 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1485,15 +1575,20 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1508,6 +1603,11 @@ impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1868,15 +1968,21 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
+
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1891,12 +1997,17 @@ impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1925,6 +2036,7 @@ where
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
         //  follow the frame header.
+        r.consume_len(core::mem::size_of::<u32>())?;
         let header = u32::read_xdr(r)?;
         // TODO: Use the length and cap the length we'll read from `r`.
         let last_record = header >> 31 == 1;
@@ -1948,16 +2060,14 @@ mod tests {
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
@@ -1986,11 +2096,8 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1998,11 +2105,8 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
@@ -2044,10 +2148,7 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -2056,10 +2157,7 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
@@ -2096,10 +2194,22 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
+        let mut dlr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
@@ -2107,7 +2217,13 @@ mod test {
     #[test]
     fn write_over_depth_limit_fail() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 3,
+                len: usize::MAX,
+            },
+        );
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2117,8 +2233,14 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_limits = Limits { depth: 3 };
-        let write_limits = Limits { depth: 5 };
+        let read_limits = Limits {
+            depth: 3,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            depth: 5,
+            ..Limits::default()
+        };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
         let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
@@ -2570,7 +2692,7 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2589,7 +2711,7 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2598,11 +2720,11 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
-TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
+                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
+TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
                 }
             }
 
@@ -2610,11 +2732,11 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(&mut r.inn
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
-TypeVariant::Foo => Box::new(ReadXdrIter::<_, Frame<Foo>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Foo(Box::new(t.0))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
-TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, Frame<MyUnionOne>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t.0))))),
-TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t.0))))),
+                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
+TypeVariant::Foo => Box::new(ReadXdrIter::<_, Frame<Foo>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Foo(Box::new(t.0))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
+TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, Frame<MyUnionOne>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t.0))))),
+TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t.0))))),
                 }
             }
 
@@ -2623,11 +2745,11 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(&mu
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.limits).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(dec, r.limits).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, r.limits).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(dec, r.limits).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
-TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.limits).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
+                    TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::MyUnionOne => Box::new(ReadXdrIter::<_, MyUnionOne>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::MyUnionOne(Box::new(t))))),
+TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::MyUnionTwo(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -219,21 +219,21 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
-    fn none() -> Self {
+    pub fn none() -> Self {
         Self {
             depth: u32::MAX,
             len: usize::MAX,
         }
     }
 
-    fn depth(depth: u32) -> Self {
+    pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
             ..Limits::none()
         }
     }
 
-    fn len(len: usize) -> Self {
+    pub fn len(len: usize) -> Self {
         Limits {
             len,
             ..Limits::none()

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -69,6 +69,7 @@ pub enum Error {
     DepthLimitExceeded,
     #[cfg(feature = "serde_json")]
     Json(serde_json::Error),
+    LengthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -117,6 +118,7 @@ impl fmt::Display for Error {
             Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
             #[cfg(feature = "serde_json")]
             Error::Json(e) => write!(f, "{e}"),
+            Error::LengthLimitExceeded => write!(f, "length limit exceeded"),
         }
     }
 }
@@ -199,6 +201,7 @@ where
 /// `Limits` contains the limits that a limited reader or writer will be
 /// constrained to.
 #[cfg(feature = "std")]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Limits {
     /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
     ///
@@ -207,12 +210,18 @@ pub struct Limits {
     /// For more information about Rust's stack size limit, refer to the
     /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
     pub depth: u32,
+
+    /// Defines the maximum number of bytes that will be read or read.
+    pub len: usize,
 }
 
 #[cfg(feature = "std")]
 impl Default for Limits {
     fn default() -> Self {
-        Self { depth: 500 }
+        Self {
+            depth: 500,
+            len: usize::MAX,
+        }
     }
 }
 
@@ -233,7 +242,16 @@ impl<L> Limited<L> {
         Limited { inner, limits }
     }
 
-    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+        if let Some(len) = self.limits.len.checked_sub(len) {
+            self.limits.len = len;
+            Ok(())
+        } else {
+            Err(Error::LengthLimitExceeded)
+        }
+    }
+
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
     where
         F: FnOnce(&mut Self) -> Result<T>,
     {
@@ -245,6 +263,40 @@ impl<L> Limited<L> {
         let res = f(self);
         self.limits.depth = self.limits.depth.saturating_add(1);
         res
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: BufRead> BufRead for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        self.inner.fill_buf()
+    }
+
+    /// Forwards the read operation to the wrapped object.
+    fn consume(&mut self, amt: usize) {
+        self.inner.consume(amt);
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for Limited<W> {
+    /// Forwards the write operation to the wrapped object.
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    /// Forwards the flush operation to the wrapped object.
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
     }
 }
 
@@ -285,7 +337,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.inner.fill_buf() {
+        match self.reader.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -332,7 +384,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -376,7 +428,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -452,7 +504,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
+        ReadXdrIter::new(&mut r.inner, r.limits.clone())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -462,7 +514,7 @@ where
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining)
+        ReadXdrIter::new(dec, r.limits.clone())
     }
 
     /// Construct the type from the XDR bytes.
@@ -528,6 +580,7 @@ impl ReadXdr for i32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i32::from_be_bytes(b))
         })
@@ -538,7 +591,10 @@ impl WriteXdr for i32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -547,6 +603,7 @@ impl ReadXdr for u32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u32::from_be_bytes(b))
         })
@@ -557,7 +614,10 @@ impl WriteXdr for u32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -566,6 +626,7 @@ impl ReadXdr for i64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i64::from_be_bytes(b))
         })
@@ -576,7 +637,10 @@ impl WriteXdr for i64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -585,6 +649,7 @@ impl ReadXdr for u64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u64::from_be_bytes(b))
         })
@@ -595,7 +660,10 @@ impl WriteXdr for u64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -631,6 +699,7 @@ impl ReadXdr for bool {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             let b = i == 1;
             Ok(b)
@@ -642,6 +711,7 @@ impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
         })
@@ -652,6 +722,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             match i {
                 0 => Ok(None),
@@ -669,6 +740,7 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
                 t.write_xdr(w)?;
@@ -712,9 +784,12 @@ impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(N)?;
+            let padding = pad_len(N);
+            r.consume_len(padding)?;
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
-            let pad = &mut [0u8; 3][..pad_len(N)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -728,8 +803,11 @@ impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(N)?;
+            let padding = pad_len(N);
+            w.consume_len(padding)?;
             w.write_all(self)?;
-            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            w.write_all(&[0u8; 3][..padding])?;
             Ok(())
         })
     }
@@ -1087,15 +1165,20 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1110,12 +1193,17 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1126,6 +1214,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
@@ -1146,6 +1235,7 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1485,15 +1575,20 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1508,6 +1603,11 @@ impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1868,15 +1968,21 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
+
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1891,12 +1997,17 @@ impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1925,6 +2036,7 @@ where
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
         //  follow the frame header.
+        r.consume_len(core::mem::size_of::<u32>())?;
         let header = u32::read_xdr(r)?;
         // TODO: Use the length and cap the length we'll read from `r`.
         let last_record = header >> 31 == 1;
@@ -1948,16 +2060,14 @@ mod tests {
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
@@ -1986,11 +2096,8 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1998,11 +2105,8 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
@@ -2044,10 +2148,7 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -2056,10 +2157,7 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
@@ -2096,10 +2194,22 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
+        let mut dlr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
@@ -2107,7 +2217,13 @@ mod test {
     #[test]
     fn write_over_depth_limit_fail() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 3,
+                len: usize::MAX,
+            },
+        );
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2117,8 +2233,14 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_limits = Limits { depth: 3 };
-        let write_limits = Limits { depth: 5 };
+        let read_limits = Limits {
+            depth: 3,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            depth: 5,
+            ..Limits::default()
+        };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
         let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
@@ -2285,7 +2407,7 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2304,7 +2426,7 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2313,8 +2435,8 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
                 }
             }
 
@@ -2322,8 +2444,8 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inn
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Frame<Arr>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Arr(Box::new(t.0))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::HasOptions(Box::new(t.0))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Frame<Arr>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Arr(Box::new(t.0))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::HasOptions(Box::new(t.0))))),
                 }
             }
 
@@ -2332,8 +2454,8 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mu
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec, r.limits).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.limits).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -2268,6 +2268,68 @@ mod test {
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
         }
     }
+
+    #[test]
+    fn length_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut lr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[test]
+    fn write_over_length_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 15,
+                ..Limits::default()
+            },
+        );
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected LengthLimitExceeded got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn read_over_length_limit_fail() {
+        let read_limits = Limits {
+            len: 15,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            len: 16,
+            ..Limits::default()
+        };
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(Vec::new(), read_limits);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
+    }
 }
 
 #[cfg(all(test, not(feature = "alloc")))]

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -273,12 +273,12 @@ impl<L> Limited<L> {
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
+            let res = f(self);
+            self.limits.depth = self.limits.depth.saturating_add(1);
+            res
         } else {
-            return Err(Error::DepthLimitExceeded);
+            Err(Error::DepthLimitExceeded)
         }
-        let res = f(self);
-        self.limits.depth = self.limits.depth.saturating_add(1);
-        res
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -219,6 +219,7 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
+    #[must_use]
     pub fn none() -> Self {
         Self {
             depth: u32::MAX,
@@ -226,6 +227,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
@@ -233,6 +235,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn len(len: usize) -> Self {
         Limits {
             len,

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -51,14 +51,6 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
-///
-/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
-/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the
-/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
-
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
 /// compared on their `ErrorKind`.
@@ -204,172 +196,71 @@ where
 {
 }
 
-/// `DepthLimiter` is a trait designed for managing the depth of recursive operations.
-/// It provides a mechanism to limit recursion depth, and defines the behavior upon
-/// entering and leaving a recursion level.
-pub trait DepthLimiter {
-    /// A general error type for any type implementing, or an operation under the guard of
-    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
-    /// which is returned from `enter`.
-    type DepthLimiterError;
+/// `Limits` contains the limits that a limited reader or writer will be
+/// constrained to.
+#[cfg(feature = "std")]
+pub struct Limits {
+    /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+    ///
+    /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+    /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+    /// For more information about Rust's stack size limit, refer to the
+    /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+    pub depth: u32,
+}
 
-    /// Defines the behavior for entering a new recursion level.
-    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
-    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Defines the behavior for leaving a recursion level.
-    /// A `DepthLimiterError` is returned if an error occurs.
-    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Wraps a given function `f` with depth limiting guards.
-    /// It triggers an `enter` before, and a `leave` after the execution of `f`.
-    ///
-    /// # Parameters
-    ///
-    /// - `f`: The function to be executed under depth limit constraints.
-    ///
-    /// # Returns
-    ///
-    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
-    ///         with an error 3. if error occurs on `leave`.
-    ///   `Ok` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
-    where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
-    {
-        self.enter()?;
-        let res = f(self);
-        self.leave()?;
-        res
+#[cfg(feature = "std")]
+impl Default for Limits {
+    fn default() -> Self {
+        Self { depth: 500 }
     }
 }
 
-/// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
+/// `Limited` wraps an object and provides functions for enforcing limits.
 #[cfg(feature = "std")]
-pub struct DepthLimitedRead<R: Read> {
-    pub inner: R,
-    pub(crate) depth_remaining: u32,
+pub struct Limited<L> {
+    pub inner: L,
+    pub(crate) limits: Limits,
 }
 
 #[cfg(feature = "std")]
-impl<R: Read> DepthLimitedRead<R> {
-    /// Constructs a new `DepthLimitedRead`.
+impl<L> Limited<L> {
+    /// Constructs a new `Limited`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
     /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth_limit: u32) -> Self {
-        DepthLimitedRead {
-            inner,
-            depth_remaining: depth_limit,
-        }
+    pub fn new(inner: L, limits: Limits) -> Self {
+        Limited { inner, limits }
     }
-}
 
-#[cfg(feature = "std")]
-impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> core::result::Result<(), Error> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
+    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut Self) -> Result<T>,
+    {
+        if let Some(depth) = self.limits.depth.checked_sub(1) {
+            self.limits.depth = depth;
         } else {
             return Err(Error::DepthLimitExceeded);
         }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<R: Read> Read for DepthLimitedRead<R> {
-    /// Forwards the read operation to the wrapped object.
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.inner.read(buf)
-    }
-}
-
-/// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
-#[cfg(feature = "std")]
-pub struct DepthLimitedWrite<W: Write> {
-    pub inner: W,
-    pub(crate) depth_remaining: u32,
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimitedWrite<W> {
-    /// Constructs a new `DepthLimitedWrite`.
-    ///
-    /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth_limit: u32) -> Self {
-        DepthLimitedWrite {
-            inner,
-            depth_remaining: depth_limit,
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> Result<()> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
-        } else {
-            return Err(Error::DepthLimitExceeded);
-        }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> Write for DepthLimitedWrite<W> {
-    /// Forwards the write operation to the wrapped object.
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.inner.write(buf)
-    }
-
-    /// Forwards the flush operation to the wrapped object.
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.inner.flush()
+        let res = f(self);
+        self.limits.depth = self.limits.depth.saturating_add(1);
+        res
     }
 }
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: DepthLimitedRead<BufReader<R>>,
+    reader: Limited<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth_limit: u32) -> Self {
+    fn new(r: R, limits: Limits) -> Self {
         Self {
-            reader: DepthLimitedRead {
+            reader: Limited {
                 inner: BufReader::new(r),
-                depth_remaining: depth_limit,
+                limits,
             },
             _s: PhantomData,
         }
@@ -431,15 +322,15 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -466,7 +357,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -482,8 +373,8 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -506,7 +397,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -530,7 +421,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -560,7 +451,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
+    fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
         ReadXdrIter::new(&mut r.inner, r.depth_remaining)
     }
 
@@ -568,88 +459,60 @@ where
     /// values that are read into the implementing type.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
-        r: &mut DepthLimitedRead<R>,
+        r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         ReadXdrIter::new(dec, r.depth_remaining)
     }
 
-    /// Construct the type from the XDR bytes, specifying a depth limit.
+    /// Construct the type from the XDR bytes.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+        let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            depth_limit,
+            limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+        let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
     #[cfg(feature = "base64")]
-    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
-        let mut enc = DepthLimitedWrite::new(
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+        let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            depth_limit,
+            limits,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
-    }
-
-    #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -662,7 +525,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -673,7 +536,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -681,7 +544,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -692,7 +555,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -700,7 +563,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -711,7 +574,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -719,7 +582,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -730,7 +593,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -738,35 +601,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -777,7 +640,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -787,7 +650,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -804,7 +667,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -819,35 +682,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
@@ -863,7 +726,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             w.write_all(self)?;
             w.write_all(&[0u8; 3][..pad_len(N)])?;
@@ -874,7 +737,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -889,7 +752,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -1222,7 +1085,7 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1245,7 +1108,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1261,7 +1124,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1281,7 +1144,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1620,7 +1483,7 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1643,7 +1506,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2003,7 +1866,7 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2026,7 +1889,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2057,7 +1920,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2080,17 +1943,13 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use super::{
-        DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_XDR_RW_DEPTH_LIMIT,
-    };
+    use super::*;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
@@ -2098,16 +1957,14 @@ mod tests {
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2117,8 +1974,7 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2130,7 +1986,7 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2142,7 +1998,7 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2153,23 +2009,21 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2179,7 +2033,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2190,9 +2044,9 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2202,9 +2056,9 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2242,19 +2096,18 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
 
     #[test]
     fn write_over_depth_limit_fail() {
-        let depth_limit = 3;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), depth_limit);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2264,13 +2117,13 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_depth_limit = 3;
-        let write_depth_limit = 5;
+        let read_limits = Limits { depth: 3 };
+        let write_limits = Limits { depth: 5 };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), write_depth_limit);
+        let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), read_depth_limit);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
         let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2322,7 +2175,7 @@ pub struct HasOptions {
 
         impl ReadXdr for HasOptions {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       first_option: Option::<i32>::read_xdr(r)?,
@@ -2335,7 +2188,7 @@ third_option: Option::<i32>::read_xdr(r)?,
 
         impl WriteXdr for HasOptions {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     self.first_option.write_xdr(w)?;
 self.second_option.write_xdr(w)?;
@@ -2423,7 +2276,7 @@ TypeVariant::HasOptions, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 match v {
                     TypeVariant::Arr => r.with_limited_depth(|r| Ok(Self::Arr(Box::new(Arr::read_xdr(r)?)))),
 TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new(HasOptions::read_xdr(r)?)))),
@@ -2431,14 +2284,14 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2450,51 +2303,51 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Frame<Arr>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Arr(Box::new(t.0))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::HasOptions(Box::new(t.0))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Frame<Arr>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Arr(Box::new(t.0))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::HasOptions(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
-TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
+                    TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec, r.limits).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
+TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.limits).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+                let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String, limits: Limits) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2560,7 +2413,7 @@ Self::HasOptions(_) => TypeVariant::HasOptions,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 match self {
                     Self::Arr(v) => v.write_xdr(w),
 Self::HasOptions(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -219,21 +219,21 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
-    fn none() -> Self {
+    pub fn none() -> Self {
         Self {
             depth: u32::MAX,
             len: usize::MAX,
         }
     }
 
-    fn depth(depth: u32) -> Self {
+    pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
             ..Limits::none()
         }
     }
 
-    fn len(len: usize) -> Self {
+    pub fn len(len: usize) -> Self {
         Limits {
             len,
             ..Limits::none()

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -2268,6 +2268,68 @@ mod test {
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
         }
     }
+
+    #[test]
+    fn length_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut lr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[test]
+    fn write_over_length_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 15,
+                ..Limits::default()
+            },
+        );
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected LengthLimitExceeded got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn read_over_length_limit_fail() {
+        let read_limits = Limits {
+            len: 15,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            len: 16,
+            ..Limits::default()
+        };
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(Vec::new(), read_limits);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
+    }
 }
 
 #[cfg(all(test, not(feature = "alloc")))]

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -273,12 +273,12 @@ impl<L> Limited<L> {
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
+            let res = f(self);
+            self.limits.depth = self.limits.depth.saturating_add(1);
+            res
         } else {
-            return Err(Error::DepthLimitExceeded);
+            Err(Error::DepthLimitExceeded)
         }
-        let res = f(self);
-        self.limits.depth = self.limits.depth.saturating_add(1);
-        res
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -219,6 +219,7 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
+    #[must_use]
     pub fn none() -> Self {
         Self {
             depth: u32::MAX,
@@ -226,6 +227,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
@@ -233,6 +235,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn len(len: usize) -> Self {
         Limits {
             len,

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -51,14 +51,6 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
-///
-/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
-/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the
-/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
-
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
 /// compared on their `ErrorKind`.
@@ -204,172 +196,71 @@ where
 {
 }
 
-/// `DepthLimiter` is a trait designed for managing the depth of recursive operations.
-/// It provides a mechanism to limit recursion depth, and defines the behavior upon
-/// entering and leaving a recursion level.
-pub trait DepthLimiter {
-    /// A general error type for any type implementing, or an operation under the guard of
-    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
-    /// which is returned from `enter`.
-    type DepthLimiterError;
+/// `Limits` contains the limits that a limited reader or writer will be
+/// constrained to.
+#[cfg(feature = "std")]
+pub struct Limits {
+    /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+    ///
+    /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+    /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+    /// For more information about Rust's stack size limit, refer to the
+    /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+    pub depth: u32,
+}
 
-    /// Defines the behavior for entering a new recursion level.
-    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
-    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Defines the behavior for leaving a recursion level.
-    /// A `DepthLimiterError` is returned if an error occurs.
-    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Wraps a given function `f` with depth limiting guards.
-    /// It triggers an `enter` before, and a `leave` after the execution of `f`.
-    ///
-    /// # Parameters
-    ///
-    /// - `f`: The function to be executed under depth limit constraints.
-    ///
-    /// # Returns
-    ///
-    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
-    ///         with an error 3. if error occurs on `leave`.
-    ///   `Ok` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
-    where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
-    {
-        self.enter()?;
-        let res = f(self);
-        self.leave()?;
-        res
+#[cfg(feature = "std")]
+impl Default for Limits {
+    fn default() -> Self {
+        Self { depth: 500 }
     }
 }
 
-/// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
+/// `Limited` wraps an object and provides functions for enforcing limits.
 #[cfg(feature = "std")]
-pub struct DepthLimitedRead<R: Read> {
-    pub inner: R,
-    pub(crate) depth_remaining: u32,
+pub struct Limited<L> {
+    pub inner: L,
+    pub(crate) limits: Limits,
 }
 
 #[cfg(feature = "std")]
-impl<R: Read> DepthLimitedRead<R> {
-    /// Constructs a new `DepthLimitedRead`.
+impl<L> Limited<L> {
+    /// Constructs a new `Limited`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
     /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth_limit: u32) -> Self {
-        DepthLimitedRead {
-            inner,
-            depth_remaining: depth_limit,
-        }
+    pub fn new(inner: L, limits: Limits) -> Self {
+        Limited { inner, limits }
     }
-}
 
-#[cfg(feature = "std")]
-impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> core::result::Result<(), Error> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
+    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut Self) -> Result<T>,
+    {
+        if let Some(depth) = self.limits.depth.checked_sub(1) {
+            self.limits.depth = depth;
         } else {
             return Err(Error::DepthLimitExceeded);
         }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<R: Read> Read for DepthLimitedRead<R> {
-    /// Forwards the read operation to the wrapped object.
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.inner.read(buf)
-    }
-}
-
-/// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
-#[cfg(feature = "std")]
-pub struct DepthLimitedWrite<W: Write> {
-    pub inner: W,
-    pub(crate) depth_remaining: u32,
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimitedWrite<W> {
-    /// Constructs a new `DepthLimitedWrite`.
-    ///
-    /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth_limit: u32) -> Self {
-        DepthLimitedWrite {
-            inner,
-            depth_remaining: depth_limit,
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> Result<()> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
-        } else {
-            return Err(Error::DepthLimitExceeded);
-        }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> Write for DepthLimitedWrite<W> {
-    /// Forwards the write operation to the wrapped object.
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.inner.write(buf)
-    }
-
-    /// Forwards the flush operation to the wrapped object.
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.inner.flush()
+        let res = f(self);
+        self.limits.depth = self.limits.depth.saturating_add(1);
+        res
     }
 }
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: DepthLimitedRead<BufReader<R>>,
+    reader: Limited<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth_limit: u32) -> Self {
+    fn new(r: R, limits: Limits) -> Self {
         Self {
-            reader: DepthLimitedRead {
+            reader: Limited {
                 inner: BufReader::new(r),
-                depth_remaining: depth_limit,
+                limits,
             },
             _s: PhantomData,
         }
@@ -431,15 +322,15 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -466,7 +357,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -482,8 +373,8 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -506,7 +397,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -530,7 +421,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -560,7 +451,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
+    fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
         ReadXdrIter::new(&mut r.inner, r.depth_remaining)
     }
 
@@ -568,88 +459,60 @@ where
     /// values that are read into the implementing type.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
-        r: &mut DepthLimitedRead<R>,
+        r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         ReadXdrIter::new(dec, r.depth_remaining)
     }
 
-    /// Construct the type from the XDR bytes, specifying a depth limit.
+    /// Construct the type from the XDR bytes.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+        let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            depth_limit,
+            limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+        let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
     #[cfg(feature = "base64")]
-    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
-        let mut enc = DepthLimitedWrite::new(
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+        let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            depth_limit,
+            limits,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
-    }
-
-    #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -662,7 +525,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -673,7 +536,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -681,7 +544,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -692,7 +555,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -700,7 +563,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -711,7 +574,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -719,7 +582,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -730,7 +593,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -738,35 +601,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -777,7 +640,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -787,7 +650,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -804,7 +667,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -819,35 +682,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
@@ -863,7 +726,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             w.write_all(self)?;
             w.write_all(&[0u8; 3][..pad_len(N)])?;
@@ -874,7 +737,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -889,7 +752,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -1222,7 +1085,7 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1245,7 +1108,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1261,7 +1124,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1281,7 +1144,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1620,7 +1483,7 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1643,7 +1506,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2003,7 +1866,7 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2026,7 +1889,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2057,7 +1920,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2080,17 +1943,13 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use super::{
-        DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_XDR_RW_DEPTH_LIMIT,
-    };
+    use super::*;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
@@ -2098,16 +1957,14 @@ mod tests {
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2117,8 +1974,7 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2130,7 +1986,7 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2142,7 +1998,7 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2153,23 +2009,21 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2179,7 +2033,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2190,9 +2044,9 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2202,9 +2056,9 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2242,19 +2096,18 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
 
     #[test]
     fn write_over_depth_limit_fail() {
-        let depth_limit = 3;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), depth_limit);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2264,13 +2117,13 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_depth_limit = 3;
-        let write_depth_limit = 5;
+        let read_limits = Limits { depth: 3 };
+        let write_limits = Limits { depth: 5 };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), write_depth_limit);
+        let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), read_depth_limit);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
         let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2326,7 +2179,7 @@ pub struct MyStruct {
 
         impl ReadXdr for MyStruct {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       some_int: i32::read_xdr(r)?,
@@ -2341,7 +2194,7 @@ max_string: StringM::<100>::read_xdr(r)?,
 
         impl WriteXdr for MyStruct {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     self.some_int.write_xdr(w)?;
 self.a_big_int.write_xdr(w)?;
@@ -2431,7 +2284,7 @@ TypeVariant::MyStruct, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 match v {
                     TypeVariant::Int64 => r.with_limited_depth(|r| Ok(Self::Int64(Box::new(Int64::read_xdr(r)?)))),
 TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyStruct::read_xdr(r)?)))),
@@ -2439,14 +2292,14 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2458,51 +2311,51 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Frame<Int64>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Int64(Box::new(t.0))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
+                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Frame<Int64>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int64(Box::new(t.0))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(dec, r.limits).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+                let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String, limits: Limits) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2568,7 +2421,7 @@ Self::MyStruct(_) => TypeVariant::MyStruct,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 match self {
                     Self::Int64(v) => v.write_xdr(w),
 Self::MyStruct(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -69,6 +69,7 @@ pub enum Error {
     DepthLimitExceeded,
     #[cfg(feature = "serde_json")]
     Json(serde_json::Error),
+    LengthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -117,6 +118,7 @@ impl fmt::Display for Error {
             Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
             #[cfg(feature = "serde_json")]
             Error::Json(e) => write!(f, "{e}"),
+            Error::LengthLimitExceeded => write!(f, "length limit exceeded"),
         }
     }
 }
@@ -199,6 +201,7 @@ where
 /// `Limits` contains the limits that a limited reader or writer will be
 /// constrained to.
 #[cfg(feature = "std")]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Limits {
     /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
     ///
@@ -207,12 +210,18 @@ pub struct Limits {
     /// For more information about Rust's stack size limit, refer to the
     /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
     pub depth: u32,
+
+    /// Defines the maximum number of bytes that will be read or read.
+    pub len: usize,
 }
 
 #[cfg(feature = "std")]
 impl Default for Limits {
     fn default() -> Self {
-        Self { depth: 500 }
+        Self {
+            depth: 500,
+            len: usize::MAX,
+        }
     }
 }
 
@@ -233,7 +242,16 @@ impl<L> Limited<L> {
         Limited { inner, limits }
     }
 
-    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+        if let Some(len) = self.limits.len.checked_sub(len) {
+            self.limits.len = len;
+            Ok(())
+        } else {
+            Err(Error::LengthLimitExceeded)
+        }
+    }
+
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
     where
         F: FnOnce(&mut Self) -> Result<T>,
     {
@@ -245,6 +263,40 @@ impl<L> Limited<L> {
         let res = f(self);
         self.limits.depth = self.limits.depth.saturating_add(1);
         res
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: BufRead> BufRead for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        self.inner.fill_buf()
+    }
+
+    /// Forwards the read operation to the wrapped object.
+    fn consume(&mut self, amt: usize) {
+        self.inner.consume(amt);
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for Limited<W> {
+    /// Forwards the write operation to the wrapped object.
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    /// Forwards the flush operation to the wrapped object.
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
     }
 }
 
@@ -285,7 +337,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.inner.fill_buf() {
+        match self.reader.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -332,7 +384,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -376,7 +428,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -452,7 +504,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
+        ReadXdrIter::new(&mut r.inner, r.limits.clone())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -462,7 +514,7 @@ where
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining)
+        ReadXdrIter::new(dec, r.limits.clone())
     }
 
     /// Construct the type from the XDR bytes.
@@ -528,6 +580,7 @@ impl ReadXdr for i32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i32::from_be_bytes(b))
         })
@@ -538,7 +591,10 @@ impl WriteXdr for i32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -547,6 +603,7 @@ impl ReadXdr for u32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u32::from_be_bytes(b))
         })
@@ -557,7 +614,10 @@ impl WriteXdr for u32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -566,6 +626,7 @@ impl ReadXdr for i64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i64::from_be_bytes(b))
         })
@@ -576,7 +637,10 @@ impl WriteXdr for i64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -585,6 +649,7 @@ impl ReadXdr for u64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u64::from_be_bytes(b))
         })
@@ -595,7 +660,10 @@ impl WriteXdr for u64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -631,6 +699,7 @@ impl ReadXdr for bool {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             let b = i == 1;
             Ok(b)
@@ -642,6 +711,7 @@ impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
         })
@@ -652,6 +722,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             match i {
                 0 => Ok(None),
@@ -669,6 +740,7 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
                 t.write_xdr(w)?;
@@ -712,9 +784,12 @@ impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(N)?;
+            let padding = pad_len(N);
+            r.consume_len(padding)?;
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
-            let pad = &mut [0u8; 3][..pad_len(N)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -728,8 +803,11 @@ impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(N)?;
+            let padding = pad_len(N);
+            w.consume_len(padding)?;
             w.write_all(self)?;
-            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            w.write_all(&[0u8; 3][..padding])?;
             Ok(())
         })
     }
@@ -1087,15 +1165,20 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1110,12 +1193,17 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1126,6 +1214,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
@@ -1146,6 +1235,7 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1485,15 +1575,20 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1508,6 +1603,11 @@ impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1868,15 +1968,21 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
+
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1891,12 +1997,17 @@ impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1925,6 +2036,7 @@ where
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
         //  follow the frame header.
+        r.consume_len(core::mem::size_of::<u32>())?;
         let header = u32::read_xdr(r)?;
         // TODO: Use the length and cap the length we'll read from `r`.
         let last_record = header >> 31 == 1;
@@ -1948,16 +2060,14 @@ mod tests {
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
@@ -1986,11 +2096,8 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1998,11 +2105,8 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
@@ -2044,10 +2148,7 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -2056,10 +2157,7 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
@@ -2096,10 +2194,22 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
+        let mut dlr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
@@ -2107,7 +2217,13 @@ mod test {
     #[test]
     fn write_over_depth_limit_fail() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 3,
+                len: usize::MAX,
+            },
+        );
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2117,8 +2233,14 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_limits = Limits { depth: 3 };
-        let write_limits = Limits { depth: 5 };
+        let read_limits = Limits {
+            depth: 3,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            depth: 5,
+            ..Limits::default()
+        };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
         let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
@@ -2293,7 +2415,7 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -2312,7 +2434,7 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2321,8 +2443,8 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
                 }
             }
 
@@ -2330,8 +2452,8 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, 
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Frame<Int64>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int64(Box::new(t.0))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
+                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Frame<Int64>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int64(Box::new(t.0))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
                 }
             }
 
@@ -2340,8 +2462,8 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(dec, r.limits).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+                    TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -219,21 +219,21 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
-    fn none() -> Self {
+    pub fn none() -> Self {
         Self {
             depth: u32::MAX,
             len: usize::MAX,
         }
     }
 
-    fn depth(depth: u32) -> Self {
+    pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
             ..Limits::none()
         }
     }
 
-    fn len(len: usize) -> Self {
+    pub fn len(len: usize) -> Self {
         Limits {
             len,
             ..Limits::none()

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -69,6 +69,7 @@ pub enum Error {
     DepthLimitExceeded,
     #[cfg(feature = "serde_json")]
     Json(serde_json::Error),
+    LengthLimitExceeded,
 }
 
 impl PartialEq for Error {
@@ -117,6 +118,7 @@ impl fmt::Display for Error {
             Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
             #[cfg(feature = "serde_json")]
             Error::Json(e) => write!(f, "{e}"),
+            Error::LengthLimitExceeded => write!(f, "length limit exceeded"),
         }
     }
 }
@@ -199,6 +201,7 @@ where
 /// `Limits` contains the limits that a limited reader or writer will be
 /// constrained to.
 #[cfg(feature = "std")]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Limits {
     /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
     ///
@@ -207,12 +210,18 @@ pub struct Limits {
     /// For more information about Rust's stack size limit, refer to the
     /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
     pub depth: u32,
+
+    /// Defines the maximum number of bytes that will be read or read.
+    pub len: usize,
 }
 
 #[cfg(feature = "std")]
 impl Default for Limits {
     fn default() -> Self {
-        Self { depth: 500 }
+        Self {
+            depth: 500,
+            len: usize::MAX,
+        }
     }
 }
 
@@ -233,7 +242,16 @@ impl<L> Limited<L> {
         Limited { inner, limits }
     }
 
-    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+        if let Some(len) = self.limits.len.checked_sub(len) {
+            self.limits.len = len;
+            Ok(())
+        } else {
+            Err(Error::LengthLimitExceeded)
+        }
+    }
+
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
     where
         F: FnOnce(&mut Self) -> Result<T>,
     {
@@ -245,6 +263,40 @@ impl<L> Limited<L> {
         let res = f(self);
         self.limits.depth = self.limits.depth.saturating_add(1);
         res
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: BufRead> BufRead for Limited<R> {
+    /// Forwards the read operation to the wrapped object.
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        self.inner.fill_buf()
+    }
+
+    /// Forwards the read operation to the wrapped object.
+    fn consume(&mut self, amt: usize) {
+        self.inner.consume(amt);
+    }
+}
+
+#[cfg(feature = "std")]
+impl<W: Write> Write for Limited<W> {
+    /// Forwards the write operation to the wrapped object.
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    /// Forwards the flush operation to the wrapped object.
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
     }
 }
 
@@ -285,7 +337,7 @@ impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
         // xdr types in this crate heavily use the `std::io::Read::read_exact`
         // method that doesn't distinguish between an EOF at the beginning of a
         // read and an EOF after a partial fill of a read_exact.
-        match self.reader.inner.fill_buf() {
+        match self.reader.fill_buf() {
             // If the reader has no more data and is unable to fill any new data
             // into its internal buf, then the EOF has been reached.
             Ok([]) => return None,
@@ -332,7 +384,7 @@ where
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
         Ok(t)
@@ -376,7 +428,7 @@ where
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
-            r.depth_remaining,
+            r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
@@ -452,7 +504,7 @@ where
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
     fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
-        ReadXdrIter::new(&mut r.inner, r.depth_remaining)
+        ReadXdrIter::new(&mut r.inner, r.limits.clone())
     }
 
     /// Create an iterator that reads the read implementation as a stream of
@@ -462,7 +514,7 @@ where
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
-        ReadXdrIter::new(dec, r.depth_remaining)
+        ReadXdrIter::new(dec, r.limits.clone())
     }
 
     /// Construct the type from the XDR bytes.
@@ -528,6 +580,7 @@ impl ReadXdr for i32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i32::from_be_bytes(b))
         })
@@ -538,7 +591,10 @@ impl WriteXdr for i32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -547,6 +603,7 @@ impl ReadXdr for u32 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u32::from_be_bytes(b))
         })
@@ -557,7 +614,10 @@ impl WriteXdr for u32 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -566,6 +626,7 @@ impl ReadXdr for i64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(i64::from_be_bytes(b))
         })
@@ -576,7 +637,10 @@ impl WriteXdr for i64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -585,6 +649,7 @@ impl ReadXdr for u64 {
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
+            r.consume_len(b.len())?;
             r.read_exact(&mut b)?;
             Ok(u64::from_be_bytes(b))
         })
@@ -595,7 +660,10 @@ impl WriteXdr for u64 {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
-        w.with_limited_depth(|w| Ok(w.write_all(&b)?))
+        w.with_limited_depth(|w| {
+            w.consume_len(b.len())?;
+            Ok(w.write_all(&b)?)
+        })
     }
 }
 
@@ -631,6 +699,7 @@ impl ReadXdr for bool {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             let b = i == 1;
             Ok(b)
@@ -642,6 +711,7 @@ impl WriteXdr for bool {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
         })
@@ -652,6 +722,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let i = u32::read_xdr(r)?;
             match i {
                 0 => Ok(None),
@@ -669,6 +740,7 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
                 t.write_xdr(w)?;
@@ -712,9 +784,12 @@ impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(N)?;
+            let padding = pad_len(N);
+            r.consume_len(padding)?;
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
-            let pad = &mut [0u8; 3][..pad_len(N)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -728,8 +803,11 @@ impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(N)?;
+            let padding = pad_len(N);
+            w.consume_len(padding)?;
             w.write_all(self)?;
-            w.write_all(&[0u8; 3][..pad_len(N)])?;
+            w.write_all(&[0u8; 3][..padding])?;
             Ok(())
         })
     }
@@ -1087,15 +1165,20 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1110,12 +1193,17 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1126,6 +1214,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
@@ -1146,6 +1235,7 @@ impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1485,15 +1575,20 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1508,6 +1603,11 @@ impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
@@ -1868,15 +1968,21 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
+            r.consume_len(core::mem::size_of::<u32>())?;
+
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
                 return Err(Error::LengthExceedsMax);
             }
 
+            r.consume_len(len as usize)?;
+            let padding = pad_len(len as usize);
+            r.consume_len(padding)?;
+
             let mut vec = vec![0u8; len as usize];
             r.read_exact(&mut vec)?;
 
-            let pad = &mut [0u8; 3][..pad_len(len as usize)];
+            let pad = &mut [0u8; 3][..padding];
             r.read_exact(pad)?;
             if pad.iter().any(|b| *b != 0) {
                 return Err(Error::NonZeroPadding);
@@ -1891,12 +1997,17 @@ impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
     fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
+            w.consume_len(core::mem::size_of::<u32>())?;
+            w.consume_len(self.len())?;
+            let padding = pad_len(self.len());
+            w.consume_len(padding)?;
+
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
 
             w.write_all(&self.0)?;
 
-            w.write_all(&[0u8; 3][..pad_len(len as usize)])?;
+            w.write_all(&[0u8; 3][..padding])?;
 
             Ok(())
         })
@@ -1925,6 +2036,7 @@ where
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
         //  follow the frame header.
+        r.consume_len(core::mem::size_of::<u32>())?;
         let header = u32::read_xdr(r)?;
         // TODO: Use the length and cap the length we'll read from `r`.
         let last_record = header >> 31 == 1;
@@ -1948,16 +2060,14 @@ mod tests {
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
-        let v =
-            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
+        let v = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
@@ -1986,11 +2096,8 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 4, 2, 2, 2, 2]);
     }
 
@@ -1998,11 +2105,8 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut Limited::new(
-            Cursor::new(&mut buf),
-            DEFAULT_XDR_RW_DEPTH_LIMIT,
-        ))
-        .unwrap();
+        v.write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
+            .unwrap();
         assert_eq!(buf, vec![0, 0, 0, 1, 2, 0, 0, 0]);
     }
 
@@ -2044,10 +2148,7 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
     }
@@ -2056,10 +2157,7 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut Limited::new(
-                Cursor::new(&mut buf),
-                Limits::default(),
-            ))
+            .write_xdr(&mut Limited::new(Cursor::new(&mut buf), Limits::default()))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
     }
@@ -2096,10 +2194,22 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
+        let mut dlr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                depth: 4,
+                ..Limits::default()
+            },
+        );
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
@@ -2107,7 +2217,13 @@ mod test {
     #[test]
     fn write_over_depth_limit_fail() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                depth: 3,
+                len: usize::MAX,
+            },
+        );
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2117,8 +2233,14 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_limits = Limits { depth: 3 };
-        let write_limits = Limits { depth: 5 };
+        let read_limits = Limits {
+            depth: 3,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            depth: 5,
+            ..Limits::default()
+        };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
         let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
@@ -3990,7 +4112,7 @@ TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNested
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -4009,7 +4131,7 @@ TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNested
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -4018,29 +4140,29 @@ TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNested
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
-TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Uint513>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Uint513(Box::new(t))))),
-TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Uint514>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Uint514(Box::new(t))))),
-TypeVariant::Str => Box::new(ReadXdrIter::<_, Str>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Str(Box::new(t))))),
-TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Str2>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Str2(Box::new(t))))),
-TypeVariant::Hash => Box::new(ReadXdrIter::<_, Hash>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Hash(Box::new(t))))),
-TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Hashes1>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Hashes1(Box::new(t))))),
-TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Hashes2>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Hashes2(Box::new(t))))),
-TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Hashes3>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Hashes3(Box::new(t))))),
-TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, OptHash1>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::OptHash1(Box::new(t))))),
-TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, OptHash2>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::OptHash2(Box::new(t))))),
-TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Int1>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int1(Box::new(t))))),
-TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Int2>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int2(Box::new(t))))),
-TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Int3>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int3(Box::new(t))))),
-TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Int4>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int4(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
-TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, LotsOfMyStructs>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t))))),
-TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, HasStuff>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::HasStuff(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Nester => Box::new(ReadXdrIter::<_, Nester>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Nester(Box::new(t))))),
-TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, NesterNestedEnum>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t))))),
-TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, NesterNestedStruct>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t))))),
-TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t))))),
+                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
+TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Uint513>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Uint513(Box::new(t))))),
+TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Uint514>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Uint514(Box::new(t))))),
+TypeVariant::Str => Box::new(ReadXdrIter::<_, Str>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Str(Box::new(t))))),
+TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Str2>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Str2(Box::new(t))))),
+TypeVariant::Hash => Box::new(ReadXdrIter::<_, Hash>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Hash(Box::new(t))))),
+TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Hashes1>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Hashes1(Box::new(t))))),
+TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Hashes2>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Hashes2(Box::new(t))))),
+TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Hashes3>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Hashes3(Box::new(t))))),
+TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, OptHash1>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::OptHash1(Box::new(t))))),
+TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, OptHash2>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::OptHash2(Box::new(t))))),
+TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Int1>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int1(Box::new(t))))),
+TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Int2>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int2(Box::new(t))))),
+TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Int3>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int3(Box::new(t))))),
+TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Int4>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int4(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, LotsOfMyStructs>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t))))),
+TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, HasStuff>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::HasStuff(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Nester => Box::new(ReadXdrIter::<_, Nester>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Nester(Box::new(t))))),
+TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, NesterNestedEnum>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t))))),
+TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, NesterNestedStruct>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t))))),
+TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t))))),
                 }
             }
 
@@ -4048,29 +4170,29 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Frame<Uint512>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Uint512(Box::new(t.0))))),
-TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Frame<Uint513>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Uint513(Box::new(t.0))))),
-TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Frame<Uint514>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Uint514(Box::new(t.0))))),
-TypeVariant::Str => Box::new(ReadXdrIter::<_, Frame<Str>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Str(Box::new(t.0))))),
-TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Frame<Str2>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Str2(Box::new(t.0))))),
-TypeVariant::Hash => Box::new(ReadXdrIter::<_, Frame<Hash>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Hash(Box::new(t.0))))),
-TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Frame<Hashes1>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Hashes1(Box::new(t.0))))),
-TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Frame<Hashes2>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Hashes2(Box::new(t.0))))),
-TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Frame<Hashes3>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Hashes3(Box::new(t.0))))),
-TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, Frame<OptHash1>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::OptHash1(Box::new(t.0))))),
-TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, Frame<OptHash2>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::OptHash2(Box::new(t.0))))),
-TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Frame<Int1>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int1(Box::new(t.0))))),
-TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Frame<Int2>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int2(Box::new(t.0))))),
-TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Frame<Int3>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int3(Box::new(t.0))))),
-TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Frame<Int4>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Int4(Box::new(t.0))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
-TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, Frame<LotsOfMyStructs>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t.0))))),
-TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, Frame<HasStuff>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::HasStuff(Box::new(t.0))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
-TypeVariant::Nester => Box::new(ReadXdrIter::<_, Frame<Nester>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Nester(Box::new(t.0))))),
-TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, Frame<NesterNestedEnum>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t.0))))),
-TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, Frame<NesterNestedStruct>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t.0))))),
-TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, Frame<NesterNestedUnion>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t.0))))),
+                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Frame<Uint512>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Uint512(Box::new(t.0))))),
+TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Frame<Uint513>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Uint513(Box::new(t.0))))),
+TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Frame<Uint514>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Uint514(Box::new(t.0))))),
+TypeVariant::Str => Box::new(ReadXdrIter::<_, Frame<Str>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Str(Box::new(t.0))))),
+TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Frame<Str2>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Str2(Box::new(t.0))))),
+TypeVariant::Hash => Box::new(ReadXdrIter::<_, Frame<Hash>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Hash(Box::new(t.0))))),
+TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Frame<Hashes1>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Hashes1(Box::new(t.0))))),
+TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Frame<Hashes2>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Hashes2(Box::new(t.0))))),
+TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Frame<Hashes3>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Hashes3(Box::new(t.0))))),
+TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, Frame<OptHash1>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::OptHash1(Box::new(t.0))))),
+TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, Frame<OptHash2>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::OptHash2(Box::new(t.0))))),
+TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Frame<Int1>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int1(Box::new(t.0))))),
+TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Frame<Int2>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int2(Box::new(t.0))))),
+TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Frame<Int3>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int3(Box::new(t.0))))),
+TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Frame<Int4>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int4(Box::new(t.0))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
+TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, Frame<LotsOfMyStructs>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t.0))))),
+TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, Frame<HasStuff>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::HasStuff(Box::new(t.0))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
+TypeVariant::Nester => Box::new(ReadXdrIter::<_, Frame<Nester>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Nester(Box::new(t.0))))),
+TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, Frame<NesterNestedEnum>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t.0))))),
+TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, Frame<NesterNestedStruct>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t.0))))),
+TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, Frame<NesterNestedUnion>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t.0))))),
                 }
             }
 
@@ -4079,29 +4201,29 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, Frame<NesterNestedUn
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(dec, r.limits).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
-TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Uint513>::new(dec, r.limits).map(|r| r.map(|t| Self::Uint513(Box::new(t))))),
-TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Uint514>::new(dec, r.limits).map(|r| r.map(|t| Self::Uint514(Box::new(t))))),
-TypeVariant::Str => Box::new(ReadXdrIter::<_, Str>::new(dec, r.limits).map(|r| r.map(|t| Self::Str(Box::new(t))))),
-TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Str2>::new(dec, r.limits).map(|r| r.map(|t| Self::Str2(Box::new(t))))),
-TypeVariant::Hash => Box::new(ReadXdrIter::<_, Hash>::new(dec, r.limits).map(|r| r.map(|t| Self::Hash(Box::new(t))))),
-TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Hashes1>::new(dec, r.limits).map(|r| r.map(|t| Self::Hashes1(Box::new(t))))),
-TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Hashes2>::new(dec, r.limits).map(|r| r.map(|t| Self::Hashes2(Box::new(t))))),
-TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Hashes3>::new(dec, r.limits).map(|r| r.map(|t| Self::Hashes3(Box::new(t))))),
-TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, OptHash1>::new(dec, r.limits).map(|r| r.map(|t| Self::OptHash1(Box::new(t))))),
-TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, OptHash2>::new(dec, r.limits).map(|r| r.map(|t| Self::OptHash2(Box::new(t))))),
-TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Int1>::new(dec, r.limits).map(|r| r.map(|t| Self::Int1(Box::new(t))))),
-TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Int2>::new(dec, r.limits).map(|r| r.map(|t| Self::Int2(Box::new(t))))),
-TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Int3>::new(dec, r.limits).map(|r| r.map(|t| Self::Int3(Box::new(t))))),
-TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Int4>::new(dec, r.limits).map(|r| r.map(|t| Self::Int4(Box::new(t))))),
-TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
-TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, LotsOfMyStructs>::new(dec, r.limits).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t))))),
-TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, HasStuff>::new(dec, r.limits).map(|r| r.map(|t| Self::HasStuff(Box::new(t))))),
-TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, r.limits).map(|r| r.map(|t| Self::Color(Box::new(t))))),
-TypeVariant::Nester => Box::new(ReadXdrIter::<_, Nester>::new(dec, r.limits).map(|r| r.map(|t| Self::Nester(Box::new(t))))),
-TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, NesterNestedEnum>::new(dec, r.limits).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t))))),
-TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, NesterNestedStruct>::new(dec, r.limits).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t))))),
-TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::new(dec, r.limits).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t))))),
+                    TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
+TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Uint513>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Uint513(Box::new(t))))),
+TypeVariant::Uint514 => Box::new(ReadXdrIter::<_, Uint514>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Uint514(Box::new(t))))),
+TypeVariant::Str => Box::new(ReadXdrIter::<_, Str>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Str(Box::new(t))))),
+TypeVariant::Str2 => Box::new(ReadXdrIter::<_, Str2>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Str2(Box::new(t))))),
+TypeVariant::Hash => Box::new(ReadXdrIter::<_, Hash>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Hash(Box::new(t))))),
+TypeVariant::Hashes1 => Box::new(ReadXdrIter::<_, Hashes1>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Hashes1(Box::new(t))))),
+TypeVariant::Hashes2 => Box::new(ReadXdrIter::<_, Hashes2>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Hashes2(Box::new(t))))),
+TypeVariant::Hashes3 => Box::new(ReadXdrIter::<_, Hashes3>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Hashes3(Box::new(t))))),
+TypeVariant::OptHash1 => Box::new(ReadXdrIter::<_, OptHash1>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::OptHash1(Box::new(t))))),
+TypeVariant::OptHash2 => Box::new(ReadXdrIter::<_, OptHash2>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::OptHash2(Box::new(t))))),
+TypeVariant::Int1 => Box::new(ReadXdrIter::<_, Int1>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Int1(Box::new(t))))),
+TypeVariant::Int2 => Box::new(ReadXdrIter::<_, Int2>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Int2(Box::new(t))))),
+TypeVariant::Int3 => Box::new(ReadXdrIter::<_, Int3>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Int3(Box::new(t))))),
+TypeVariant::Int4 => Box::new(ReadXdrIter::<_, Int4>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Int4(Box::new(t))))),
+TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
+TypeVariant::LotsOfMyStructs => Box::new(ReadXdrIter::<_, LotsOfMyStructs>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::LotsOfMyStructs(Box::new(t))))),
+TypeVariant::HasStuff => Box::new(ReadXdrIter::<_, HasStuff>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::HasStuff(Box::new(t))))),
+TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
+TypeVariant::Nester => Box::new(ReadXdrIter::<_, Nester>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Nester(Box::new(t))))),
+TypeVariant::NesterNestedEnum => Box::new(ReadXdrIter::<_, NesterNestedEnum>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::NesterNestedEnum(Box::new(t))))),
+TypeVariant::NesterNestedStruct => Box::new(ReadXdrIter::<_, NesterNestedStruct>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::NesterNestedStruct(Box::new(t))))),
+TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::NesterNestedUnion(Box::new(t))))),
                 }
             }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -2268,6 +2268,68 @@ mod test {
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
         }
     }
+
+    #[test]
+    fn length_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut lr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[test]
+    fn write_over_length_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 15,
+                ..Limits::default()
+            },
+        );
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected LengthLimitExceeded got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn read_over_length_limit_fail() {
+        let read_limits = Limits {
+            len: 15,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            len: 16,
+            ..Limits::default()
+        };
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(Vec::new(), read_limits);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
+    }
 }
 
 #[cfg(all(test, not(feature = "alloc")))]

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -273,12 +273,12 @@ impl<L> Limited<L> {
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
+            let res = f(self);
+            self.limits.depth = self.limits.depth.saturating_add(1);
+            res
         } else {
-            return Err(Error::DepthLimitExceeded);
+            Err(Error::DepthLimitExceeded)
         }
-        let res = f(self);
-        self.limits.depth = self.limits.depth.saturating_add(1);
-        res
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -219,6 +219,7 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
+    #[must_use]
     pub fn none() -> Self {
         Self {
             depth: u32::MAX,
@@ -226,6 +227,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
@@ -233,6 +235,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn len(len: usize) -> Self {
         Limits {
             len,

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -219,21 +219,21 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
-    fn none() -> Self {
+    pub fn none() -> Self {
         Self {
             depth: u32::MAX,
             len: usize::MAX,
         }
     }
 
-    fn depth(depth: u32) -> Self {
+    pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
             ..Limits::none()
         }
     }
 
-    fn len(len: usize) -> Self {
+    pub fn len(len: usize) -> Self {
         Limits {
             len,
             ..Limits::none()

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -2268,6 +2268,68 @@ mod test {
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
         }
     }
+
+    #[test]
+    fn length_limited_read_write_under_the_limit_success() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut lr = Limited::new(
+            Cursor::new(buf.inner.as_slice()),
+            Limits {
+                len: 16,
+                ..Limits::default()
+            },
+        );
+        let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut lr).unwrap();
+        assert_eq!(a, a_back);
+    }
+
+    #[test]
+    fn write_over_length_limit_fail() {
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(
+            Vec::new(),
+            Limits {
+                len: 15,
+                ..Limits::default()
+            },
+        );
+        let res = a.write_xdr(&mut buf);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected LengthLimitExceeded got {res:?}"),
+        }
+    }
+
+    #[test]
+    fn read_over_length_limit_fail() {
+        let read_limits = Limits {
+            len: 15,
+            ..Limits::default()
+        };
+        let write_limits = Limits {
+            len: 16,
+            ..Limits::default()
+        };
+        let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
+        let mut buf = Limited::new(Vec::new(), read_limits);
+        a.write_xdr(&mut buf).unwrap();
+
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
+        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        match res {
+            Err(Error::LengthLimitExceeded) => (),
+            _ => panic!("expected DepthLimitExceeded got {res:?}"),
+        }
+    }
 }
 
 #[cfg(all(test, not(feature = "alloc")))]

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -273,12 +273,12 @@ impl<L> Limited<L> {
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
+            let res = f(self);
+            self.limits.depth = self.limits.depth.saturating_add(1);
+            res
         } else {
-            return Err(Error::DepthLimitExceeded);
+            Err(Error::DepthLimitExceeded)
         }
-        let res = f(self);
-        self.limits.depth = self.limits.depth.saturating_add(1);
-        res
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -219,6 +219,7 @@ pub struct Limits {
 
 #[cfg(feature = "std")]
 impl Limits {
+    #[must_use]
     pub fn none() -> Self {
         Self {
             depth: u32::MAX,
@@ -226,6 +227,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn depth(depth: u32) -> Self {
         Limits {
             depth,
@@ -233,6 +235,7 @@ impl Limits {
         }
     }
 
+    #[must_use]
     pub fn len(len: usize) -> Self {
         Limits {
             len,

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -51,14 +51,6 @@ use std::{
     io::{BufRead, BufReader, Cursor, Read, Write},
 };
 
-/// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
-///
-/// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
-/// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
-/// For more information about Rust's stack size limit, refer to the
-/// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
-pub const DEFAULT_XDR_RW_DEPTH_LIMIT: u32 = 500;
-
 /// Error contains all errors returned by functions in this crate. It can be
 /// compared via `PartialEq`, however any contained IO errors will only be
 /// compared on their `ErrorKind`.
@@ -204,172 +196,71 @@ where
 {
 }
 
-/// `DepthLimiter` is a trait designed for managing the depth of recursive operations.
-/// It provides a mechanism to limit recursion depth, and defines the behavior upon
-/// entering and leaving a recursion level.
-pub trait DepthLimiter {
-    /// A general error type for any type implementing, or an operation under the guard of
-    /// `DepthLimiter`. It must at least include the error case where the depth limit is exceeded
-    /// which is returned from `enter`.
-    type DepthLimiterError;
+/// `Limits` contains the limits that a limited reader or writer will be
+/// constrained to.
+#[cfg(feature = "std")]
+pub struct Limits {
+    /// Defines the maximum depth for recursive calls in `Read/WriteXdr` to prevent stack overflow.
+    ///
+    /// The depth limit is akin to limiting stack depth. Its purpose is to prevent the program from
+    /// hitting the maximum stack size allowed by Rust, which would result in an unrecoverable `SIGABRT`.
+    /// For more information about Rust's stack size limit, refer to the
+    /// [Rust documentation](https://doc.rust-lang.org/std/thread/#stack-size).
+    pub depth: u32,
+}
 
-    /// Defines the behavior for entering a new recursion level.
-    /// A `DepthLimiterError` is returned if the new level exceeds the depth limit.
-    fn enter(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Defines the behavior for leaving a recursion level.
-    /// A `DepthLimiterError` is returned if an error occurs.
-    fn leave(&mut self) -> core::result::Result<(), Self::DepthLimiterError>;
-
-    /// Wraps a given function `f` with depth limiting guards.
-    /// It triggers an `enter` before, and a `leave` after the execution of `f`.
-    ///
-    /// # Parameters
-    ///
-    /// - `f`: The function to be executed under depth limit constraints.
-    ///
-    /// # Returns
-    ///
-    /// - `Err` if 1. the depth limit has been exceeded upon `enter` 2. `f` executes
-    ///         with an error 3. if error occurs on `leave`.
-    ///   `Ok` otherwise.
-    fn with_limited_depth<T, F>(&mut self, f: F) -> core::result::Result<T, Self::DepthLimiterError>
-    where
-        F: FnOnce(&mut Self) -> core::result::Result<T, Self::DepthLimiterError>,
-    {
-        self.enter()?;
-        let res = f(self);
-        self.leave()?;
-        res
+#[cfg(feature = "std")]
+impl Default for Limits {
+    fn default() -> Self {
+        Self { depth: 500 }
     }
 }
 
-/// `DepthLimitedRead` wraps a `Read` object and enforces a depth limit to
-/// recursive read operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
+/// `Limited` wraps an object and provides functions for enforcing limits.
 #[cfg(feature = "std")]
-pub struct DepthLimitedRead<R: Read> {
-    pub inner: R,
-    pub(crate) depth_remaining: u32,
+pub struct Limited<L> {
+    pub inner: L,
+    pub(crate) limits: Limits,
 }
 
 #[cfg(feature = "std")]
-impl<R: Read> DepthLimitedRead<R> {
-    /// Constructs a new `DepthLimitedRead`.
+impl<L> Limited<L> {
+    /// Constructs a new `Limited`.
     ///
     /// - `inner`: The object implementing the `Read` trait.
     /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: R, depth_limit: u32) -> Self {
-        DepthLimitedRead {
-            inner,
-            depth_remaining: depth_limit,
-        }
+    pub fn new(inner: L, limits: Limits) -> Self {
+        Limited { inner, limits }
     }
-}
 
-#[cfg(feature = "std")]
-impl<R: Read> DepthLimiter for DepthLimitedRead<R> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the `depth_remaining` is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> core::result::Result<(), Error> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
+    fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut Self) -> Result<T>,
+    {
+        if let Some(depth) = self.limits.depth.checked_sub(1) {
+            self.limits.depth = depth;
         } else {
             return Err(Error::DepthLimitExceeded);
         }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<R: Read> Read for DepthLimitedRead<R> {
-    /// Forwards the read operation to the wrapped object.
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.inner.read(buf)
-    }
-}
-
-/// `DepthLimitedWrite` wraps a `Write` object and enforces a depth limit to
-/// recursive write operations. It maintains a `depth_remaining` state tracking
-/// remaining allowed recursion depth.
-#[cfg(feature = "std")]
-pub struct DepthLimitedWrite<W: Write> {
-    pub inner: W,
-    pub(crate) depth_remaining: u32,
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimitedWrite<W> {
-    /// Constructs a new `DepthLimitedWrite`.
-    ///
-    /// - `inner`: The object implementing the `Write` trait.
-    /// - `depth_limit`: The maximum allowed recursion depth.
-    pub fn new(inner: W, depth_limit: u32) -> Self {
-        DepthLimitedWrite {
-            inner,
-            depth_remaining: depth_limit,
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> DepthLimiter for DepthLimitedWrite<W> {
-    type DepthLimiterError = Error;
-
-    /// Decrements the `depth_remaining`. If the depth is already zero, an error is
-    /// returned indicating that the maximum depth limit has been exceeded.
-    fn enter(&mut self) -> Result<()> {
-        if let Some(depth) = self.depth_remaining.checked_sub(1) {
-            self.depth_remaining = depth;
-        } else {
-            return Err(Error::DepthLimitExceeded);
-        }
-        Ok(())
-    }
-
-    /// Increments the depth. `leave` should be called in tandem with `enter` such that the depth
-    /// doesn't exceed the initial depth limit.
-    fn leave(&mut self) -> core::result::Result<(), Error> {
-        self.depth_remaining = self.depth_remaining.saturating_add(1);
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<W: Write> Write for DepthLimitedWrite<W> {
-    /// Forwards the write operation to the wrapped object.
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.inner.write(buf)
-    }
-
-    /// Forwards the flush operation to the wrapped object.
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.inner.flush()
+        let res = f(self);
+        self.limits.depth = self.limits.depth.saturating_add(1);
+        res
     }
 }
 
 #[cfg(feature = "std")]
 pub struct ReadXdrIter<R: Read, S: ReadXdr> {
-    reader: DepthLimitedRead<BufReader<R>>,
+    reader: Limited<BufReader<R>>,
     _s: PhantomData<S>,
 }
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
-    fn new(r: R, depth_limit: u32) -> Self {
+    fn new(r: R, limits: Limits) -> Self {
         Self {
-            reader: DepthLimitedRead {
+            reader: Limited {
                 inner: BufReader::new(r),
-                depth_remaining: depth_limit,
+                limits,
             },
             _s: PhantomData,
         }
@@ -431,15 +322,15 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -466,7 +357,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -482,8 +373,8 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
-        let mut dec = DepthLimitedRead::new(
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.depth_remaining,
         );
@@ -506,7 +397,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -530,7 +421,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut DepthLimitedRead<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -560,7 +451,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_iter<R: Read>(r: &mut DepthLimitedRead<R>) -> ReadXdrIter<&mut R, Self> {
+    fn read_xdr_iter<R: Read>(r: &mut Limited<R>) -> ReadXdrIter<&mut R, Self> {
         ReadXdrIter::new(&mut r.inner, r.depth_remaining)
     }
 
@@ -568,88 +459,60 @@ where
     /// values that are read into the implementing type.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
-        r: &mut DepthLimitedRead<R>,
+        r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         ReadXdrIter::new(dec, r.depth_remaining)
     }
 
-    /// Construct the type from the XDR bytes, specifying a depth limit.
+    /// Construct the type from the XDR bytes.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr_with_depth_limit(bytes: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
-        let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), depth_limit);
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+        let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
     }
 
-    /// Construct the type from the XDR bytes, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_with_depth_limit(bytes, DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, specifying a depth limit.
+    /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64_with_depth_limit(b64: impl AsRef<[u8]>, depth_limit: u32) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
-        let mut dec = DepthLimitedRead::new(
+        let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
-            depth_limit,
+            limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
         Ok(t)
-    }
-
-    /// Construct the type from the XDR bytes base64 encoded, using the default depth limit.
-    ///
-    /// An error is returned if the bytes are not completely consumed by the
-    /// deserialization.
-    #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>) -> Result<Self> {
-        ReadXdr::from_xdr_base64_with_depth_limit(b64, DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
 
     #[cfg(feature = "std")]
-    fn to_xdr_with_depth_limit(&self, depth_limit: u32) -> Result<Vec<u8>> {
-        let mut cursor = DepthLimitedWrite::new(Cursor::new(vec![]), depth_limit);
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+        let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
         Ok(bytes)
     }
 
-    #[cfg(feature = "std")]
-    fn to_xdr(&self) -> Result<Vec<u8>> {
-        self.to_xdr_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
-    }
-
     #[cfg(feature = "base64")]
-    fn to_xdr_base64_with_depth_limit(&self, depth_limit: u32) -> Result<String> {
-        let mut enc = DepthLimitedWrite::new(
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+        let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
-            depth_limit,
+            limits,
         );
         self.write_xdr(&mut enc)?;
         let b64 = enc.inner.into_inner();
         Ok(b64)
-    }
-
-    #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self) -> Result<String> {
-        self.to_xdr_base64_with_depth_limit(DEFAULT_XDR_RW_DEPTH_LIMIT)
     }
 }
 
@@ -662,7 +525,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -673,7 +536,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -681,7 +544,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -692,7 +555,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -700,7 +563,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -711,7 +574,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -719,7 +582,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.read_exact(&mut b)?;
@@ -730,7 +593,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| Ok(w.write_all(&b)?))
     }
@@ -738,35 +601,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -777,7 +640,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -787,7 +650,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -804,7 +667,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -819,35 +682,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut arr = [0u8; N];
             r.read_exact(&mut arr)?;
@@ -863,7 +726,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             w.write_all(self)?;
             w.write_all(&[0u8; 3][..pad_len(N)])?;
@@ -874,7 +737,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -889,7 +752,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -1222,7 +1085,7 @@ impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1245,7 +1108,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1261,7 +1124,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1281,7 +1144,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1620,7 +1483,7 @@ impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1643,7 +1506,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2003,7 +1866,7 @@ impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2026,7 +1889,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2057,7 +1920,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2080,17 +1943,13 @@ where
 mod tests {
     use std::io::Cursor;
 
-    use super::{
-        DepthLimitedRead, DepthLimitedWrite, Error, ReadXdr, VecM, WriteXdr,
-        DEFAULT_XDR_RW_DEPTH_LIMIT,
-    };
+    use super::*;
 
     #[test]
     pub fn vec_u8_read_without_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 4, 2, 2, 2, 2]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2, 2, 2, 2]);
     }
 
@@ -2098,16 +1957,14 @@ mod tests {
     pub fn vec_u8_read_with_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0, 0]);
         let v =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-                .unwrap();
+            VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v.to_vec(), vec![2]);
     }
 
     #[test]
     pub fn vec_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2117,8 +1974,7 @@ mod tests {
     #[test]
     pub fn vec_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![0, 0, 0, 1, 2, 3, 0, 0]);
-        let res =
-            VecM::<u8, 8>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = VecM::<u8, 8>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2130,7 +1986,7 @@ mod tests {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2, 2, 2, 2].try_into().unwrap();
 
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2142,7 +1998,7 @@ mod tests {
     pub fn vec_u8_write_with_padding() {
         let mut buf = vec![];
         let v: VecM<u8, 8> = vec![2].try_into().unwrap();
-        v.write_xdr(&mut DepthLimitedWrite::new(
+        v.write_xdr(&mut Limited::new(
             Cursor::new(&mut buf),
             DEFAULT_XDR_RW_DEPTH_LIMIT,
         ))
@@ -2153,23 +2009,21 @@ mod tests {
     #[test]
     pub fn arr_u8_read_without_padding() {
         let buf = Cursor::new(vec![2, 2, 2, 2]);
-        let v = <[u8; 4]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 4]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2, 2, 2, 2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_padding() {
         let buf = Cursor::new(vec![2, 0, 0, 0]);
-        let v = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT))
-            .unwrap();
+        let v = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default())).unwrap();
         assert_eq!(v, [2]);
     }
 
     #[test]
     pub fn arr_u8_read_with_insufficient_padding() {
         let buf = Cursor::new(vec![2, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::Io(_)) => (),
             _ => panic!("expected IO error got {res:?}"),
@@ -2179,7 +2033,7 @@ mod tests {
     #[test]
     pub fn arr_u8_read_with_non_zero_padding() {
         let buf = Cursor::new(vec![2, 3, 0, 0]);
-        let res = <[u8; 1]>::read_xdr(&mut DepthLimitedRead::new(buf, DEFAULT_XDR_RW_DEPTH_LIMIT));
+        let res = <[u8; 1]>::read_xdr(&mut Limited::new(buf, Limits::default()));
         match res {
             Err(Error::NonZeroPadding) => (),
             _ => panic!("expected NonZeroPadding got {res:?}"),
@@ -2190,9 +2044,9 @@ mod tests {
     pub fn arr_u8_write_without_padding() {
         let mut buf = vec![];
         [2u8, 2, 2, 2]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 2, 2, 2]);
@@ -2202,9 +2056,9 @@ mod tests {
     pub fn arr_u8_write_with_padding() {
         let mut buf = vec![];
         [2u8]
-            .write_xdr(&mut DepthLimitedWrite::new(
+            .write_xdr(&mut Limited::new(
                 Cursor::new(&mut buf),
-                DEFAULT_XDR_RW_DEPTH_LIMIT,
+                Limits::default(),
             ))
             .unwrap();
         assert_eq!(buf, vec![2, 0, 0, 0]);
@@ -2242,19 +2096,18 @@ mod test {
     #[test]
     fn depth_limited_read_write_under_the_limit_success() {
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), 4);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 4});
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), 4);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), Limites { depth: 4 });
         let a_back: Option<Option<Option<u32>>> = ReadXdr::read_xdr(&mut dlr).unwrap();
         assert_eq!(a, a_back);
     }
 
     #[test]
     fn write_over_depth_limit_fail() {
-        let depth_limit = 3;
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), depth_limit);
+        let mut buf = Limited::new(Vec::new(), Limits { depth: 3 });
         let res = a.write_xdr(&mut buf);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2264,13 +2117,13 @@ mod test {
 
     #[test]
     fn read_over_depth_limit_fail() {
-        let read_depth_limit = 3;
-        let write_depth_limit = 5;
+        let read_limits = Limits { depth: 3 };
+        let write_limits = Limits { depth: 5 };
         let a: Option<Option<Option<u32>>> = Some(Some(Some(5)));
-        let mut buf = DepthLimitedWrite::new(Vec::new(), write_depth_limit);
+        let mut buf = Limited::new(Vec::new(), read_limits);
         a.write_xdr(&mut buf).unwrap();
 
-        let mut dlr = DepthLimitedRead::new(Cursor::new(buf.inner.as_slice()), read_depth_limit);
+        let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), write_limits);
         let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
@@ -2389,7 +2242,7 @@ Self::Multi => "Multi",
 
         impl ReadXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -2400,7 +2253,7 @@ Self::Multi => "Multi",
 
         impl WriteXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -2487,7 +2340,7 @@ Self::Multi(_) => UnionKey::Multi,
 
         impl ReadXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     let dv: UnionKey = <UnionKey as ReadXdr>::read_xdr(r)?;
                     #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
@@ -2504,7 +2357,7 @@ UnionKey::Multi => Self::Multi(VecM::<i32>::read_xdr(r)?),
 
         impl WriteXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     self.discriminant().write_xdr(w)?;
                     #[allow(clippy::match_same_arms)]
@@ -2595,7 +2448,7 @@ Self::V1(_) => 1,
 
         impl ReadXdr for IntUnion {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
                 r.with_limited_depth(|r| {
                     let dv: i32 = <i32 as ReadXdr>::read_xdr(r)?;
                     #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
@@ -2612,7 +2465,7 @@ Self::V1(_) => 1,
 
         impl WriteXdr for IntUnion {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 w.with_limited_depth(|w| {
                     self.discriminant().write_xdr(w)?;
                     #[allow(clippy::match_same_arms)]
@@ -2658,7 +2511,7 @@ impl AsRef<IntUnion> for IntUnion2 {
 
 impl ReadXdr for IntUnion2 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut DepthLimitedRead<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         r.with_limited_depth(|r| {
             let i = IntUnion::read_xdr(r)?;
             let v = IntUnion2(i);
@@ -2669,7 +2522,7 @@ impl ReadXdr for IntUnion2 {
 
 impl WriteXdr for IntUnion2 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -2784,7 +2637,7 @@ TypeVariant::IntUnion2, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 match v {
                     TypeVariant::SError => r.with_limited_depth(|r| Ok(Self::SError(Box::new(SError::read_xdr(r)?)))),
 TypeVariant::Multi => r.with_limited_depth(|r| Ok(Self::Multi(Box::new(Multi::read_xdr(r)?)))),
@@ -2796,14 +2649,14 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2815,63 +2668,63 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Result<Self> {
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.depth_remaining);
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::SError(Box::new(t))))),
-TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
-TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
-TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
+                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::SError(Box::new(t))))),
+TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
+TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
+TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 match v {
-                    TypeVariant::SError => Box::new(ReadXdrIter::<_, Frame<SError>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::SError(Box::new(t.0))))),
-TypeVariant::Multi => Box::new(ReadXdrIter::<_, Frame<Multi>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::Multi(Box::new(t.0))))),
-TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
-TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, Frame<IntUnion>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::IntUnion(Box::new(t.0))))),
-TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, Frame<IntUnion2>>::new(&mut r.inner, r.depth_remaining).map(|r| r.map(|t| Self::IntUnion2(Box::new(t.0))))),
+                    TypeVariant::SError => Box::new(ReadXdrIter::<_, Frame<SError>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::SError(Box::new(t.0))))),
+TypeVariant::Multi => Box::new(ReadXdrIter::<_, Frame<Multi>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::Multi(Box::new(t.0))))),
+TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, Frame<MyUnion>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::MyUnion(Box::new(t.0))))),
+TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, Frame<IntUnion>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::IntUnion(Box::new(t.0))))),
+TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, Frame<IntUnion2>>::new(&mut r.inner, r.limits).map(|r| r.map(|t| Self::IntUnion2(Box::new(t.0))))),
                 }
             }
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut DepthLimitedRead<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
-                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::SError(Box::new(t))))),
-TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
-TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
-TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
-TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
-TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.depth_remaining).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
+                    TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(dec, r.limits).map(|r| r.map(|t| Self::SError(Box::new(t))))),
+TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(dec, r.limits).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
+TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.limits).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
+TypeVariant::MyUnion => Box::new(ReadXdrIter::<_, MyUnion>::new(dec, r.limits).map(|r| r.map(|t| Self::MyUnion(Box::new(t))))),
+TypeVariant::IntUnion => Box::new(ReadXdrIter::<_, IntUnion>::new(dec, r.limits).map(|r| r.map(|t| Self::IntUnion(Box::new(t))))),
+TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.limits).map(|r| r.map(|t| Self::IntUnion2(Box::new(t))))),
                 }
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B) -> Result<Self> {
-                let mut cursor = DepthLimitedRead::new(Cursor::new(bytes.as_ref()), DEFAULT_XDR_RW_DEPTH_LIMIT);
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+                let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: String) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: String, limits: Limits) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = DepthLimitedRead::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), DEFAULT_XDR_RW_DEPTH_LIMIT);
+                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -2953,7 +2806,7 @@ Self::IntUnion2(_) => TypeVariant::IntUnion2,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut DepthLimitedWrite<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
                 match self {
                     Self::SError(v) => v.write_xdr(w),
 Self::Multi(v) => v.write_xdr(w),


### PR DESCRIPTION
### What
Add length limits to the Rust generated code.

### How
Simplified the existing DepthLimitedRead/Write structs, combining them into one, and renaming them to Limited. Added the Limits type that captures the limits and made it a required input to functions that used to collect the depth limit.

### Why

To avoid preallocating memory when parsing will ultimately fail because the message being parsed doesn't contain sufficient data for the parse to succeed.

Close #174

Alternative to https://github.com/stellar/xdrgen/pull/178