### PR TITLE
Change StringM Debug, String, and Debug representations to escaped

### DIFF
--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1660,31 +1660,6 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
-/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
-/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
-fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
-    loop {
-        match core::str::from_utf8(input) {
-            Ok(valid) => {
-                write!(f, "{valid}")?;
-                break;
-            }
-            Err(error) => {
-                let (valid, after_valid) = input.split_at(error.valid_up_to());
-                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
-                write!(f, "\u{FFFD}")?;
-
-                if let Some(invalid_sequence_length) = error.error_len() {
-                    input = &after_valid[invalid_sequence_length..];
-                } else {
-                    break;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         #[cfg(feature = "alloc")]

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1717,7 +1717,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        let b = escape_bytes::unescape(&mut code, s.as_bytes()).map_err(|_| Error::Invalid)?;
+        let b = escape_bytes::unescape(s.as_bytes()).map_err(|_| Error::Invalid)?;
         Ok(Self(b))
     }
 }

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -1635,6 +1635,17 @@ impl<const MAX: u32> WriteXdr for BytesM<MAX> {
 
 // StringM ------------------------------------------------------------------------
 
+/// A string type that contains arbitrary bytes.
+///
+/// Convertible, fallibly, to/from a Rust UTF-8 String using
+/// [`TryFrom`]/[`TryInto`]/[`StringM::to_utf8_string`].
+///
+/// Convertible, lossyly, to a Rust UTF-8 String using
+/// [`StringM::to_utf8_string_lossy`].
+///
+/// Convertible to/from escaped printable-ASCII using
+/// [`Display`]/[`ToString`]/[`FromStr`].
+
 #[cfg(feature = "alloc")]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(
@@ -1680,7 +1691,9 @@ impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
         let v = &self.0;
         #[cfg(not(feature = "alloc"))]
         let v = self.0;
-        write_utf8_lossy(f, v)?;
+        for b in escape_bytes::Escape::new(v) {
+            write!(f, "{}", b as char)?;
+        }
         Ok(())
     }
 }
@@ -1692,7 +1705,9 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
         #[cfg(not(feature = "alloc"))]
         let v = self.0;
         write!(f, "StringM(")?;
-        write_utf8_lossy(f, v)?;
+        for b in escape_bytes::Escape::new(v) {
+            write!(f, "{}", b as char)?;
+        }
         write!(f, ")")?;
         Ok(())
     }
@@ -1702,7 +1717,8 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        s.try_into()
+        let b = escape_bytes::unescape(&mut code, s.as_bytes()).map_err(|_| Error::Invalid)?;
+        Ok(Self(b))
     }
 }
 
@@ -1750,24 +1766,24 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
     #[must_use]
