### PR TITLE
Rust: Render doc comments on types

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -348,14 +348,14 @@ module Xdrgen
         return if defn.is_a?(AST::Definitions::Namespace)
 
         out.puts <<-EOS.strip_heredoc
-          // #{name defn} is an XDR #{defn.class.name.demodulize} defines as:
-          //
+          /// #{name defn} is an XDR #{defn.class.name.demodulize} defines as:
+          ///
         EOS
 
-        out.puts "//   " + defn.text_value.split("\n").join("\n//    ")
+        out.puts "///   " + defn.text_value.split("\n").join("\n//    ")
 
         out.puts <<-EOS.strip_heredoc
-          //
+          ///
         EOS
       end
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -2686,13 +2686,13 @@ mod test {
     }
 }
 
-// AccountFlags is an XDR Enum defines as:
-//
-//   enum AccountFlags
+/// AccountFlags is an XDR Enum defines as:
+///
+///   enum AccountFlags
 //    { // masks for each flag
 //        AUTH_REQUIRED_FLAG = 0x1
 //    };
-//
+///
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -2686,22 +2686,22 @@ mod test {
     }
 }
 
-// Foo is an XDR Const defines as:
-//
-//   const FOO = 1;
-//
+/// Foo is an XDR Const defines as:
+///
+///   const FOO = 1;
+///
 pub const FOO: u64 = 1;
 
-// TestArray is an XDR Typedef defines as:
-//
-//   typedef int TestArray[FOO];
-//
+/// TestArray is an XDR Typedef defines as:
+///
+///   typedef int TestArray[FOO];
+///
 pub type TestArray = [i32; Foo];
 
-// TestArray2 is an XDR Typedef defines as:
-//
-//   typedef int TestArray2<FOO>;
-//
+/// TestArray2 is an XDR Typedef defines as:
+///
+///   typedef int TestArray2<FOO>;
+///
 pub type TestArray2 = VecM::<i32, 1>;
 
         #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -2686,9 +2686,9 @@ mod test {
     }
 }
 
-// MessageType is an XDR Enum defines as:
-//
-//   enum MessageType
+/// MessageType is an XDR Enum defines as:
+///
+///   enum MessageType
 //    {
 //        ERROR_MSG,    
 //        HELLO,
@@ -2711,7 +2711,7 @@ mod test {
 //        FBA_QUORUMSET,    
 //        FBA_MESSAGE
 //    };
-//
+///
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -2865,14 +2865,14 @@ Self::FbaMessage => "FbaMessage",
             }
         }
 
-// Color is an XDR Enum defines as:
-//
-//   enum Color {
+/// Color is an XDR Enum defines as:
+///
+///   enum Color {
 //        RED=0,  
 //        GREEN=1,  
 //        BLUE=2  
 //    };
-//
+///
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -2971,14 +2971,14 @@ Self::Blue => "Blue",
             }
         }
 
-// Color2 is an XDR Enum defines as:
-//
-//   enum Color2 {
+/// Color2 is an XDR Enum defines as:
+///
+///   enum Color2 {
 //        RED2=RED,  
 //        GREEN2=1,  
 //        BLUE2=2  
 //    };
-//
+///
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -2686,14 +2686,14 @@ mod test {
     }
 }
 
-// UnionKey is an XDR Enum defines as:
-//
-//   enum UnionKey {
+/// UnionKey is an XDR Enum defines as:
+///
+///   enum UnionKey {
 //      ONE = 1,
 //      TWO = 2,
 //      OFFER = 3
 //    };
-//
+///
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -2792,18 +2792,18 @@ Self::Offer => "Offer",
             }
         }
 
-// Foo is an XDR Typedef defines as:
-//
-//   typedef int Foo;
-//
+/// Foo is an XDR Typedef defines as:
+///
+///   typedef int Foo;
+///
 pub type Foo = i32;
 
-// MyUnionOne is an XDR NestedStruct defines as:
-//
-//   struct {
+/// MyUnionOne is an XDR NestedStruct defines as:
+///
+///   struct {
 //                int someInt;
 //            }
-//
+///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
@@ -2832,13 +2832,13 @@ impl WriteXdr for MyUnionOne {
     }
 }
 
