### PR TITLE
Java: show the XDR source code in the javadoc

### DIFF
--- a/lib/xdrgen/generators/java.rb
+++ b/lib/xdrgen/generators/java.rb
@@ -138,6 +138,7 @@ module Xdrgen
       def render_nested_definitions(defn, out, post_name="implements XdrElement")
         return unless defn.respond_to? :nested_definitions
         defn.nested_definitions.each{|ndefn|
+          render_source_comment out, ndefn
           case ndefn
           when AST::Definitions::Struct ;
             name = name ndefn
@@ -699,17 +700,12 @@ module Xdrgen
       def render_source_comment(out, defn)
         return if defn.is_a?(AST::Definitions::Namespace)
 
-        out.puts <<-EOS.strip_heredoc
-        // === xdr source ============================================================
-
-        EOS
-
-        out.puts "//  " + defn.text_value.split("\n").join("\n//  ")
-
-        out.puts <<-EOS.strip_heredoc
-
-        //  ===========================================================================
-        EOS
+        out.puts "/**"
+        out.puts " * #{name defn}'s original definition in the XDR file is:"
+        out.puts " * <pre>"
+        out.puts " * " + escape_html(defn.text_value).split("\n").join("\n * ")
+        out.puts " * </pre>"
+        out.puts " */"
       end
 
       def render_base64(return_type, out)
@@ -960,6 +956,14 @@ module Xdrgen
 
       def name_string(name)
         name.camelize
+      end
+
+      def escape_html(value)
+        value.to_s
+             .gsub('&', '&amp;')
+             .gsub('<', '&lt;')
+             .gsub('>', '&gt;')
+             .gsub('*', '&#42;') # to avoid encountering`*/`
       end
     end
   end

--- a/spec/output/generator_spec_java/block_comments.x/AccountFlags.java
+++ b/spec/output/generator_spec_java/block_comments.x/AccountFlags.java
@@ -10,14 +10,15 @@ import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
-// === xdr source ============================================================
-
-//  enum AccountFlags
-//  { // masks for each flag
-//      AUTH_REQUIRED_FLAG = 0x1
-//  };
-
-//  ===========================================================================
+/**
+ * AccountFlags's original definition in the XDR file is:
+ * <pre>
+ * enum AccountFlags
+ * { // masks for each flag
+ *     AUTH_REQUIRED_FLAG = 0x1
+ * };
+ * </pre>
+ */
 public enum AccountFlags implements XdrElement {
   AUTH_REQUIRED_FLAG(1),
   ;

--- a/spec/output/generator_spec_java/const.x/TestArray.java
+++ b/spec/output/generator_spec_java/const.x/TestArray.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 
-// === xdr source ============================================================
-
-//  typedef int TestArray[FOO];
-
-//  ===========================================================================
+/**
+ * TestArray's original definition in the XDR file is:
+ * <pre>
+ * typedef int TestArray[FOO];
+ * </pre>
+ */
 public class TestArray implements XdrElement {
   private Integer[] TestArray;
 

--- a/spec/output/generator_spec_java/const.x/TestArray2.java
+++ b/spec/output/generator_spec_java/const.x/TestArray2.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 
-// === xdr source ============================================================
-
-//  typedef int TestArray2<FOO>;
-
-//  ===========================================================================
+/**
+ * TestArray2's original definition in the XDR file is:
+ * <pre>
+ * typedef int TestArray2&lt;FOO&gt;;
+ * </pre>
+ */
 public class TestArray2 implements XdrElement {
   private Integer[] TestArray2;
 

--- a/spec/output/generator_spec_java/enum.x/Color.java
+++ b/spec/output/generator_spec_java/enum.x/Color.java
@@ -10,15 +10,16 @@ import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
-// === xdr source ============================================================
-
-//  enum Color {
-//      RED=0,  
-//      GREEN=1,  
-//      BLUE=2  
-//  };
-
-//  ===========================================================================
+/**
+ * Color's original definition in the XDR file is:
+ * <pre>
+ * enum Color {
+ *     RED=0,  
+ *     GREEN=1,  
+ *     BLUE=2  
+ * };
+ * </pre>
+ */
 public enum Color implements XdrElement {
   RED(0),
   GREEN(1),

--- a/spec/output/generator_spec_java/enum.x/Color2.java
+++ b/spec/output/generator_spec_java/enum.x/Color2.java
@@ -10,15 +10,16 @@ import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
-// === xdr source ============================================================
-
-//  enum Color2 {
-//      RED2=RED,  
-//      GREEN2=1,  
-//      BLUE2=2  
-//  };
-
-//  ===========================================================================
+/**
+ * Color2's original definition in the XDR file is:
+ * <pre>
+ * enum Color2 {
+ *     RED2=RED,  
+ *     GREEN2=1,  
+ *     BLUE2=2  
+ * };
+ * </pre>
+ */
 public enum Color2 implements XdrElement {
   RED2(0),
   GREEN2(1),

--- a/spec/output/generator_spec_java/enum.x/MessageType.java
+++ b/spec/output/generator_spec_java/enum.x/MessageType.java
@@ -10,33 +10,34 @@ import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
-// === xdr source ============================================================
-
-//  enum MessageType
-//  {
-//      ERROR_MSG,    
-//      HELLO,
-//      DONT_HAVE,
-//  
-//      GET_PEERS,   // gets a list of peers this guy knows about        
-//      PEERS,
-//  
-//      GET_TX_SET,  // gets a particular txset by hash        
-//      TX_SET,    
-//  
-//      GET_VALIDATIONS, // gets validations for a given ledger hash        
-//      VALIDATIONS,    
-//  
-//      TRANSACTION, //pass on a tx you have heard about        
-//      JSON_TRANSACTION,
-//  
-//      // FBA        
-//      GET_FBA_QUORUMSET,        
-//      FBA_QUORUMSET,    
-//      FBA_MESSAGE
-//  };
-
-//  ===========================================================================
+/**
+ * MessageType's original definition in the XDR file is:
+ * <pre>
+ * enum MessageType
+ * {
+ *     ERROR_MSG,    
+ *     HELLO,
+ *     DONT_HAVE,
+ * 
+ *     GET_PEERS,   // gets a list of peers this guy knows about        
+ *     PEERS,
+ * 
+ *     GET_TX_SET,  // gets a particular txset by hash        
+ *     TX_SET,    
+ * 
+ *     GET_VALIDATIONS, // gets validations for a given ledger hash        
+ *     VALIDATIONS,    
+ * 
+ *     TRANSACTION, //pass on a tx you have heard about        
+ *     JSON_TRANSACTION,
+ * 
+ *     // FBA        
+ *     GET_FBA_QUORUMSET,        
+ *     FBA_QUORUMSET,    
+ *     FBA_MESSAGE
+ * };
+ * </pre>
+ */
 public enum MessageType implements XdrElement {
   ERROR_MSG(0),
   HELLO(1),

--- a/spec/output/generator_spec_java/nesting.x/Foo.java
+++ b/spec/output/generator_spec_java/nesting.x/Foo.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 
-// === xdr source ============================================================
-
-//  typedef int Foo;
-
-//  ===========================================================================
+/**
+ * Foo's original definition in the XDR file is:
+ * <pre>
+ * typedef int Foo;
+ * </pre>
+ */
 public class Foo implements XdrElement {
   private Integer Foo;
 

--- a/spec/output/generator_spec_java/nesting.x/MyUnion.java
+++ b/spec/output/generator_spec_java/nesting.x/MyUnion.java
@@ -11,26 +11,27 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 
-// === xdr source ============================================================
-
-//  union MyUnion switch (UnionKey type)
-//  {
-//      case ONE:
-//          struct {
-//              int someInt;
-//          } one;
-//  
-//      case TWO:
-//          struct {
-//              int someInt;
-//              Foo foo;
-//          } two;
-//  
-//      case OFFER:
-//          void;
-//  };
-
-//  ===========================================================================
+/**
+ * MyUnion's original definition in the XDR file is:
+ * <pre>
+ * union MyUnion switch (UnionKey type)
+ * {
+ *     case ONE:
+ *         struct {
+ *             int someInt;
+ *         } one;
+ * 
+ *     case TWO:
+ *         struct {
+ *             int someInt;
+ *             Foo foo;
+ *         } two;
+ * 
+ *     case OFFER:
+ *         void;
+ * };
+ * </pre>
+ */
 public class MyUnion implements XdrElement {
   public MyUnion () {}
   UnionKey type;
@@ -155,6 +156,14 @@ public class MyUnion implements XdrElement {
     return decode(xdrDataInputStream);
   }
 
+  /**
+   * MyUnionOne's original definition in the XDR file is:
+   * <pre>
+   * struct {
+   *             int someInt;
+   *         }
+   * </pre>
+   */
   public static class MyUnionOne implements XdrElement {
     public MyUnionOne () {}
     private Integer someInt;
@@ -228,6 +237,15 @@ public class MyUnion implements XdrElement {
     }
 
   }
+  /**
+   * MyUnionTwo's original definition in the XDR file is:
+   * <pre>
+   * struct {
+   *             int someInt;
+   *             Foo foo;
+   *         }
+   * </pre>
+   */
   public static class MyUnionTwo implements XdrElement {
     public MyUnionTwo () {}
     private Integer someInt;

--- a/spec/output/generator_spec_java/nesting.x/UnionKey.java
+++ b/spec/output/generator_spec_java/nesting.x/UnionKey.java
@@ -10,15 +10,16 @@ import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
-// === xdr source ============================================================
-
-//  enum UnionKey {
-//    ONE = 1,
-//    TWO = 2,
-//    OFFER = 3
-//  };
-
-//  ===========================================================================
+/**
+ * UnionKey's original definition in the XDR file is:
+ * <pre>
+ * enum UnionKey {
+ *   ONE = 1,
+ *   TWO = 2,
+ *   OFFER = 3
+ * };
+ * </pre>
+ */
 public enum UnionKey implements XdrElement {
   ONE(1),
   TWO(2),

--- a/spec/output/generator_spec_java/optional.x/Arr.java
+++ b/spec/output/generator_spec_java/optional.x/Arr.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 
-// === xdr source ============================================================
-
-//  typedef int Arr[2];
-
-//  ===========================================================================
+/**
+ * Arr's original definition in the XDR file is:
+ * <pre>
+ * typedef int Arr[2];
+ * </pre>
+ */
 public class Arr implements XdrElement {
   private Integer[] Arr;
 

--- a/spec/output/generator_spec_java/optional.x/HasOptions.java
+++ b/spec/output/generator_spec_java/optional.x/HasOptions.java
@@ -11,16 +11,17 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 
-// === xdr source ============================================================
-
-//  struct HasOptions
-//  {
-//    int* firstOption;
-//    int *secondOption;
-//    Arr *thirdOption;
-//  };
-
-//  ===========================================================================
+/**
+ * HasOptions's original definition in the XDR file is:
+ * <pre>
+ * struct HasOptions
+ * {
+ *   int&#42; firstOption;
+ *   int &#42;secondOption;
+ *   Arr &#42;thirdOption;
+ * };
+ * </pre>
+ */
 public class HasOptions implements XdrElement {
   public HasOptions () {}
   private Integer firstOption;

--- a/spec/output/generator_spec_java/struct.x/Int64.java
+++ b/spec/output/generator_spec_java/struct.x/Int64.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 
-// === xdr source ============================================================
-
-//  typedef hyper int64;
-
-//  ===========================================================================
+/**
+ * Int64's original definition in the XDR file is:
+ * <pre>
+ * typedef hyper int64;
+ * </pre>
+ */
 public class Int64 implements XdrElement {
   private Long int64;
 

--- a/spec/output/generator_spec_java/struct.x/MyStruct.java
+++ b/spec/output/generator_spec_java/struct.x/MyStruct.java
@@ -12,18 +12,19 @@ import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 import java.util.Arrays;
 
-// === xdr source ============================================================
-
-//  struct MyStruct
-//  {
-//      int    someInt;
-//      int64  aBigInt;
-//      opaque someOpaque[10];
-//      string someString<>;
-//      string maxString<100>;
-//  };
-
-//  ===========================================================================
+/**
+ * MyStruct's original definition in the XDR file is:
+ * <pre>
+ * struct MyStruct
+ * {
+ *     int    someInt;
+ *     int64  aBigInt;
+ *     opaque someOpaque[10];
+ *     string someString&lt;&gt;;
+ *     string maxString&lt;100&gt;;
+ * };
+ * </pre>
+ */
 public class MyStruct implements XdrElement {
   public MyStruct () {}
   private Integer someInt;

--- a/spec/output/generator_spec_java/test.x/Color.java
+++ b/spec/output/generator_spec_java/test.x/Color.java
@@ -10,15 +10,16 @@ import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
-// === xdr source ============================================================
-
-//  enum Color {
-//    RED,
-//    BLUE = 5,
-//    GREEN
-//  };
-
-//  ===========================================================================
+/**
+ * Color's original definition in the XDR file is:
+ * <pre>
+ * enum Color {
+ *   RED,
+ *   BLUE = 5,
+ *   GREEN
+ * };
+ * </pre>
+ */
 public enum Color implements XdrElement {
   RED(0),
   BLUE(5),

--- a/spec/output/generator_spec_java/test.x/HasStuff.java
+++ b/spec/output/generator_spec_java/test.x/HasStuff.java
@@ -11,14 +11,15 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 
-// === xdr source ============================================================
-
-//  struct HasStuff
-//  {
-//    LotsOfMyStructs data;
-//  };
-
-//  ===========================================================================
+/**
+ * HasStuff's original definition in the XDR file is:
+ * <pre>
+ * struct HasStuff
+ * {
+ *   LotsOfMyStructs data;
+ * };
+ * </pre>
+ */
 public class HasStuff implements XdrElement {
   public HasStuff () {}
   private LotsOfMyStructs data;

--- a/spec/output/generator_spec_java/test.x/Hash.java
+++ b/spec/output/generator_spec_java/test.x/Hash.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 
-// === xdr source ============================================================
-
-//  typedef opaque Hash[32];
-
-//  ===========================================================================
+/**
+ * Hash's original definition in the XDR file is:
+ * <pre>
+ * typedef opaque Hash[32];
+ * </pre>
+ */
 public class Hash implements XdrElement {
   private byte[] Hash;
 

--- a/spec/output/generator_spec_java/test.x/Hashes1.java
+++ b/spec/output/generator_spec_java/test.x/Hashes1.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 
-// === xdr source ============================================================
-
-//  typedef Hash Hashes1[12];
-
-//  ===========================================================================
+/**
+ * Hashes1's original definition in the XDR file is:
+ * <pre>
+ * typedef Hash Hashes1[12];
+ * </pre>
+ */
 public class Hashes1 implements XdrElement {
   private Hash[] Hashes1;
 

--- a/spec/output/generator_spec_java/test.x/Hashes2.java
+++ b/spec/output/generator_spec_java/test.x/Hashes2.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 
-// === xdr source ============================================================
-
-//  typedef Hash Hashes2<12>;
-
-//  ===========================================================================
+/**
+ * Hashes2's original definition in the XDR file is:
+ * <pre>
+ * typedef Hash Hashes2&lt;12&gt;;
+ * </pre>
+ */
 public class Hashes2 implements XdrElement {
   private Hash[] Hashes2;
 

--- a/spec/output/generator_spec_java/test.x/Hashes3.java
+++ b/spec/output/generator_spec_java/test.x/Hashes3.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 
-// === xdr source ============================================================
-
-//  typedef Hash Hashes3<>;
-
-//  ===========================================================================
+/**
+ * Hashes3's original definition in the XDR file is:
+ * <pre>
+ * typedef Hash Hashes3&lt;&gt;;
+ * </pre>
+ */
 public class Hashes3 implements XdrElement {
   private Hash[] Hashes3;
 

--- a/spec/output/generator_spec_java/test.x/Int1.java
+++ b/spec/output/generator_spec_java/test.x/Int1.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 
-// === xdr source ============================================================
-
-//  typedef int             int1;
-
-//  ===========================================================================
+/**
+ * Int1's original definition in the XDR file is:
+ * <pre>
+ * typedef int             int1;
+ * </pre>
+ */
 public class Int1 implements XdrElement {
   private Integer int1;
 

--- a/spec/output/generator_spec_java/test.x/Int2.java
+++ b/spec/output/generator_spec_java/test.x/Int2.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 
-// === xdr source ============================================================
-
-//  typedef hyper           int2;
-
-//  ===========================================================================
+/**
+ * Int2's original definition in the XDR file is:
+ * <pre>
+ * typedef hyper           int2;
+ * </pre>
+ */
 public class Int2 implements XdrElement {
   private Long int2;
 

--- a/spec/output/generator_spec_java/test.x/Int3.java
+++ b/spec/output/generator_spec_java/test.x/Int3.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 
-// === xdr source ============================================================
-
-//  typedef unsigned int    int3;
-
-//  ===========================================================================
+/**
+ * Int3's original definition in the XDR file is:
+ * <pre>
+ * typedef unsigned int    int3;
+ * </pre>
+ */
 public class Int3 implements XdrElement {
   private XdrUnsignedInteger int3;
 

--- a/spec/output/generator_spec_java/test.x/Int4.java
+++ b/spec/output/generator_spec_java/test.x/Int4.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 
-// === xdr source ============================================================
-
-//  typedef unsigned hyper  int4;
-
-//  ===========================================================================
+/**
+ * Int4's original definition in the XDR file is:
+ * <pre>
+ * typedef unsigned hyper  int4;
+ * </pre>
+ */
 public class Int4 implements XdrElement {
   private XdrUnsignedHyperInteger int4;
 

--- a/spec/output/generator_spec_java/test.x/LotsOfMyStructs.java
+++ b/spec/output/generator_spec_java/test.x/LotsOfMyStructs.java
@@ -11,14 +11,15 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 
-// === xdr source ============================================================
-
-//  struct LotsOfMyStructs
-//  {
-//      MyStruct members<>;
-//  };
-
-//  ===========================================================================
+/**
+ * LotsOfMyStructs's original definition in the XDR file is:
+ * <pre>
+ * struct LotsOfMyStructs
+ * {
+ *     MyStruct members&lt;&gt;;
+ * };
+ * </pre>
+ */
 public class LotsOfMyStructs implements XdrElement {
   public LotsOfMyStructs () {}
   private MyStruct[] members;

--- a/spec/output/generator_spec_java/test.x/MyStruct.java
+++ b/spec/output/generator_spec_java/test.x/MyStruct.java
@@ -11,20 +11,21 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 
-// === xdr source ============================================================
-
-//  struct MyStruct
-//  {
-//      uint512 field1;
-//      optHash1 field2;
-//      int1 field3;
-//      unsigned int field4;
-//      float field5;
-//      double field6;
-//      bool field7;
-//  };
-
-//  ===========================================================================
+/**
+ * MyStruct's original definition in the XDR file is:
+ * <pre>
+ * struct MyStruct
+ * {
+ *     uint512 field1;
+ *     optHash1 field2;
+ *     int1 field3;
+ *     unsigned int field4;
+ *     float field5;
+ *     double field6;
+ *     bool field7;
+ * };
+ * </pre>
+ */
 public class MyStruct implements XdrElement {
   public MyStruct () {}
   private Uint512 field1;

--- a/spec/output/generator_spec_java/test.x/Nester.java
+++ b/spec/output/generator_spec_java/test.x/Nester.java
@@ -11,30 +11,31 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 
-// === xdr source ============================================================
-
-//  struct Nester
-//  {
-//    enum {
-//      BLAH_1,
-//      BLAH_2
-//    } nestedEnum;
-//  
-//    struct {
-//      int blah;
-//    } nestedStruct;
-//  
-//    union switch (Color color) {
-//      case RED:
-//        void;
-//      default:
-//        int blah2;
-//    } nestedUnion;
-//  
-//  
-//  };
-
-//  ===========================================================================
+/**
+ * Nester's original definition in the XDR file is:
+ * <pre>
+ * struct Nester
+ * {
+ *   enum {
+ *     BLAH_1,
+ *     BLAH_2
+ *   } nestedEnum;
+ * 
+ *   struct {
+ *     int blah;
+ *   } nestedStruct;
+ * 
+ *   union switch (Color color) {
+ *     case RED:
+ *       void;
+ *     default:
+ *       int blah2;
+ *   } nestedUnion;
+ * 
+ * 
+ * };
+ * </pre>
+ */
 public class Nester implements XdrElement {
   public Nester () {}
   private NesterNestedEnum nestedEnum;
@@ -139,6 +140,15 @@ public class Nester implements XdrElement {
     }
   }
 
+  /**
+   * NesterNestedEnum's original definition in the XDR file is:
+   * <pre>
+   * enum {
+   *     BLAH_1,
+   *     BLAH_2
+   *   }
+   * </pre>
+   */
   public static enum NesterNestedEnum implements XdrElement {
     BLAH_1(0),
     BLAH_2(1),
@@ -195,6 +205,14 @@ public class Nester implements XdrElement {
     }
 
   }
+  /**
+   * NesterNestedStruct's original definition in the XDR file is:
+   * <pre>
+   * struct {
+   *     int blah;
+   *   }
+   * </pre>
+   */
   public static class NesterNestedStruct implements XdrElement {
     public NesterNestedStruct () {}
     private Integer blah;
@@ -268,6 +286,17 @@ public class Nester implements XdrElement {
     }
 
   }
+  /**
+   * NesterNestedUnion's original definition in the XDR file is:
+   * <pre>
+   * union switch (Color color) {
+   *     case RED:
+   *       void;
+   *     default:
+   *       int blah2;
+   *   }
+   * </pre>
+   */
   public static class NesterNestedUnion implements XdrElement {
     public NesterNestedUnion () {}
     Color color;

--- a/spec/output/generator_spec_java/test.x/OptHash1.java
+++ b/spec/output/generator_spec_java/test.x/OptHash1.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 
-// === xdr source ============================================================
-
-//  typedef Hash *optHash1;
-
-//  ===========================================================================
+/**
+ * OptHash1's original definition in the XDR file is:
+ * <pre>
+ * typedef Hash &#42;optHash1;
+ * </pre>
+ */
 public class OptHash1 implements XdrElement {
   private Hash optHash1;
 

--- a/spec/output/generator_spec_java/test.x/OptHash2.java
+++ b/spec/output/generator_spec_java/test.x/OptHash2.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 
-// === xdr source ============================================================
-
-//  typedef Hash* optHash2;
-
-//  ===========================================================================
+/**
+ * OptHash2's original definition in the XDR file is:
+ * <pre>
+ * typedef Hash&#42; optHash2;
+ * </pre>
+ */
 public class OptHash2 implements XdrElement {
   private Hash optHash2;
 

--- a/spec/output/generator_spec_java/test.x/Str.java
+++ b/spec/output/generator_spec_java/test.x/Str.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 
-// === xdr source ============================================================
-
-//  typedef string str<64>;
-
-//  ===========================================================================
+/**
+ * Str's original definition in the XDR file is:
+ * <pre>
+ * typedef string str&lt;64&gt;;
+ * </pre>
+ */
 public class Str implements XdrElement {
   private XdrString str;
 

--- a/spec/output/generator_spec_java/test.x/Str2.java
+++ b/spec/output/generator_spec_java/test.x/Str2.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 
-// === xdr source ============================================================
-
-//  typedef string str2<>;
-
-//  ===========================================================================
+/**
+ * Str2's original definition in the XDR file is:
+ * <pre>
+ * typedef string str2&lt;&gt;;
+ * </pre>
+ */
 public class Str2 implements XdrElement {
   private XdrString str2;
 

--- a/spec/output/generator_spec_java/test.x/Uint512.java
+++ b/spec/output/generator_spec_java/test.x/Uint512.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 
-// === xdr source ============================================================
-
-//  typedef opaque uint512[64];
-
-//  ===========================================================================
+/**
+ * Uint512's original definition in the XDR file is:
+ * <pre>
+ * typedef opaque uint512[64];
+ * </pre>
+ */
 public class Uint512 implements XdrElement {
   private byte[] uint512;
 

--- a/spec/output/generator_spec_java/test.x/Uint513.java
+++ b/spec/output/generator_spec_java/test.x/Uint513.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 
-// === xdr source ============================================================
-
-//  typedef opaque uint513<64>;
-
-//  ===========================================================================
+/**
+ * Uint513's original definition in the XDR file is:
+ * <pre>
+ * typedef opaque uint513&lt;64&gt;;
+ * </pre>
+ */
 public class Uint513 implements XdrElement {
   private byte[] uint513;
 

--- a/spec/output/generator_spec_java/test.x/Uint514.java
+++ b/spec/output/generator_spec_java/test.x/Uint514.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 
-// === xdr source ============================================================
-
-//  typedef opaque uint514<>;
-
-//  ===========================================================================
+/**
+ * Uint514's original definition in the XDR file is:
+ * <pre>
+ * typedef opaque uint514&lt;&gt;;
+ * </pre>
+ */
 public class Uint514 implements XdrElement {
   private byte[] uint514;
 

--- a/spec/output/generator_spec_java/union.x/Error.java
+++ b/spec/output/generator_spec_java/union.x/Error.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 
-// === xdr source ============================================================
-
-//  typedef int Error;
-
-//  ===========================================================================
+/**
+ * Error's original definition in the XDR file is:
+ * <pre>
+ * typedef int Error;
+ * </pre>
+ */
 public class Error implements XdrElement {
   private Integer Error;
 

--- a/spec/output/generator_spec_java/union.x/IntUnion.java
+++ b/spec/output/generator_spec_java/union.x/IntUnion.java
@@ -12,18 +12,19 @@ import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 import java.util.Arrays;
 
-// === xdr source ============================================================
-
-//  union IntUnion switch (int type)
-//  {
-//      case 0:
-//          Error error;
-//      case 1:
-//          Multi things<>;
-//  
-//  };
-
-//  ===========================================================================
+/**
+ * IntUnion's original definition in the XDR file is:
+ * <pre>
+ * union IntUnion switch (int type)
+ * {
+ *     case 0:
+ *         Error error;
+ *     case 1:
+ *         Multi things&lt;&gt;;
+ * 
+ * };
+ * </pre>
+ */
 public class IntUnion implements XdrElement {
   public IntUnion () {}
   Integer type;

--- a/spec/output/generator_spec_java/union.x/IntUnion2.java
+++ b/spec/output/generator_spec_java/union.x/IntUnion2.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 
-// === xdr source ============================================================
-
-//  typedef IntUnion IntUnion2;
-
-//  ===========================================================================
+/**
+ * IntUnion2's original definition in the XDR file is:
+ * <pre>
+ * typedef IntUnion IntUnion2;
+ * </pre>
+ */
 public class IntUnion2 implements XdrElement {
   private IntUnion IntUnion2;
 

--- a/spec/output/generator_spec_java/union.x/Multi.java
+++ b/spec/output/generator_spec_java/union.x/Multi.java
@@ -11,11 +11,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 
-// === xdr source ============================================================
-
-//  typedef int Multi;
-
-//  ===========================================================================
+/**
+ * Multi's original definition in the XDR file is:
+ * <pre>
+ * typedef int Multi;
+ * </pre>
+ */
 public class Multi implements XdrElement {
   private Integer Multi;
 

--- a/spec/output/generator_spec_java/union.x/MyUnion.java
+++ b/spec/output/generator_spec_java/union.x/MyUnion.java
@@ -12,19 +12,20 @@ import java.io.ByteArrayOutputStream;
 import java.util.Objects;
 import java.util.Arrays;
 
-// === xdr source ============================================================
-
-//  union MyUnion switch (UnionKey type)
-//  {
-//      case ERROR:
-//          Error error;
-//      case MULTI:
-//          Multi things<>;
-//  
-//  
-//  };
-
-//  ===========================================================================
+/**
+ * MyUnion's original definition in the XDR file is:
+ * <pre>
+ * union MyUnion switch (UnionKey type)
+ * {
+ *     case ERROR:
+ *         Error error;
+ *     case MULTI:
+ *         Multi things&lt;&gt;;
+ * 
+ * 
+ * };
+ * </pre>
+ */
 public class MyUnion implements XdrElement {
   public MyUnion () {}
   UnionKey type;

--- a/spec/output/generator_spec_java/union.x/UnionKey.java
+++ b/spec/output/generator_spec_java/union.x/UnionKey.java
@@ -10,14 +10,15 @@ import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
-// === xdr source ============================================================
-
-//  enum UnionKey {
-//    ERROR,
-//    MULTI
-//  };
-
-//  ===========================================================================
+/**
+ * UnionKey's original definition in the XDR file is:
+ * <pre>
+ * enum UnionKey {
+ *   ERROR,
+ *   MULTI
+ * };
+ * </pre>
+ */
 public enum UnionKey implements XdrElement {
   ERROR(0),
   MULTI(1),


### PR DESCRIPTION
Previously, the way we rendered comments prevented XDR definitions from being displayed in javadoc, in this PR we have added it.

See https://github.com/lightsail-network/java-stellar-sdk/pull/595