-    pub fn to_string_lossy(&self) -> String {
+    pub fn to_utf8_string_lossy(&self) -> String {
         String::from_utf8_lossy(&self.0).into_owned()
     }
 
     #[cfg(feature = "alloc")]
     #[must_use]
-    pub fn into_string_lossy(self) -> String {
+    pub fn into_utf8_string_lossy(self) -> String {
         String::from_utf8_lossy(&self.0).into_owned()
     }
 }

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -1670,31 +1670,6 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
-/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
-/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
-fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
-    loop {
-        match core::str::from_utf8(input) {
-            Ok(valid) => {
-                write!(f, "{valid}")?;
-                break;
-            }
-            Err(error) => {
-                let (valid, after_valid) = input.split_at(error.valid_up_to());
-                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
-                write!(f, "\u{FFFD}")?;
-
-                if let Some(invalid_sequence_length) = error.error_len() {
-                    input = &after_valid[invalid_sequence_length..];
-                } else {
-                    break;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -1727,7 +1727,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        let b = escape_bytes::unescape(&mut code, s.as_bytes()).map_err(|_| Error::Invalid)?;
+        let b = escape_bytes::unescape(s.as_bytes()).map_err(|_| Error::Invalid)?;
         Ok(Self(b))
     }
 }

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -1670,31 +1670,6 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
-/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
-/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
-fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
-    loop {
-        match core::str::from_utf8(input) {
-            Ok(valid) => {
-                write!(f, "{valid}")?;
-                break;
-            }
-            Err(error) => {
-                let (valid, after_valid) = input.split_at(error.valid_up_to());
-                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
-                write!(f, "\u{FFFD}")?;
-
-                if let Some(invalid_sequence_length) = error.error_len() {
-                    input = &after_valid[invalid_sequence_length..];
-                } else {
-                    break;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -1727,7 +1727,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        let b = escape_bytes::unescape(&mut code, s.as_bytes()).map_err(|_| Error::Invalid)?;
+        let b = escape_bytes::unescape(s.as_bytes()).map_err(|_| Error::Invalid)?;
         Ok(Self(b))
     }
 }

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -1670,31 +1670,6 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
-/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
-/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
-fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
-    loop {
-        match core::str::from_utf8(input) {
-            Ok(valid) => {
-                write!(f, "{valid}")?;
-                break;
-            }
-            Err(error) => {
-                let (valid, after_valid) = input.split_at(error.valid_up_to());
-                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
-                write!(f, "\u{FFFD}")?;
-
-                if let Some(invalid_sequence_length) = error.error_len() {
-                    input = &after_valid[invalid_sequence_length..];
-                } else {
-                    break;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -1727,7 +1727,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        let b = escape_bytes::unescape(&mut code, s.as_bytes()).map_err(|_| Error::Invalid)?;
+        let b = escape_bytes::unescape(s.as_bytes()).map_err(|_| Error::Invalid)?;
         Ok(Self(b))
     }
 }

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -1670,31 +1670,6 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
-/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
-/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
-fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
-    loop {
-        match core::str::from_utf8(input) {
-            Ok(valid) => {
-                write!(f, "{valid}")?;
-                break;
-            }
-            Err(error) => {
-                let (valid, after_valid) = input.split_at(error.valid_up_to());
-                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
-                write!(f, "\u{FFFD}")?;
-
-                if let Some(invalid_sequence_length) = error.error_len() {
-                    input = &after_valid[invalid_sequence_length..];
-                } else {
-                    break;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -1727,7 +1727,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        let b = escape_bytes::unescape(&mut code, s.as_bytes()).map_err(|_| Error::Invalid)?;
+        let b = escape_bytes::unescape(s.as_bytes()).map_err(|_| Error::Invalid)?;
         Ok(Self(b))
     }
 }

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -1670,31 +1670,6 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
-/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
-/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
-fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
-    loop {
-        match core::str::from_utf8(input) {
-            Ok(valid) => {
-                write!(f, "{valid}")?;
-                break;
-            }
-            Err(error) => {
-                let (valid, after_valid) = input.split_at(error.valid_up_to());
-                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
-                write!(f, "\u{FFFD}")?;
-
-                if let Some(invalid_sequence_length) = error.error_len() {
-                    input = &after_valid[invalid_sequence_length..];
-                } else {
-                    break;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -1727,7 +1727,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        let b = escape_bytes::unescape(&mut code, s.as_bytes()).map_err(|_| Error::Invalid)?;
+        let b = escape_bytes::unescape(s.as_bytes()).map_err(|_| Error::Invalid)?;
         Ok(Self(b))
     }
 }

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -1670,31 +1670,6 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
-/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
-/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
-fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
-    loop {
-        match core::str::from_utf8(input) {
-            Ok(valid) => {
-                write!(f, "{valid}")?;
-                break;
-            }
-            Err(error) => {
-                let (valid, after_valid) = input.split_at(error.valid_up_to());
-                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
-                write!(f, "\u{FFFD}")?;
-
-                if let Some(invalid_sequence_length) = error.error_len() {
-                    input = &after_valid[invalid_sequence_length..];
-                } else {
-                    break;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -1727,7 +1727,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        let b = escape_bytes::unescape(&mut code, s.as_bytes()).map_err(|_| Error::Invalid)?;
+        let b = escape_bytes::unescape(s.as_bytes()).map_err(|_| Error::Invalid)?;
         Ok(Self(b))
     }
 }

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -1670,31 +1670,6 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
-/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
-/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
-fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
-    loop {
-        match core::str::from_utf8(input) {
-            Ok(valid) => {
-                write!(f, "{valid}")?;
-                break;
-            }
-            Err(error) => {
-                let (valid, after_valid) = input.split_at(error.valid_up_to());
-                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
-                write!(f, "\u{FFFD}")?;
-
-                if let Some(invalid_sequence_length) = error.error_len() {
-                    input = &after_valid[invalid_sequence_length..];
-                } else {
-                    break;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -1727,7 +1727,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        let b = escape_bytes::unescape(&mut code, s.as_bytes()).map_err(|_| Error::Invalid)?;
+        let b = escape_bytes::unescape(s.as_bytes()).map_err(|_| Error::Invalid)?;
         Ok(Self(b))
     }
 }

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -1670,31 +1670,6 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
-/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
-/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
-fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
-    loop {
-        match core::str::from_utf8(input) {
-            Ok(valid) => {
-                write!(f, "{valid}")?;
-                break;
-            }
-            Err(error) => {
-                let (valid, after_valid) = input.split_at(error.valid_up_to());
-                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
-                write!(f, "\u{FFFD}")?;
-
-                if let Some(invalid_sequence_length) = error.error_len() {
-                    input = &after_valid[invalid_sequence_length..];
-                } else {
-                    break;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -1727,7 +1727,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        let b = escape_bytes::unescape(&mut code, s.as_bytes()).map_err(|_| Error::Invalid)?;
+        let b = escape_bytes::unescape(s.as_bytes()).map_err(|_| Error::Invalid)?;
         Ok(Self(b))
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -1670,31 +1670,6 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
-/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
-/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
-fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
-    loop {
-        match core::str::from_utf8(input) {
-            Ok(valid) => {
-                write!(f, "{valid}")?;
-                break;
-            }
-            Err(error) => {
-                let (valid, after_valid) = input.split_at(error.valid_up_to());
-                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
-                write!(f, "\u{FFFD}")?;
-
-                if let Some(invalid_sequence_length) = error.error_len() {
-                    input = &after_valid[invalid_sequence_length..];
-                } else {
-                    break;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -1727,7 +1727,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        let b = escape_bytes::unescape(&mut code, s.as_bytes()).map_err(|_| Error::Invalid)?;
+        let b = escape_bytes::unescape(s.as_bytes()).map_err(|_| Error::Invalid)?;
         Ok(Self(b))
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -1670,31 +1670,6 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
-/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
-/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
-fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
-    loop {
-        match core::str::from_utf8(input) {
-            Ok(valid) => {
-                write!(f, "{valid}")?;
-                break;
-            }
-            Err(error) => {
-                let (valid, after_valid) = input.split_at(error.valid_up_to());
-                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
-                write!(f, "\u{FFFD}")?;
-
-                if let Some(invalid_sequence_length) = error.error_len() {
-                    input = &after_valid[invalid_sequence_length..];
-                } else {
-                    break;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -1727,7 +1727,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        let b = escape_bytes::unescape(&mut code, s.as_bytes()).map_err(|_| Error::Invalid)?;
+        let b = escape_bytes::unescape(s.as_bytes()).map_err(|_| Error::Invalid)?;
         Ok(Self(b))
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -1670,31 +1670,6 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
-/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
-/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
-fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
-    loop {
-        match core::str::from_utf8(input) {
-            Ok(valid) => {
-                write!(f, "{valid}")?;
-                break;
-            }
-            Err(error) => {
-                let (valid, after_valid) = input.split_at(error.valid_up_to());
-                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
-                write!(f, "\u{FFFD}")?;
-
-                if let Some(invalid_sequence_length) = error.error_len() {
-                    input = &after_valid[invalid_sequence_length..];
-                } else {
-                    break;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -1727,7 +1727,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        let b = escape_bytes::unescape(&mut code, s.as_bytes()).map_err(|_| Error::Invalid)?;
+        let b = escape_bytes::unescape(s.as_bytes()).map_err(|_| Error::Invalid)?;
         Ok(Self(b))
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -1670,31 +1670,6 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
-/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
-/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
-fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
-    loop {
-        match core::str::from_utf8(input) {
-            Ok(valid) => {
-                write!(f, "{valid}")?;
-                break;
-            }
-            Err(error) => {
-                let (valid, after_valid) = input.split_at(error.valid_up_to());
-                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
-                write!(f, "\u{FFFD}")?;
-
-                if let Some(invalid_sequence_length) = error.error_len() {
-                    input = &after_valid[invalid_sequence_length..];
-                } else {
-                    break;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -1727,7 +1727,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        let b = escape_bytes::unescape(&mut code, s.as_bytes()).map_err(|_| Error::Invalid)?;
+        let b = escape_bytes::unescape(s.as_bytes()).map_err(|_| Error::Invalid)?;
         Ok(Self(b))
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -1670,31 +1670,6 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
-/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
-/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
-fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
-    loop {
-        match core::str::from_utf8(input) {
-            Ok(valid) => {
-                write!(f, "{valid}")?;
-                break;
-            }
-            Err(error) => {
-                let (valid, after_valid) = input.split_at(error.valid_up_to());
-                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
-                write!(f, "\u{FFFD}")?;
-
-                if let Some(invalid_sequence_length) = error.error_len() {
-                    input = &after_valid[invalid_sequence_length..];
-                } else {
-                    break;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -1727,7 +1727,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        let b = escape_bytes::unescape(&mut code, s.as_bytes()).map_err(|_| Error::Invalid)?;
+        let b = escape_bytes::unescape(s.as_bytes()).map_err(|_| Error::Invalid)?;
         Ok(Self(b))
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -1670,31 +1670,6 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
-/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
-/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
-fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
-    loop {
-        match core::str::from_utf8(input) {
-            Ok(valid) => {
-                write!(f, "{valid}")?;
-                break;
-            }
-            Err(error) => {
-                let (valid, after_valid) = input.split_at(error.valid_up_to());
-                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
-                write!(f, "\u{FFFD}")?;
-
-                if let Some(invalid_sequence_length) = error.error_len() {
-                    input = &after_valid[invalid_sequence_length..];
-                } else {
-                    break;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -1727,7 +1727,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        let b = escape_bytes::unescape(&mut code, s.as_bytes()).map_err(|_| Error::Invalid)?;
+        let b = escape_bytes::unescape(s.as_bytes()).map_err(|_| Error::Invalid)?;
         Ok(Self(b))
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -1670,31 +1670,6 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
-/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
-/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
-fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
-    loop {
-        match core::str::from_utf8(input) {
-            Ok(valid) => {
-                write!(f, "{valid}")?;
-                break;
-            }
-            Err(error) => {
-                let (valid, after_valid) = input.split_at(error.valid_up_to());
-                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
-                write!(f, "\u{FFFD}")?;
-
-                if let Some(invalid_sequence_length) = error.error_len() {
-                    input = &after_valid[invalid_sequence_length..];
-                } else {
-                    break;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -1727,7 +1727,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        let b = escape_bytes::unescape(&mut code, s.as_bytes()).map_err(|_| Error::Invalid)?;
+        let b = escape_bytes::unescape(s.as_bytes()).map_err(|_| Error::Invalid)?;
         Ok(Self(b))
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -1670,31 +1670,6 @@ pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct StringM<const MAX: u32 = { u32::MAX }>(Vec<u8>);
 
-/// `write_utf8_lossy` is a modified copy of the Rust stdlib docs examples here:
-/// <https://doc.rust-lang.org/stable/core/str/struct.Utf8Error.html#examples>
-fn write_utf8_lossy(f: &mut impl core::fmt::Write, mut input: &[u8]) -> core::fmt::Result {
-    loop {
-        match core::str::from_utf8(input) {
-            Ok(valid) => {
-                write!(f, "{valid}")?;
-                break;
-            }
-            Err(error) => {
-                let (valid, after_valid) = input.split_at(error.valid_up_to());
-                write!(f, "{}", core::str::from_utf8(valid).unwrap())?;
-                write!(f, "\u{FFFD}")?;
-
-                if let Some(invalid_sequence_length) = error.error_len() {
-                    input = &after_valid[invalid_sequence_length..];
-                } else {
-                    break;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 impl<const MAX: u32> core::fmt::Display for StringM<MAX> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -1727,7 +1727,7 @@ impl<const MAX: u32> core::fmt::Debug for StringM<MAX> {
 impl<const MAX: u32> core::str::FromStr for StringM<MAX> {
     type Err = Error;
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
-        let b = escape_bytes::unescape(&mut code, s.as_bytes()).map_err(|_| Error::Invalid)?;
+        let b = escape_bytes::unescape(s.as_bytes()).map_err(|_| Error::Invalid)?;
         Ok(Self(b))
     }
 }


### PR DESCRIPTION
### What
Change StringM Debug, String, and Debug representations to escaped printable-ASCII. But keep ability to convert to/from UTF-8 Strings.

### Why
The `Debug`, `Display`, and `FromStr` functions are intended for converting to and from a reliable String representation for the type. Today these do not render reliable String representations because `StringM` can actually contains arbitrary byte sequences that have no representation in ASCII or UTF-8.

These representations are also used in the XDR<>JSON encoding, and so there are values of StringM that are not roundtrip convertible.

It is however reasonable that someone would want to convert to and from a StringM type using Unicode/UTF-8 String values. The TryFrom/TryInto conversions with String have been retained for this, as well as some inherent functions on the StringM type. The inherent functions were renamed to make it clearer their intent.

Unfortunately this change does make the interface of StringM harder to understand. It's easy to forget that `FromStr` is for parsing strings into types, or that `Display` (and its auto-derived cousin `ToString`) are for formatting values for printing, and that both of those traits are good for converting to a reliable format. These traits are not great for conversion to and from unreliable conversions where conversion is not necessarily supported for all values.

There might be a way for us to improve this in a future release and reduce the ambiguity. An option might be to remove the conversions to and from String, and require folks to go through bytes first.