-// MyUnionTwo is an XDR NestedStruct defines as:
-//
-//   struct {
+/// MyUnionTwo is an XDR NestedStruct defines as:
+///
+///   struct {
 //                int someInt;
 //                Foo foo;
 //            }
-//
+///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
@@ -2870,9 +2870,9 @@ self.foo.write_xdr(w)?;
             }
         }
 
-// MyUnion is an XDR Union defines as:
-//
-//   union MyUnion switch (UnionKey type)
+/// MyUnion is an XDR Union defines as:
+///
+///   union MyUnion switch (UnionKey type)
 //    {
 //        case ONE:
 //            struct {
@@ -2888,7 +2888,7 @@ self.foo.write_xdr(w)?;
 //        case OFFER:
 //            void;
 //    };
-//
+///
 // union with discriminant UnionKey
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -2686,21 +2686,21 @@ mod test {
     }
 }
 
-// Arr is an XDR Typedef defines as:
-//
-//   typedef int Arr[2];
-//
+/// Arr is an XDR Typedef defines as:
+///
+///   typedef int Arr[2];
+///
 pub type Arr = [i32; 2];
 
-// HasOptions is an XDR Struct defines as:
-//
-//   struct HasOptions
+/// HasOptions is an XDR Struct defines as:
+///
+///   struct HasOptions
 //    {
 //      int* firstOption;
 //      int *secondOption;
 //      Arr *thirdOption;
 //    };
-//
+///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -2686,15 +2686,15 @@ mod test {
     }
 }
 
-// Int64 is an XDR Typedef defines as:
-//
-//   typedef hyper int64;
-//
+/// Int64 is an XDR Typedef defines as:
+///
+///   typedef hyper int64;
+///
 pub type Int64 = i64;
 
-// MyStruct is an XDR Struct defines as:
-//
-//   struct MyStruct
+/// MyStruct is an XDR Struct defines as:
+///
+///   struct MyStruct
 //    {
 //        int    someInt;
 //        int64  aBigInt;
@@ -2702,7 +2702,7 @@ pub type Int64 = i64;
 //        string someString<>;
 //        string maxString<100>;
 //    };
-//
+///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -2686,10 +2686,10 @@ mod test {
     }
 }
 
-// Uint512 is an XDR Typedef defines as:
-//
-//   typedef opaque uint512[64];
-//
+/// Uint512 is an XDR Typedef defines as:
+///
+///   typedef opaque uint512[64];
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
@@ -2799,10 +2799,10 @@ impl AsRef<[u8]> for Uint512 {
     }
 }
 
-// Uint513 is an XDR Typedef defines as:
-//
-//   typedef opaque uint513<64>;
-//
+/// Uint513 is an XDR Typedef defines as:
+///
+///   typedef opaque uint513<64>;
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
@@ -2898,10 +2898,10 @@ impl AsRef<[u8]> for Uint513 {
     }
 }
 
-// Uint514 is an XDR Typedef defines as:
-//
-//   typedef opaque uint514<>;
-//
+/// Uint514 is an XDR Typedef defines as:
+///
+///   typedef opaque uint514<>;
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
@@ -2997,10 +2997,10 @@ impl AsRef<[u8]> for Uint514 {
     }
 }
 
-// Str is an XDR Typedef defines as:
-//
-//   typedef string str<64>;
-//
+/// Str is an XDR Typedef defines as:
+///
+///   typedef string str<64>;
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
@@ -3096,10 +3096,10 @@ impl AsRef<[u8]> for Str {
     }
 }
 
-// Str2 is an XDR Typedef defines as:
-//
-//   typedef string str2<>;
-//
+/// Str2 is an XDR Typedef defines as:
+///
+///   typedef string str2<>;
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
@@ -3195,10 +3195,10 @@ impl AsRef<[u8]> for Str2 {
     }
 }
 
-// Hash is an XDR Typedef defines as:
-//
-//   typedef opaque Hash[32];
-//
+/// Hash is an XDR Typedef defines as:
+///
+///   typedef opaque Hash[32];
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
@@ -3308,10 +3308,10 @@ impl AsRef<[u8]> for Hash {
     }
 }
 
-// Hashes1 is an XDR Typedef defines as:
-//
-//   typedef Hash Hashes1[12];
-//
+/// Hashes1 is an XDR Typedef defines as:
+///
+///   typedef Hash Hashes1[12];
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
@@ -3394,10 +3394,10 @@ impl AsRef<[Hash]> for Hashes1 {
     }
 }
 
-// Hashes2 is an XDR Typedef defines as:
-//
-//   typedef Hash Hashes2<12>;
-//
+/// Hashes2 is an XDR Typedef defines as:
+///
+///   typedef Hash Hashes2<12>;
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
@@ -3493,10 +3493,10 @@ impl AsRef<[Hash]> for Hashes2 {
     }
 }
 
-// Hashes3 is an XDR Typedef defines as:
-//
-//   typedef Hash Hashes3<>;
-//
+/// Hashes3 is an XDR Typedef defines as:
+///
+///   typedef Hash Hashes3<>;
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
@@ -3592,10 +3592,10 @@ impl AsRef<[Hash]> for Hashes3 {
     }
 }
 
-// OptHash1 is an XDR Typedef defines as:
-//
-//   typedef Hash *optHash1;
-//
+/// OptHash1 is an XDR Typedef defines as:
+///
+///   typedef Hash *optHash1;
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
@@ -3641,10 +3641,10 @@ impl WriteXdr for OptHash1 {
     }
 }
 
-// OptHash2 is an XDR Typedef defines as:
-//
-//   typedef Hash* optHash2;
-//
+/// OptHash2 is an XDR Typedef defines as:
+///
+///   typedef Hash* optHash2;
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
@@ -3690,33 +3690,33 @@ impl WriteXdr for OptHash2 {
     }
 }
 
-// Int1 is an XDR Typedef defines as:
-//
-//   typedef int             int1;
-//
+/// Int1 is an XDR Typedef defines as:
+///
+///   typedef int             int1;
+///
 pub type Int1 = i32;
 
-// Int2 is an XDR Typedef defines as:
-//
-//   typedef hyper           int2;
-//
+/// Int2 is an XDR Typedef defines as:
+///
+///   typedef hyper           int2;
+///
 pub type Int2 = i64;
 
-// Int3 is an XDR Typedef defines as:
-//
-//   typedef unsigned int    int3;
-//
+/// Int3 is an XDR Typedef defines as:
+///
+///   typedef unsigned int    int3;
+///
 pub type Int3 = u32;
 
-// Int4 is an XDR Typedef defines as:
-//
-//   typedef unsigned hyper  int4;
-//
+/// Int4 is an XDR Typedef defines as:
+///
+///   typedef unsigned hyper  int4;
+///
 pub type Int4 = u64;
 
-// MyStruct is an XDR Struct defines as:
-//
-//   struct MyStruct
+/// MyStruct is an XDR Struct defines as:
+///
+///   struct MyStruct
 //    {
 //        uint512 field1;
 //        optHash1 field2;
@@ -3726,7 +3726,7 @@ pub type Int4 = u64;
 //        double field6;
 //        bool field7;
 //    };
-//
+///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
@@ -3773,13 +3773,13 @@ self.field7.write_xdr(w)?;
             }
         }
 
-// LotsOfMyStructs is an XDR Struct defines as:
-//
-//   struct LotsOfMyStructs
+/// LotsOfMyStructs is an XDR Struct defines as:
+///
+///   struct LotsOfMyStructs
 //    {
 //        MyStruct members<>;
 //    };
-//
+///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
@@ -3808,13 +3808,13 @@ impl WriteXdr for LotsOfMyStructs {
     }
 }
 
-// HasStuff is an XDR Struct defines as:
-//
-//   struct HasStuff
+/// HasStuff is an XDR Struct defines as:
+///
+///   struct HasStuff
 //    {
 //      LotsOfMyStructs data;
 //    };
-//
+///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
@@ -3843,14 +3843,14 @@ impl WriteXdr for HasStuff {
     }
 }
 
-// Color is an XDR Enum defines as:
-//
-//   enum Color {
+/// Color is an XDR Enum defines as:
+///
+///   enum Color {
 //      RED,
 //      BLUE = 5,
 //      GREEN
 //    };
-//
+///
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -3949,25 +3949,25 @@ Self::Green => "Green",
             }
         }
 
-// Foo is an XDR Const defines as:
-//
-//   const FOO = 1244;
-//
+/// Foo is an XDR Const defines as:
+///
+///   const FOO = 1244;
+///
 pub const FOO: u64 = 1244;
 
-// Bar is an XDR Const defines as:
-//
-//   const BAR = FOO;
-//
+/// Bar is an XDR Const defines as:
+///
+///   const BAR = FOO;
+///
 pub const BAR: u64 = FOO;
 
-// NesterNestedEnum is an XDR NestedEnum defines as:
-//
-//   enum {
+/// NesterNestedEnum is an XDR NestedEnum defines as:
+///
+///   enum {
 //        BLAH_1,
 //        BLAH_2
 //      }
-//
+///
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -4061,12 +4061,12 @@ Self::2 => "2",
             }
         }
 
-// NesterNestedStruct is an XDR NestedStruct defines as:
-//
-//   struct {
+/// NesterNestedStruct is an XDR NestedStruct defines as:
+///
+///   struct {
 //        int blah;
 //      }
-//
+///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
@@ -4095,15 +4095,15 @@ impl WriteXdr for NesterNestedStruct {
     }
 }
 
-// NesterNestedUnion is an XDR NestedUnion defines as:
-//
-//   union switch (Color color) {
+/// NesterNestedUnion is an XDR NestedUnion defines as:
+///
+///   union switch (Color color) {
 //        case RED:
 //          void;
 //        default:
 //          int blah2;
 //      }
-//
+///
 // union with discriminant Color
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -4194,9 +4194,9 @@ impl WriteXdr for NesterNestedUnion {
     }
 }
 
-// Nester is an XDR Struct defines as:
-//
-//   struct Nester
+/// Nester is an XDR Struct defines as:
+///
+///   struct Nester
 //    {
 //      enum {
 //        BLAH_1,
@@ -4216,7 +4216,7 @@ impl WriteXdr for NesterNestedUnion {
 //    
 //    
 //    };
-//
+///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -2686,25 +2686,25 @@ mod test {
     }
 }
 
-// SError is an XDR Typedef defines as:
-//
-//   typedef int Error;
-//
+/// SError is an XDR Typedef defines as:
+///
+///   typedef int Error;
+///
 pub type SError = i32;
 
-// Multi is an XDR Typedef defines as:
-//
-//   typedef int Multi;
-//
+/// Multi is an XDR Typedef defines as:
+///
+///   typedef int Multi;
+///
 pub type Multi = i32;
 
-// UnionKey is an XDR Enum defines as:
-//
-//   enum UnionKey {
+/// UnionKey is an XDR Enum defines as:
+///
+///   enum UnionKey {
 //      ERROR,
 //      MULTI
 //    };
-//
+///
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -2798,9 +2798,9 @@ Self::Multi => "Multi",
             }
         }
 
-// MyUnion is an XDR Union defines as:
-//
-//   union MyUnion switch (UnionKey type)
+/// MyUnion is an XDR Union defines as:
+///
+///   union MyUnion switch (UnionKey type)
 //    {
 //        case ERROR:
 //            Error error;
@@ -2809,7 +2809,7 @@ Self::Multi => "Multi",
 //    
 //    
 //    };
-//
+///
 // union with discriminant UnionKey
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -2907,9 +2907,9 @@ Self::Multi(v) => v.write_xdr(w)?,
             }
         }
 
-// IntUnion is an XDR Union defines as:
-//
-//   union IntUnion switch (int type)
+/// IntUnion is an XDR Union defines as:
+///
+///   union IntUnion switch (int type)
 //    {
 //        case 0:
 //            Error error;
@@ -2917,7 +2917,7 @@ Self::Multi(v) => v.write_xdr(w)?,
 //            Multi things<>;
 //    
 //    };
-//
+///
 // union with discriminant i32
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -3015,10 +3015,10 @@ Self::V1(v) => v.write_xdr(w)?,
             }
         }
 
-// IntUnion2 is an XDR Typedef defines as:
-//
-//   typedef IntUnion IntUnion2;
-//
+/// IntUnion2 is an XDR Typedef defines as:
+///
+///   typedef IntUnion IntUnion2;
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -2686,13 +2686,13 @@ mod test {
     }
 }
 
-// AccountFlags is an XDR Enum defines as:
-//
-//   enum AccountFlags
+/// AccountFlags is an XDR Enum defines as:
+///
+///   enum AccountFlags
 //    { // masks for each flag
 //        AUTH_REQUIRED_FLAG = 0x1
 //    };
-//
+///
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -2686,22 +2686,22 @@ mod test {
     }
 }
 
-// Foo is an XDR Const defines as:
-//
-//   const FOO = 1;
-//
+/// Foo is an XDR Const defines as:
+///
+///   const FOO = 1;
+///
 pub const FOO: u64 = 1;
 
-// TestArray is an XDR Typedef defines as:
-//
-//   typedef int TestArray[FOO];
-//
+/// TestArray is an XDR Typedef defines as:
+///
+///   typedef int TestArray[FOO];
+///
 pub type TestArray = [i32; Foo];
 
-// TestArray2 is an XDR Typedef defines as:
-//
-//   typedef int TestArray2<FOO>;
-//
+/// TestArray2 is an XDR Typedef defines as:
+///
+///   typedef int TestArray2<FOO>;
+///
 pub type TestArray2 = VecM::<i32, 1>;
 
         #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -2686,9 +2686,9 @@ mod test {
     }
 }
 
-// MessageType is an XDR Enum defines as:
-//
-//   enum MessageType
+/// MessageType is an XDR Enum defines as:
+///
+///   enum MessageType
 //    {
 //        ERROR_MSG,    
 //        HELLO,
@@ -2711,7 +2711,7 @@ mod test {
 //        FBA_QUORUMSET,    
 //        FBA_MESSAGE
 //    };
-//
+///
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -2865,14 +2865,14 @@ Self::FbaMessage => "FbaMessage",
             }
         }
 
-// Color is an XDR Enum defines as:
-//
-//   enum Color {
+/// Color is an XDR Enum defines as:
+///
+///   enum Color {
 //        RED=0,  
 //        GREEN=1,  
 //        BLUE=2  
 //    };
-//
+///
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -2971,14 +2971,14 @@ Self::Blue => "Blue",
             }
         }
 
-// Color2 is an XDR Enum defines as:
-//
-//   enum Color2 {
+/// Color2 is an XDR Enum defines as:
+///
+///   enum Color2 {
 //        RED2=RED,  
 //        GREEN2=1,  
 //        BLUE2=2  
 //    };
-//
+///
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -2686,14 +2686,14 @@ mod test {
     }
 }
 
-// UnionKey is an XDR Enum defines as:
-//
-//   enum UnionKey {
+/// UnionKey is an XDR Enum defines as:
+///
+///   enum UnionKey {
 //      ONE = 1,
 //      TWO = 2,
 //      OFFER = 3
 //    };
-//
+///
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -2792,18 +2792,18 @@ Self::Offer => "Offer",
             }
         }
 
-// Foo is an XDR Typedef defines as:
-//
-//   typedef int Foo;
-//
+/// Foo is an XDR Typedef defines as:
+///
+///   typedef int Foo;
+///
 pub type Foo = i32;
 
-// MyUnionOne is an XDR NestedStruct defines as:
-//
-//   struct {
+/// MyUnionOne is an XDR NestedStruct defines as:
+///
+///   struct {
 //                int someInt;
 //            }
-//
+///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
@@ -2832,13 +2832,13 @@ impl WriteXdr for MyUnionOne {
     }
 }
 
-// MyUnionTwo is an XDR NestedStruct defines as:
-//
-//   struct {
+/// MyUnionTwo is an XDR NestedStruct defines as:
+///
+///   struct {
 //                int someInt;
 //                Foo foo;
 //            }
-//
+///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
@@ -2870,9 +2870,9 @@ self.foo.write_xdr(w)?;
             }
         }
 
-// MyUnion is an XDR Union defines as:
-//
-//   union MyUnion switch (UnionKey type)
+/// MyUnion is an XDR Union defines as:
+///
+///   union MyUnion switch (UnionKey type)
 //    {
 //        case ONE:
 //            struct {
@@ -2888,7 +2888,7 @@ self.foo.write_xdr(w)?;
 //        case OFFER:
 //            void;
 //    };
-//
+///
 // union with discriminant UnionKey
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -2686,21 +2686,21 @@ mod test {
     }
 }
 
-// Arr is an XDR Typedef defines as:
-//
-//   typedef int Arr[2];
-//
+/// Arr is an XDR Typedef defines as:
+///
+///   typedef int Arr[2];
+///
 pub type Arr = [i32; 2];
 
-// HasOptions is an XDR Struct defines as:
-//
-//   struct HasOptions
+/// HasOptions is an XDR Struct defines as:
+///
+///   struct HasOptions
 //    {
 //      int* firstOption;
 //      int *secondOption;
 //      Arr *thirdOption;
 //    };
-//
+///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -2686,15 +2686,15 @@ mod test {
     }
 }
 
-// Int64 is an XDR Typedef defines as:
-//
-//   typedef hyper int64;
-//
+/// Int64 is an XDR Typedef defines as:
+///
+///   typedef hyper int64;
+///
 pub type Int64 = i64;
 
-// MyStruct is an XDR Struct defines as:
-//
-//   struct MyStruct
+/// MyStruct is an XDR Struct defines as:
+///
+///   struct MyStruct
 //    {
 //        int    someInt;
 //        int64  aBigInt;
@@ -2702,7 +2702,7 @@ pub type Int64 = i64;
 //        string someString<>;
 //        string maxString<100>;
 //    };
-//
+///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -2686,10 +2686,10 @@ mod test {
     }
 }
 
-// Uint512 is an XDR Typedef defines as:
-//
-//   typedef opaque uint512[64];
-//
+/// Uint512 is an XDR Typedef defines as:
+///
+///   typedef opaque uint512[64];
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
@@ -2799,10 +2799,10 @@ impl AsRef<[u8]> for Uint512 {
     }
 }
 
-// Uint513 is an XDR Typedef defines as:
-//
-//   typedef opaque uint513<64>;
-//
+/// Uint513 is an XDR Typedef defines as:
+///
+///   typedef opaque uint513<64>;
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
@@ -2898,10 +2898,10 @@ impl AsRef<[u8]> for Uint513 {
     }
 }
 
-// Uint514 is an XDR Typedef defines as:
-//
-//   typedef opaque uint514<>;
-//
+/// Uint514 is an XDR Typedef defines as:
+///
+///   typedef opaque uint514<>;
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
@@ -2997,10 +2997,10 @@ impl AsRef<[u8]> for Uint514 {
     }
 }
 
-// Str is an XDR Typedef defines as:
-//
-//   typedef string str<64>;
-//
+/// Str is an XDR Typedef defines as:
+///
+///   typedef string str<64>;
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
@@ -3096,10 +3096,10 @@ impl AsRef<[u8]> for Str {
     }
 }
 
-// Str2 is an XDR Typedef defines as:
-//
-//   typedef string str2<>;
-//
+/// Str2 is an XDR Typedef defines as:
+///
+///   typedef string str2<>;
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
@@ -3195,10 +3195,10 @@ impl AsRef<[u8]> for Str2 {
     }
 }
 
-// Hash is an XDR Typedef defines as:
-//
-//   typedef opaque Hash[32];
-//
+/// Hash is an XDR Typedef defines as:
+///
+///   typedef opaque Hash[32];
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
@@ -3308,10 +3308,10 @@ impl AsRef<[u8]> for Hash {
     }
 }
 
-// Hashes1 is an XDR Typedef defines as:
-//
-//   typedef Hash Hashes1[12];
-//
+/// Hashes1 is an XDR Typedef defines as:
+///
+///   typedef Hash Hashes1[12];
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
@@ -3394,10 +3394,10 @@ impl AsRef<[Hash]> for Hashes1 {
     }
 }
 
-// Hashes2 is an XDR Typedef defines as:
-//
-//   typedef Hash Hashes2<12>;
-//
+/// Hashes2 is an XDR Typedef defines as:
+///
+///   typedef Hash Hashes2<12>;
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
@@ -3493,10 +3493,10 @@ impl AsRef<[Hash]> for Hashes2 {
     }
 }
 
-// Hashes3 is an XDR Typedef defines as:
-//
-//   typedef Hash Hashes3<>;
-//
+/// Hashes3 is an XDR Typedef defines as:
+///
+///   typedef Hash Hashes3<>;
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
@@ -3592,10 +3592,10 @@ impl AsRef<[Hash]> for Hashes3 {
     }
 }
 
-// OptHash1 is an XDR Typedef defines as:
-//
-//   typedef Hash *optHash1;
-//
+/// OptHash1 is an XDR Typedef defines as:
+///
+///   typedef Hash *optHash1;
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
@@ -3641,10 +3641,10 @@ impl WriteXdr for OptHash1 {
     }
 }
 
-// OptHash2 is an XDR Typedef defines as:
-//
-//   typedef Hash* optHash2;
-//
+/// OptHash2 is an XDR Typedef defines as:
+///
+///   typedef Hash* optHash2;
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
@@ -3690,33 +3690,33 @@ impl WriteXdr for OptHash2 {
     }
 }
 
-// Int1 is an XDR Typedef defines as:
-//
-//   typedef int             int1;
-//
+/// Int1 is an XDR Typedef defines as:
+///
+///   typedef int             int1;
+///
 pub type Int1 = i32;
 
-// Int2 is an XDR Typedef defines as:
-//
-//   typedef hyper           int2;
-//
+/// Int2 is an XDR Typedef defines as:
+///
+///   typedef hyper           int2;
+///
 pub type Int2 = i64;
 
-// Int3 is an XDR Typedef defines as:
-//
-//   typedef unsigned int    int3;
-//
+/// Int3 is an XDR Typedef defines as:
+///
+///   typedef unsigned int    int3;
+///
 pub type Int3 = u32;
 
-// Int4 is an XDR Typedef defines as:
-//
-//   typedef unsigned hyper  int4;
-//
+/// Int4 is an XDR Typedef defines as:
+///
+///   typedef unsigned hyper  int4;
+///
 pub type Int4 = u64;
 
-// MyStruct is an XDR Struct defines as:
-//
-//   struct MyStruct
+/// MyStruct is an XDR Struct defines as:
+///
+///   struct MyStruct
 //    {
 //        uint512 field1;
 //        optHash1 field2;
@@ -3726,7 +3726,7 @@ pub type Int4 = u64;
 //        double field6;
 //        bool field7;
 //    };
-//
+///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
@@ -3773,13 +3773,13 @@ self.field7.write_xdr(w)?;
             }
         }
 
-// LotsOfMyStructs is an XDR Struct defines as:
-//
-//   struct LotsOfMyStructs
+/// LotsOfMyStructs is an XDR Struct defines as:
+///
+///   struct LotsOfMyStructs
 //    {
 //        MyStruct members<>;
 //    };
-//
+///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
@@ -3808,13 +3808,13 @@ impl WriteXdr for LotsOfMyStructs {
     }
 }
 
-// HasStuff is an XDR Struct defines as:
-//
-//   struct HasStuff
+/// HasStuff is an XDR Struct defines as:
+///
+///   struct HasStuff
 //    {
 //      LotsOfMyStructs data;
 //    };
-//
+///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
@@ -3843,14 +3843,14 @@ impl WriteXdr for HasStuff {
     }
 }
 
-// Color is an XDR Enum defines as:
-//
-//   enum Color {
+/// Color is an XDR Enum defines as:
+///
+///   enum Color {
 //      RED,
 //      BLUE = 5,
 //      GREEN
 //    };
-//
+///
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -3949,25 +3949,25 @@ Self::Green => "Green",
             }
         }
 
-// Foo is an XDR Const defines as:
-//
-//   const FOO = 1244;
-//
+/// Foo is an XDR Const defines as:
+///
+///   const FOO = 1244;
+///
 pub const FOO: u64 = 1244;
 
-// Bar is an XDR Const defines as:
-//
-//   const BAR = FOO;
-//
+/// Bar is an XDR Const defines as:
+///
+///   const BAR = FOO;
+///
 pub const BAR: u64 = FOO;
 
-// NesterNestedEnum is an XDR NestedEnum defines as:
-//
-//   enum {
+/// NesterNestedEnum is an XDR NestedEnum defines as:
+///
+///   enum {
 //        BLAH_1,
 //        BLAH_2
 //      }
-//
+///
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -4061,12 +4061,12 @@ Self::2 => "2",
             }
         }
 
-// NesterNestedStruct is an XDR NestedStruct defines as:
-//
-//   struct {
+/// NesterNestedStruct is an XDR NestedStruct defines as:
+///
+///   struct {
 //        int blah;
 //      }
-//
+///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
@@ -4095,15 +4095,15 @@ impl WriteXdr for NesterNestedStruct {
     }
 }
 
-// NesterNestedUnion is an XDR NestedUnion defines as:
-//
-//   union switch (Color color) {
+/// NesterNestedUnion is an XDR NestedUnion defines as:
+///
+///   union switch (Color color) {
 //        case RED:
 //          void;
 //        default:
 //          int blah2;
 //      }
-//
+///
 // union with discriminant Color
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -4194,9 +4194,9 @@ impl WriteXdr for NesterNestedUnion {
     }
 }
 
-// Nester is an XDR Struct defines as:
-//
-//   struct Nester
+/// Nester is an XDR Struct defines as:
+///
+///   struct Nester
 //    {
 //      enum {
 //        BLAH_1,
@@ -4216,7 +4216,7 @@ impl WriteXdr for NesterNestedUnion {
 //    
 //    
 //    };
-//
+///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -2686,25 +2686,25 @@ mod test {
     }
 }
 
-// SError is an XDR Typedef defines as:
-//
-//   typedef int Error;
-//
+/// SError is an XDR Typedef defines as:
+///
+///   typedef int Error;
+///
 pub type SError = i32;
 
-// Multi is an XDR Typedef defines as:
-//
-//   typedef int Multi;
-//
+/// Multi is an XDR Typedef defines as:
+///
+///   typedef int Multi;
+///
 pub type Multi = i32;
 
-// UnionKey is an XDR Enum defines as:
-//
-//   enum UnionKey {
+/// UnionKey is an XDR Enum defines as:
+///
+///   enum UnionKey {
 //      ERROR,
 //      MULTI
 //    };
-//
+///
 // enum
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -2798,9 +2798,9 @@ Self::Multi => "Multi",
             }
         }
 
-// MyUnion is an XDR Union defines as:
-//
-//   union MyUnion switch (UnionKey type)
+/// MyUnion is an XDR Union defines as:
+///
+///   union MyUnion switch (UnionKey type)
 //    {
 //        case ERROR:
 //            Error error;
@@ -2809,7 +2809,7 @@ Self::Multi => "Multi",
 //    
 //    
 //    };
-//
+///
 // union with discriminant UnionKey
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -2907,9 +2907,9 @@ Self::Multi(v) => v.write_xdr(w)?,
             }
         }
 
-// IntUnion is an XDR Union defines as:
-//
-//   union IntUnion switch (int type)
+/// IntUnion is an XDR Union defines as:
+///
+///   union IntUnion switch (int type)
 //    {
 //        case 0:
 //            Error error;
@@ -2917,7 +2917,7 @@ Self::Multi(v) => v.write_xdr(w)?,
 //            Multi things<>;
 //    
 //    };
-//
+///
 // union with discriminant i32
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
@@ -3015,10 +3015,10 @@ Self::V1(v) => v.write_xdr(w)?,
             }
         }
 
-// IntUnion2 is an XDR Typedef defines as:
-//
-//   typedef IntUnion IntUnion2;
-//
+/// IntUnion2 is an XDR Typedef defines as:
+///
+///   typedef IntUnion IntUnion2;
+///
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]


### PR DESCRIPTION
### What
Render doc comments on types in the Rust generated code.

### Why
The generator generates regular comments that don't show up in the docs on docs.rs.

It should generate doc comments so that the comments display.