### PR TITLE
Java: use lombok to simplify the code

### DIFF
--- a/lib/xdrgen/generators/java.rb
+++ b/lib/xdrgen/generators/java.rb
@@ -463,20 +463,20 @@ module Xdrgen
         end
         case member.declaration
         when AST::Declarations::Opaque ;
-          out.puts "int #{member.name}size = #{value}.#{member.name}.length;"
+          out.puts "int #{member.name}Size = #{value}.#{member.name}.length;"
           unless member.declaration.fixed?
-            out.puts "stream.writeInt(#{member.name}size);"
+            out.puts "stream.writeInt(#{member.name}Size);"
           end
           out.puts <<-EOS.strip_heredoc
-            stream.write(#{value}.get#{member.name.slice(0,1).capitalize+member.name.slice(1..-1)}(), 0, #{member.name}size);
+            stream.write(#{value}.get#{member.name.slice(0,1).capitalize+member.name.slice(1..-1)}(), 0, #{member.name}Size);
           EOS
         when AST::Declarations::Array ;
-          out.puts "int #{member.name}size = #{value}.get#{member.name.slice(0,1).capitalize+member.name.slice(1..-1)}().length;"
+          out.puts "int #{member.name}Size = #{value}.get#{member.name.slice(0,1).capitalize+member.name.slice(1..-1)}().length;"
           unless member.declaration.fixed?
-            out.puts "stream.writeInt(#{member.name}size);"
+            out.puts "stream.writeInt(#{member.name}Size);"
           end
           out.puts <<-EOS.strip_heredoc
-            for (int i = 0; i < #{member.name}size; i++) {
+            for (int i = 0; i < #{member.name}Size; i++) {
               #{encode_type member.declaration.type, "#{value}.#{member.name}[i]"};
             }
           EOS
@@ -533,23 +533,23 @@ module Xdrgen
         case member.declaration
         when AST::Declarations::Opaque ;
           if (member.declaration.fixed?)
-            out.puts "int #{member.name}size = #{member.declaration.size};"
+            out.puts "int #{member.name}Size = #{member.declaration.size};"
           else
-            out.puts "int #{member.name}size = stream.readInt();"
+            out.puts "int #{member.name}Size = stream.readInt();"
           end
           out.puts <<-EOS.strip_heredoc
-            #{value}.#{member.name} = new byte[#{member.name}size];
-            stream.read(#{value}.#{member.name}, 0, #{member.name}size);
+            #{value}.#{member.name} = new byte[#{member.name}Size];
+            stream.read(#{value}.#{member.name}, 0, #{member.name}Size);
           EOS
         when AST::Declarations::Array ;
           if (member.declaration.fixed?)
-            out.puts "int #{member.name}size = #{member.declaration.size};"
+            out.puts "int #{member.name}Size = #{member.declaration.size};"
           else
-            out.puts "int #{member.name}size = stream.readInt();"
+            out.puts "int #{member.name}Size = stream.readInt();"
           end
           out.puts <<-EOS.strip_heredoc
-            #{value}.#{member.name} = new #{type_string member.type}[#{member.name}size];
-            for (int i = 0; i < #{member.name}size; i++) {
+            #{value}.#{member.name} = new #{type_string member.type}[#{member.name}Size];
+            for (int i = 0; i < #{member.name}Size; i++) {
               #{value}.#{member.name}[i] = #{decode_type member.declaration};
             }
           EOS

--- a/lib/xdrgen/generators/java.rb
+++ b/lib/xdrgen/generators/java.rb
@@ -48,56 +48,17 @@ module Xdrgen
         imports.add("java.io.ByteArrayOutputStream")
 
         case defn
-        when AST::Definitions::Struct ;
-          defn.members.each do |m|
-            if is_decl_array(m.declaration)
-              imports.add('java.util.Arrays')
-            else
-              imports.add('java.util.Objects')
-            end
-          end
-          # if we have more than one member field then the
-          # hash code will be computed by
-          # Objects.hash(field1, field2, ..., fieldN)
-          # therefore, we should always import java.util.Objects
-          if defn.members.length > 1
-            imports.add("java.util.Objects")
-          end
-        when AST::Definitions::Enum ;
-          # no imports required for enums
-        when AST::Definitions::Union ;
-          nonVoidArms = defn.arms.select { |arm| !arm.void? }
-          # add 1 because of the discriminant
-          totalFields = nonVoidArms.length + 1
-
-          if is_type_array(defn.discriminant.type)
-            imports.add('java.util.Arrays')
-          else
-            imports.add('java.util.Objects')
-          end
-
-          nonVoidArms.each do |a|
-            if is_decl_array(a.declaration)
-              imports.add('java.util.Arrays')
-            else
-              imports.add('java.util.Objects')
-            end
-          end
-
-          # if we have more than one field then the
-          # hash code will be computed by
-          # Objects.hash(field1, field2, ..., fieldN)
-          # therefore, we should always import java.util.Objects
-          # if we have more than one field
-          if totalFields > 1
-            imports.add("java.util.Objects")
-          end
-        when AST::Definitions::Typedef ;
-          if is_decl_array(defn.declaration)
-            imports.add('java.util.Arrays')
-          else
-            imports.add('java.util.Objects')
-          end
+        when AST::Definitions::Struct, AST::Definitions::Union
+          imports.add("lombok.Data")
+          imports.add("lombok.NoArgsConstructor")
+          imports.add("lombok.AllArgsConstructor")
+          imports.add("lombok.Builder")
+          imports.add("static #{@namespace}.Constants.*")
+        when AST::Definitions::Typedef
+          imports.add("lombok.Data")
+          imports.add("lombok.NoArgsConstructor")
+          imports.add("lombok.AllArgsConstructor")
+          imports.add("static #{@namespace}.Constants.*")
         end
 
         if defn.respond_to? :nested_definitions
@@ -111,21 +72,21 @@ module Xdrgen
 
         case defn
         when AST::Definitions::Struct ;
-          render_element "public class", imports, defn do |out|
+          render_element defn, imports, defn do |out|
             render_struct defn, out
             render_nested_definitions defn, out
           end
         when AST::Definitions::Enum ;
-          render_element "public enum", imports, defn do |out|
+          render_element defn, imports, defn do |out|
             render_enum defn, out
           end
         when AST::Definitions::Union ;
-          render_element "public class", imports, defn do |out|
+          render_element defn, imports, defn do |out|
             render_union defn, out
             render_nested_definitions defn, out
           end
         when AST::Definitions::Typedef ;
-          render_element "public class", imports, defn do |out|
+          render_element defn, imports, defn do |out|
             render_typedef defn, out
           end
         when AST::Definitions::Const ;
@@ -142,6 +103,10 @@ module Xdrgen
           case ndefn
           when AST::Definitions::Struct ;
             name = name ndefn
+            out.puts "@Data"
+            out.puts "@NoArgsConstructor"
+            out.puts "@AllArgsConstructor"
+            out.puts "@Builder(toBuilder = true)"
             out.puts "public static class #{name} #{post_name} {"
             out.indent do
               render_struct ndefn, out
@@ -157,6 +122,10 @@ module Xdrgen
             out.puts "}"
           when AST::Definitions::Union ;
             name = name ndefn
+            out.puts "@Data"
+            out.puts "@NoArgsConstructor"
+            out.puts "@AllArgsConstructor"
+            out.puts "@Builder(toBuilder = true)"
             out.puts "public static class #{name} #{post_name} {"
             out.indent do
               render_union ndefn, out
@@ -165,6 +134,9 @@ module Xdrgen
             out.puts "}"
           when AST::Definitions::Typedef ;
             name = name ndefn
+            out.puts "@Data"
+            out.puts "@NoArgsConstructor"
+            out.puts "@AllArgsConstructor"
             out.puts "public static class #{name} #{post_name} {"
             out.indent do
               render_typedef ndefn, out
@@ -174,18 +146,31 @@ module Xdrgen
         }
       end
 
-      def render_element(type, imports, element, post_name="implements XdrElement")
+      def render_element(defn, imports, element, post_name="implements XdrElement")
         path = element.name.camelize + ".java"
         name = name_string element.name
         out  = @output.open(path)
         render_top_matter out
-        out.puts "import static #{@namespace}.Constants.*;"
         imports.each do |import|
           out.puts "import #{import};"
         end
         out.puts "\n"
         render_source_comment out, element
-        out.puts "#{type} #{name} #{post_name} {"
+        case defn
+        when AST::Definitions::Struct, AST::Definitions::Union
+          out.puts "@Data"
+          out.puts "@NoArgsConstructor"
+          out.puts "@AllArgsConstructor"
+          out.puts "@Builder(toBuilder = true)"
+          out.puts "public class #{name} #{post_name} {"
+        when AST::Definitions::Enum
+          out.puts "public enum #{name} #{post_name} {"
+        when AST::Definitions::Typedef
+          out.puts "@Data"
+          out.puts "@NoArgsConstructor"
+          out.puts "@AllArgsConstructor"
+          out.puts "public class #{name} #{post_name} {"
+        end      
         out.indent do
           yield out
           out.unbreak
@@ -208,20 +193,20 @@ module Xdrgen
 
       def render_enum(enum, out)
         out.balance_after /,[\s]*/ do
-          enum.members.each do |em|
-            out.puts "#{em.name}(#{em.value}),"
+          enum.members.each_with_index do |em, index|
+            out.puts "#{em.name}(#{em.value})#{index == enum.members.size - 1 ? ';' : ','}"
           end
         end
-        out.puts ";\n"
+        out.break
         out.puts <<-EOS.strip_heredoc
-        private int mValue;
+        private final int value;
 
         #{name_string enum.name}(int value) {
-            mValue = value;
+            this.value = value;
         }
 
         public int getValue() {
-            return mValue;
+            return value;
         }
 
         public static #{name_string enum.name} decode(XdrDataInputStream stream) throws IOException {
@@ -252,19 +237,9 @@ module Xdrgen
       end
 
       def render_struct(struct, out)
-        out.puts "public #{name struct} () {}"
         struct.members.each do |m|
-          out.puts <<-EOS.strip_heredoc
-            private #{decl_string(m.declaration)} #{m.name};
-            public #{decl_string(m.declaration)} get#{m.name.slice(0,1).capitalize+m.name.slice(1..-1)}() {
-              return this.#{m.name};
-            }
-            public void set#{m.name.slice(0,1).capitalize+m.name.slice(1..-1)}(#{decl_string m.declaration} value) {
-              this.#{m.name} = value;
-            }
-          EOS
+          out.puts "private #{decl_string(m.declaration)} #{m.name};"
         end
-
 
         out.puts "public static void encode(XdrDataOutputStream stream, #{name struct} encoded#{name struct}) throws IOException{"
         struct.members.each do |m|
@@ -294,117 +269,12 @@ module Xdrgen
         end
         out.puts "}"
 
-        hashCodeExpression = case struct.members.length
-          when 0
-            "0"
-          when 1
-            if is_decl_array(struct.members[0].declaration)
-              "Arrays.hashCode(this.#{struct.members[0].name})"
-            else
-              "Objects.hash(this.#{struct.members[0].name})"
-            end
-          else
-            "Objects.hash(#{
-              (struct.members.map { |m|
-                if is_decl_array(m.declaration)
-                  "Arrays.hashCode(this.#{m.name})"
-                else
-                  "this.#{m.name}"
-                end
-              }).join(", ")
-            })"
-        end
-        out.puts <<-EOS.strip_heredoc
-          @Override
-          public int hashCode() {
-            return #{hashCodeExpression};
-          }
-        EOS
-
-        equalParts = struct.members.map { |m|
-          if is_decl_array(m.declaration)
-            "Arrays.equals(this.#{m.name}, other.#{m.name})"
-          else
-            "Objects.equals(this.#{m.name}, other.#{m.name})"
-          end
-        }
-        equalExpression = case equalParts.length
-          when 0
-            "true"
-          else
-            equalParts.join(" && ")
-        end
-        type = name struct
-        out.puts <<-EOS.strip_heredoc
-          @Override
-          public boolean equals(Object object) {
-            if (!(object instanceof #{type})) {
-              return false;
-            }
-
-            #{type} other = (#{type}) object;
-            return #{equalExpression};
-          }
-
-        EOS
-
         render_base64((name struct), out)
-
-        out.puts "public static final class Builder {"
-        out.indent do
-          struct.members.map { |m|
-            out.puts "private #{decl_string(m.declaration)} #{m.name};"
-          }
-
-          struct.members.map { |m|
-            out.puts <<-EOS.strip_heredoc
-
-              public Builder #{m.name}(#{decl_string(m.declaration)} #{m.name}) {
-                this.#{m.name} = #{m.name};
-                return this;
-              }
-            EOS
-          }
-
-        end
-
-
-        out.indent do
-          out.break
-          out.puts "public #{name struct} build() {"
-          out.indent do
-            out.puts "#{name struct} val = new #{name struct}();"
-            struct.members.map { |m|
-              out.puts "val.set#{m.name.slice(0,1).capitalize+m.name.slice(1..-1)}(this.#{m.name});"
-            }
-            out.puts "return val;"
-          end
-          out.puts "}"
-        end
-        out.puts "}"
         out.break
       end
 
       def render_typedef(typedef, out)
-        out.puts <<-EOS.strip_heredoc
-          private #{decl_string typedef.declaration} #{typedef.name};
-
-          public #{typedef.name.camelize}() {}
-
-          public #{typedef.name.camelize}(#{decl_string typedef.declaration} #{typedef.name}) {
-            this.#{typedef.name} = #{typedef.name};
-          }
-
-          public #{decl_string typedef.declaration} get#{typedef.name.slice(0,1).capitalize+typedef.name.slice(1..-1)}() {
-            return this.#{typedef.name};
-          }
-
-          public void set#{typedef.name.slice(0,1).capitalize+typedef.name.slice(1..-1)}(#{decl_string typedef.declaration} value) {
-            this.#{typedef.name} = value;
-          }
-
-        EOS
-
+        out.puts "private #{decl_string typedef.declaration} #{typedef.name};"
         out.puts "public static void encode(XdrDataOutputStream stream, #{name typedef}  encoded#{name typedef}) throws IOException {"
         out.indent do
           encode_member "encoded#{name typedef}", typedef, out
@@ -428,112 +298,16 @@ module Xdrgen
         end
         out.puts "}"
         out.break
-
-        hash_coder_for_decl =
-          if is_decl_array(typedef.declaration)
-            "Arrays.hashCode"
-          else
-            "Objects.hash"
-          end
-        out.puts <<-EOS.strip_heredoc
-          @Override
-          public int hashCode() {
-            return #{hash_coder_for_decl}(this.#{typedef.name});
-          }
-
-        EOS
-
-        equals_for_decl =
-          if is_decl_array(typedef.declaration)
-            "Arrays.equals"
-          else
-            "Objects.equals"
-          end
-        type = name_string typedef.name
-        out.puts <<-EOS.strip_heredoc
-          @Override
-          public boolean equals(Object object) {
-            if (!(object instanceof #{type})) {
-              return false;
-            }
-
-            #{type} other = (#{type}) object;
-            return #{equals_for_decl}(this.#{typedef.name}, other.#{typedef.name});
-          }
-        EOS
         render_base64(typedef.name.camelize, out)
       end
 
       def render_union(union, out)
-        out.puts "public #{name union} () {}"
-        out.puts <<-EOS.strip_heredoc
-          #{type_string union.discriminant.type} #{union.discriminant.name};
-          public #{type_string union.discriminant.type} getDiscriminant() {
-            return this.#{union.discriminant.name};
-          }
-          public void setDiscriminant(#{type_string union.discriminant.type} value) {
-            this.#{union.discriminant.name} = value;
-          }
-        EOS
+        out.puts "private #{type_string union.discriminant.type} discriminant;"
         union.arms.each do |arm|
           next if arm.void?
-          out.puts <<-EOS.strip_heredoc
-            private #{decl_string(arm.declaration)} #{arm.name};
-            public #{decl_string(arm.declaration)} get#{arm.name.slice(0,1).capitalize+arm.name.slice(1..-1)}() {
-              return this.#{arm.name};
-            }
-            public void set#{arm.name.slice(0,1).capitalize+arm.name.slice(1..-1)}(#{decl_string arm.declaration} value) {
-              this.#{arm.name} = value;
-            }
-          EOS
+          out.puts "private #{decl_string(arm.declaration)} #{arm.name};"
         end
         out.break
-
-        out.puts "public static final class Builder {"
-        out.indent do
-          out.puts "private #{type_string union.discriminant.type} discriminant;"
-          union.arms.each do |arm|
-            next if arm.void?
-            out.puts "private #{decl_string(arm.declaration)} #{arm.name};"
-          end
-          out.break
-
-          out.puts <<-EOS.strip_heredoc
-            public Builder discriminant(#{type_string union.discriminant.type} discriminant) {
-              this.discriminant = discriminant;
-              return this;
-            }
-          EOS
-
-          union.arms.each do |arm|
-            next if arm.void?
-            out.puts <<-EOS.strip_heredoc
-
-              public Builder #{arm.name}(#{decl_string(arm.declaration)} #{arm.name}) {
-                this.#{arm.name} = #{arm.name};
-                return this;
-              }
-            EOS
-          end
-        end
-
-        out.indent do
-          out.break
-          out.puts "public #{name union} build() {"
-          out.indent do
-            out.puts "#{name union} val = new #{name union}();"
-            out.puts "val.setDiscriminant(discriminant);"
-            union.arms.each do |arm|
-              next if arm.void?
-              out.puts "val.set#{arm.name.slice(0,1).capitalize+arm.name.slice(1..-1)}(this.#{arm.name});"
-            end
-            out.puts "return val;"
-          end
-          out.puts "}"
-        end
-        out.puts "}"
-        out.break
-
 
         out.puts "public static void encode(XdrDataOutputStream stream, #{name union} encoded#{name union}) throws IOException {"
         out.puts('//' + union.discriminant.type.class.to_s)
@@ -622,65 +396,6 @@ module Xdrgen
           out.puts "return decoded#{name union};"
         end
         out.puts "}"
-
-        nonVoidArms = union.arms.select { |arm| !arm.void? }
-
-        discriminantPart = if is_type_array(union.discriminant.type)
-          "Arrays.hashCode(this.#{union.discriminant.name})"
-        else
-          "this.#{union.discriminant.name}"
-        end
-
-        parts = nonVoidArms.map { |a|
-          if is_decl_array(a.declaration)
-            "Arrays.hashCode(this.#{a.name})"
-          else
-            "this.#{a.name}"
-          end
-        }
-        parts.append(discriminantPart)
-
-        hashCodeExpression = "Objects.hash(#{parts.join(", ")})"
-        out.puts <<-EOS.strip_heredoc
-          @Override
-          public int hashCode() {
-            return #{hashCodeExpression};
-          }
-        EOS
-
-        equalParts = nonVoidArms.map { |a|
-          if is_decl_array(a.declaration)
-            "Arrays.equals(this.#{a.name}, other.#{a.name})"
-          else
-            "Objects.equals(this.#{a.name}, other.#{a.name})"
-          end
-        }
-        equalParts.append(
-          if is_type_array(union.discriminant.type)
-            "Arrays.equals(this.#{union.discriminant.name}, other.#{union.discriminant.name})"
-          else
-            "Objects.equals(this.#{union.discriminant.name}, other.#{union.discriminant.name})"
-          end
-        )
-
-        equalExpression = case equalParts.length
-          when 0
-            "true"
-          else
-            equalParts.join(" && ")
-        end
-        type = name union
-        out.puts <<-EOS.strip_heredoc
-          @Override
-          public boolean equals(Object object) {
-            if (!(object instanceof #{type})) {
-              return false;
-            }
-
-            #{type} other = (#{type}) object;
-            return #{equalExpression};
-          }
-        EOS
         render_base64((name union), out)
         out.break
       end

--- a/lib/xdrgen/generators/java/XdrString.erb
+++ b/lib/xdrgen/generators/java/XdrString.erb
@@ -4,90 +4,72 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
-import java.nio.charset.Charset;
-import java.util.Arrays;
+import java.nio.charset.StandardCharsets;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
+@Value
 public class XdrString implements XdrElement {
-    private byte[] bytes;
+  byte[] bytes;
 
-    public XdrString(byte[] bytes) {
-        this.bytes = bytes;
-    }
+  public XdrString(byte[] bytes) {
+    this.bytes = bytes;
+  }
 
-    public XdrString(String text) {
-        this.bytes = text.getBytes(Charset.forName("UTF-8"));
-    }
+  public XdrString(String text) {
+    this.bytes = text.getBytes(StandardCharsets.UTF_8);
+  }
 
-    @Override
-    public void encode(XdrDataOutputStream stream) throws IOException {
-        stream.writeInt(this.bytes.length);
-        stream.write(this.bytes, 0, this.bytes.length);
-    }
+  @Override
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    stream.writeInt(this.bytes.length);
+    stream.write(this.bytes, 0, this.bytes.length);
+  }
 
-    public static XdrString decode(XdrDataInputStream stream, int maxSize) throws IOException {
-        int size = stream.readInt();
-        if (size > maxSize) {
-            throw new InvalidClassException("String length "+size+" exceeds max size "+maxSize);
-        }
-        byte[] bytes = new byte[size];
-        stream.read(bytes);
-        return new XdrString(bytes);
+  public static XdrString decode(XdrDataInputStream stream, int maxSize) throws IOException {
+    int size = stream.readInt();
+    if (size > maxSize) {
+      throw new InvalidClassException("String length " + size + " exceeds max size " + maxSize);
     }
+    byte[] bytes = new byte[size];
+    stream.read(bytes);
+    return new XdrString(bytes);
+  }
 
-    public byte[] getBytes() {
-        return this.bytes;
-    }
+  @Override
+  public String toXdrBase64() throws IOException {
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
+  }
 
-    @Override
-    public String toXdrBase64() throws IOException {
-        return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-    }
-    
-    @Override
-    public byte[] toXdrByteArray() throws IOException {
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-        encode(xdrDataOutputStream);
-        return byteArrayOutputStream.toByteArray();
-    }
-    
-    public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64Factory.getInstance().decode(xdr);
-        return fromXdrByteArray(bytes, maxSize);
-    }
-    
-    public static XdrString fromXdrBase64(String xdr) throws IOException {
-        return fromXdrBase64(xdr, Integer.MAX_VALUE);
-    }
-    
-    public static XdrString fromXdrByteArray(byte[] xdr, int maxSize) throws IOException {
-        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
-        XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
-        return decode(xdrDataInputStream, maxSize);
-    }
-    
-    public static XdrString fromXdrByteArray(byte[] xdr) throws IOException {
-        return fromXdrByteArray(xdr, Integer.MAX_VALUE);
-    }
+  @Override
+  public byte[] toXdrByteArray() throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
+    encode(xdrDataOutputStream);
+    return byteArrayOutputStream.toByteArray();
+  }
 
-    @Override
-    public int hashCode() {
-        return Arrays.hashCode(this.bytes);
-    }
+  public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
+    return fromXdrByteArray(bytes, maxSize);
+  }
 
-    @Override
-    public boolean equals(Object object) {
-        if (object == null || !(object instanceof XdrString)) {
-          return false;
-        }
+  public static XdrString fromXdrBase64(String xdr) throws IOException {
+    return fromXdrBase64(xdr, Integer.MAX_VALUE);
+  }
 
-        XdrString other = (XdrString) object;
-        return Arrays.equals(this.bytes, other.bytes);
-    }
+  public static XdrString fromXdrByteArray(byte[] xdr, int maxSize) throws IOException {
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
+    XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
+    return decode(xdrDataInputStream, maxSize);
+  }
 
-    @Override
-    public String toString() {
-        return new String(bytes, Charset.forName("UTF-8"));
-    }
+  public static XdrString fromXdrByteArray(byte[] xdr) throws IOException {
+    return fromXdrByteArray(xdr, Integer.MAX_VALUE);
+  }
+
+  @Override
+  public String toString() {
+    return new String(bytes, StandardCharsets.UTF_8);
+  }
 }

--- a/lib/xdrgen/generators/java/XdrUnsignedHyperInteger.erb
+++ b/lib/xdrgen/generators/java/XdrUnsignedHyperInteger.erb
@@ -1,10 +1,10 @@
-package org.stellar.sdk.xdr;
+package <%= @namespace %>;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Objects;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
 /**
@@ -13,10 +13,11 @@ import org.stellar.sdk.Base64Factory;
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc4506#section-4.5">XDR: External Data
  *     Representation Standard</a>
  */
+@Value
 public class XdrUnsignedHyperInteger implements XdrElement {
   public static final BigInteger MAX_VALUE = new BigInteger("18446744073709551615");
   public static final BigInteger MIN_VALUE = BigInteger.ZERO;
-  private final BigInteger number;
+  BigInteger number;
 
   public XdrUnsignedHyperInteger(BigInteger number) {
     if (number.compareTo(MIN_VALUE) < 0 || number.compareTo(MAX_VALUE) > 0) {
@@ -55,10 +56,6 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     return paddedBytes;
   }
 
-  public BigInteger getNumber() {
-    return number;
-  }
-
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());
@@ -81,24 +78,5 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.number);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof XdrUnsignedHyperInteger)) {
-      return false;
-    }
-
-    XdrUnsignedHyperInteger other = (XdrUnsignedHyperInteger) object;
-    return Objects.equals(this.number, other.number);
-  }
-
-  public String toString() {
-    return "XdrUnsignedInteger(number=" + this.getNumber() + ")";
   }
 }

--- a/lib/xdrgen/generators/java/XdrUnsignedInteger.erb
+++ b/lib/xdrgen/generators/java/XdrUnsignedInteger.erb
@@ -1,9 +1,9 @@
-package org.stellar.sdk.xdr;
+package <%= @namespace %>;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Objects;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
 /**
@@ -12,10 +12,11 @@ import org.stellar.sdk.Base64Factory;
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc4506#section-4.2">XDR: External Data
  *     Representation Standard</a>
  */
+@Value
 public class XdrUnsignedInteger implements XdrElement {
   public static final long MAX_VALUE = (1L << 32) - 1;
   public static final long MIN_VALUE = 0;
-  private final Long number;
+  Long number;
 
   public XdrUnsignedInteger(Long number) {
     if (number < MIN_VALUE || number > MAX_VALUE) {
@@ -30,10 +31,6 @@ public class XdrUnsignedInteger implements XdrElement {
           "number must be greater than or equal to 0 if you want to construct it from Integer");
     }
     this.number = number.longValue();
-  }
-
-  public Long getNumber() {
-    return number;
   }
 
   public static XdrUnsignedInteger decode(XdrDataInputStream stream) throws IOException {
@@ -69,24 +66,5 @@ public class XdrUnsignedInteger implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.number);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof XdrUnsignedInteger)) {
-      return false;
-    }
-
-    XdrUnsignedInteger other = (XdrUnsignedInteger) object;
-    return Objects.equals(this.number, other.number);
-  }
-
-  public String toString() {
-    return "XdrUnsignedInteger(number=" + this.getNumber() + ")";
   }
 }

--- a/spec/output/generator_spec_java/block_comments.x/AccountFlags.java
+++ b/spec/output/generator_spec_java/block_comments.x/AccountFlags.java
@@ -5,7 +5,6 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -20,16 +19,16 @@ import java.io.ByteArrayOutputStream;
  * </pre>
  */
 public enum AccountFlags implements XdrElement {
-  AUTH_REQUIRED_FLAG(1),
-  ;
-  private int mValue;
+  AUTH_REQUIRED_FLAG(1);
+
+  private final int value;
 
   AccountFlags(int value) {
-      mValue = value;
+      this.value = value;
   }
 
   public int getValue() {
-      return mValue;
+      return value;
   }
 
   public static AccountFlags decode(XdrDataInputStream stream) throws IOException {

--- a/spec/output/generator_spec_java/block_comments.x/XdrString.java
+++ b/spec/output/generator_spec_java/block_comments.x/XdrString.java
@@ -4,90 +4,72 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
-import java.nio.charset.Charset;
-import java.util.Arrays;
+import java.nio.charset.StandardCharsets;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
+@Value
 public class XdrString implements XdrElement {
-    private byte[] bytes;
+  byte[] bytes;
 
-    public XdrString(byte[] bytes) {
-        this.bytes = bytes;
-    }
+  public XdrString(byte[] bytes) {
+    this.bytes = bytes;
+  }
 
-    public XdrString(String text) {
-        this.bytes = text.getBytes(Charset.forName("UTF-8"));
-    }
+  public XdrString(String text) {
+    this.bytes = text.getBytes(StandardCharsets.UTF_8);
+  }
 
-    @Override
-    public void encode(XdrDataOutputStream stream) throws IOException {
-        stream.writeInt(this.bytes.length);
-        stream.write(this.bytes, 0, this.bytes.length);
-    }
+  @Override
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    stream.writeInt(this.bytes.length);
+    stream.write(this.bytes, 0, this.bytes.length);
+  }
 
-    public static XdrString decode(XdrDataInputStream stream, int maxSize) throws IOException {
-        int size = stream.readInt();
-        if (size > maxSize) {
-            throw new InvalidClassException("String length "+size+" exceeds max size "+maxSize);
-        }
-        byte[] bytes = new byte[size];
-        stream.read(bytes);
-        return new XdrString(bytes);
+  public static XdrString decode(XdrDataInputStream stream, int maxSize) throws IOException {
+    int size = stream.readInt();
+    if (size > maxSize) {
+      throw new InvalidClassException("String length " + size + " exceeds max size " + maxSize);
     }
+    byte[] bytes = new byte[size];
+    stream.read(bytes);
+    return new XdrString(bytes);
+  }
 
-    public byte[] getBytes() {
-        return this.bytes;
-    }
+  @Override
+  public String toXdrBase64() throws IOException {
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
+  }
 
-    @Override
-    public String toXdrBase64() throws IOException {
-        return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-    }
-    
-    @Override
-    public byte[] toXdrByteArray() throws IOException {
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-        encode(xdrDataOutputStream);
-        return byteArrayOutputStream.toByteArray();
-    }
-    
-    public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64Factory.getInstance().decode(xdr);
-        return fromXdrByteArray(bytes, maxSize);
-    }
-    
-    public static XdrString fromXdrBase64(String xdr) throws IOException {
-        return fromXdrBase64(xdr, Integer.MAX_VALUE);
-    }
-    
-    public static XdrString fromXdrByteArray(byte[] xdr, int maxSize) throws IOException {
-        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
-        XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
-        return decode(xdrDataInputStream, maxSize);
-    }
-    
-    public static XdrString fromXdrByteArray(byte[] xdr) throws IOException {
-        return fromXdrByteArray(xdr, Integer.MAX_VALUE);
-    }
+  @Override
+  public byte[] toXdrByteArray() throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
+    encode(xdrDataOutputStream);
+    return byteArrayOutputStream.toByteArray();
+  }
 
-    @Override
-    public int hashCode() {
-        return Arrays.hashCode(this.bytes);
-    }
+  public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
+    return fromXdrByteArray(bytes, maxSize);
+  }
 
-    @Override
-    public boolean equals(Object object) {
-        if (object == null || !(object instanceof XdrString)) {
-          return false;
-        }
+  public static XdrString fromXdrBase64(String xdr) throws IOException {
+    return fromXdrBase64(xdr, Integer.MAX_VALUE);
+  }
 
-        XdrString other = (XdrString) object;
-        return Arrays.equals(this.bytes, other.bytes);
-    }
+  public static XdrString fromXdrByteArray(byte[] xdr, int maxSize) throws IOException {
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
+    XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
+    return decode(xdrDataInputStream, maxSize);
+  }
 
-    @Override
-    public String toString() {
-        return new String(bytes, Charset.forName("UTF-8"));
-    }
+  public static XdrString fromXdrByteArray(byte[] xdr) throws IOException {
+    return fromXdrByteArray(xdr, Integer.MAX_VALUE);
+  }
+
+  @Override
+  public String toString() {
+    return new String(bytes, StandardCharsets.UTF_8);
+  }
 }

--- a/spec/output/generator_spec_java/block_comments.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/block_comments.x/XdrUnsignedHyperInteger.java
@@ -1,10 +1,10 @@
-package org.stellar.sdk.xdr;
+package MyXDR;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Objects;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
 /**
@@ -13,10 +13,11 @@ import org.stellar.sdk.Base64Factory;
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc4506#section-4.5">XDR: External Data
  *     Representation Standard</a>
  */
+@Value
 public class XdrUnsignedHyperInteger implements XdrElement {
   public static final BigInteger MAX_VALUE = new BigInteger("18446744073709551615");
   public static final BigInteger MIN_VALUE = BigInteger.ZERO;
-  private final BigInteger number;
+  BigInteger number;
 
   public XdrUnsignedHyperInteger(BigInteger number) {
     if (number.compareTo(MIN_VALUE) < 0 || number.compareTo(MAX_VALUE) > 0) {
@@ -55,10 +56,6 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     return paddedBytes;
   }
 
-  public BigInteger getNumber() {
-    return number;
-  }
-
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());
@@ -81,24 +78,5 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.number);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof XdrUnsignedHyperInteger)) {
-      return false;
-    }
-
-    XdrUnsignedHyperInteger other = (XdrUnsignedHyperInteger) object;
-    return Objects.equals(this.number, other.number);
-  }
-
-  public String toString() {
-    return "XdrUnsignedInteger(number=" + this.getNumber() + ")";
   }
 }

--- a/spec/output/generator_spec_java/block_comments.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/block_comments.x/XdrUnsignedInteger.java
@@ -1,9 +1,9 @@
-package org.stellar.sdk.xdr;
+package MyXDR;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Objects;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
 /**
@@ -12,10 +12,11 @@ import org.stellar.sdk.Base64Factory;
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc4506#section-4.2">XDR: External Data
  *     Representation Standard</a>
  */
+@Value
 public class XdrUnsignedInteger implements XdrElement {
   public static final long MAX_VALUE = (1L << 32) - 1;
   public static final long MIN_VALUE = 0;
-  private final Long number;
+  Long number;
 
   public XdrUnsignedInteger(Long number) {
     if (number < MIN_VALUE || number > MAX_VALUE) {
@@ -30,10 +31,6 @@ public class XdrUnsignedInteger implements XdrElement {
           "number must be greater than or equal to 0 if you want to construct it from Integer");
     }
     this.number = number.longValue();
-  }
-
-  public Long getNumber() {
-    return number;
   }
 
   public static XdrUnsignedInteger decode(XdrDataInputStream stream) throws IOException {
@@ -69,24 +66,5 @@ public class XdrUnsignedInteger implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.number);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof XdrUnsignedInteger)) {
-      return false;
-    }
-
-    XdrUnsignedInteger other = (XdrUnsignedInteger) object;
-    return Objects.equals(this.number, other.number);
-  }
-
-  public String toString() {
-    return "XdrUnsignedInteger(number=" + this.getNumber() + ")";
   }
 }

--- a/spec/output/generator_spec_java/const.x/TestArray.java
+++ b/spec/output/generator_spec_java/const.x/TestArray.java
@@ -25,8 +25,8 @@ import static MyXDR.Constants.*;
 public class TestArray implements XdrElement {
   private Integer[] TestArray;
   public static void encode(XdrDataOutputStream stream, TestArray  encodedTestArray) throws IOException {
-    int TestArraysize = encodedTestArray.getTestArray().length;
-    for (int i = 0; i < TestArraysize; i++) {
+    int TestArraySize = encodedTestArray.getTestArray().length;
+    for (int i = 0; i < TestArraySize; i++) {
       stream.writeInt(encodedTestArray.TestArray[i]);
     }
   }
@@ -36,9 +36,9 @@ public class TestArray implements XdrElement {
   }
   public static TestArray decode(XdrDataInputStream stream) throws IOException {
     TestArray decodedTestArray = new TestArray();
-    int TestArraysize = FOO;
-    decodedTestArray.TestArray = new Integer[TestArraysize];
-    for (int i = 0; i < TestArraysize; i++) {
+    int TestArraySize = FOO;
+    decodedTestArray.TestArray = new Integer[TestArraySize];
+    for (int i = 0; i < TestArraySize; i++) {
       decodedTestArray.TestArray[i] = stream.readInt();
     }
     return decodedTestArray;

--- a/spec/output/generator_spec_java/const.x/TestArray.java
+++ b/spec/output/generator_spec_java/const.x/TestArray.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Arrays;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * TestArray's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Arrays;
  * typedef int TestArray[FOO];
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class TestArray implements XdrElement {
   private Integer[] TestArray;
-
-  public TestArray() {}
-
-  public TestArray(Integer[] TestArray) {
-    this.TestArray = TestArray;
-  }
-
-  public Integer[] getTestArray() {
-    return this.TestArray;
-  }
-
-  public void setTestArray(Integer[] value) {
-    this.TestArray = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, TestArray  encodedTestArray) throws IOException {
     int TestArraysize = encodedTestArray.getTestArray().length;
     for (int i = 0; i < TestArraysize; i++) {
@@ -54,20 +44,6 @@ public class TestArray implements XdrElement {
     return decodedTestArray;
   }
 
-  @Override
-  public int hashCode() {
-    return Arrays.hashCode(this.TestArray);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof TestArray)) {
-      return false;
-    }
-
-    TestArray other = (TestArray) object;
-    return Arrays.equals(this.TestArray, other.TestArray);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/const.x/TestArray2.java
+++ b/spec/output/generator_spec_java/const.x/TestArray2.java
@@ -25,9 +25,9 @@ import static MyXDR.Constants.*;
 public class TestArray2 implements XdrElement {
   private Integer[] TestArray2;
   public static void encode(XdrDataOutputStream stream, TestArray2  encodedTestArray2) throws IOException {
-    int TestArray2size = encodedTestArray2.getTestArray2().length;
-    stream.writeInt(TestArray2size);
-    for (int i = 0; i < TestArray2size; i++) {
+    int TestArray2Size = encodedTestArray2.getTestArray2().length;
+    stream.writeInt(TestArray2Size);
+    for (int i = 0; i < TestArray2Size; i++) {
       stream.writeInt(encodedTestArray2.TestArray2[i]);
     }
   }
@@ -37,9 +37,9 @@ public class TestArray2 implements XdrElement {
   }
   public static TestArray2 decode(XdrDataInputStream stream) throws IOException {
     TestArray2 decodedTestArray2 = new TestArray2();
-    int TestArray2size = stream.readInt();
-    decodedTestArray2.TestArray2 = new Integer[TestArray2size];
-    for (int i = 0; i < TestArray2size; i++) {
+    int TestArray2Size = stream.readInt();
+    decodedTestArray2.TestArray2 = new Integer[TestArray2Size];
+    for (int i = 0; i < TestArray2Size; i++) {
       decodedTestArray2.TestArray2[i] = stream.readInt();
     }
     return decodedTestArray2;

--- a/spec/output/generator_spec_java/const.x/TestArray2.java
+++ b/spec/output/generator_spec_java/const.x/TestArray2.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Arrays;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * TestArray2's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Arrays;
  * typedef int TestArray2&lt;FOO&gt;;
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class TestArray2 implements XdrElement {
   private Integer[] TestArray2;
-
-  public TestArray2() {}
-
-  public TestArray2(Integer[] TestArray2) {
-    this.TestArray2 = TestArray2;
-  }
-
-  public Integer[] getTestArray2() {
-    return this.TestArray2;
-  }
-
-  public void setTestArray2(Integer[] value) {
-    this.TestArray2 = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, TestArray2  encodedTestArray2) throws IOException {
     int TestArray2size = encodedTestArray2.getTestArray2().length;
     stream.writeInt(TestArray2size);
@@ -55,20 +45,6 @@ public class TestArray2 implements XdrElement {
     return decodedTestArray2;
   }
 
-  @Override
-  public int hashCode() {
-    return Arrays.hashCode(this.TestArray2);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof TestArray2)) {
-      return false;
-    }
-
-    TestArray2 other = (TestArray2) object;
-    return Arrays.equals(this.TestArray2, other.TestArray2);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/const.x/XdrString.java
+++ b/spec/output/generator_spec_java/const.x/XdrString.java
@@ -4,90 +4,72 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
-import java.nio.charset.Charset;
-import java.util.Arrays;
+import java.nio.charset.StandardCharsets;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
+@Value
 public class XdrString implements XdrElement {
-    private byte[] bytes;
+  byte[] bytes;
 
-    public XdrString(byte[] bytes) {
-        this.bytes = bytes;
-    }
+  public XdrString(byte[] bytes) {
+    this.bytes = bytes;
+  }
 
-    public XdrString(String text) {
-        this.bytes = text.getBytes(Charset.forName("UTF-8"));
-    }
+  public XdrString(String text) {
+    this.bytes = text.getBytes(StandardCharsets.UTF_8);
+  }
 
-    @Override
-    public void encode(XdrDataOutputStream stream) throws IOException {
-        stream.writeInt(this.bytes.length);
-        stream.write(this.bytes, 0, this.bytes.length);
-    }
+  @Override
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    stream.writeInt(this.bytes.length);
+    stream.write(this.bytes, 0, this.bytes.length);
+  }
 
-    public static XdrString decode(XdrDataInputStream stream, int maxSize) throws IOException {
-        int size = stream.readInt();
-        if (size > maxSize) {
-            throw new InvalidClassException("String length "+size+" exceeds max size "+maxSize);
-        }
-        byte[] bytes = new byte[size];
-        stream.read(bytes);
-        return new XdrString(bytes);
+  public static XdrString decode(XdrDataInputStream stream, int maxSize) throws IOException {
+    int size = stream.readInt();
+    if (size > maxSize) {
+      throw new InvalidClassException("String length " + size + " exceeds max size " + maxSize);
     }
+    byte[] bytes = new byte[size];
+    stream.read(bytes);
+    return new XdrString(bytes);
+  }
 
-    public byte[] getBytes() {
-        return this.bytes;
-    }
+  @Override
+  public String toXdrBase64() throws IOException {
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
+  }
 
-    @Override
-    public String toXdrBase64() throws IOException {
-        return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-    }
-    
-    @Override
-    public byte[] toXdrByteArray() throws IOException {
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-        encode(xdrDataOutputStream);
-        return byteArrayOutputStream.toByteArray();
-    }
-    
-    public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64Factory.getInstance().decode(xdr);
-        return fromXdrByteArray(bytes, maxSize);
-    }
-    
-    public static XdrString fromXdrBase64(String xdr) throws IOException {
-        return fromXdrBase64(xdr, Integer.MAX_VALUE);
-    }
-    
-    public static XdrString fromXdrByteArray(byte[] xdr, int maxSize) throws IOException {
-        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
-        XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
-        return decode(xdrDataInputStream, maxSize);
-    }
-    
-    public static XdrString fromXdrByteArray(byte[] xdr) throws IOException {
-        return fromXdrByteArray(xdr, Integer.MAX_VALUE);
-    }
+  @Override
+  public byte[] toXdrByteArray() throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
+    encode(xdrDataOutputStream);
+    return byteArrayOutputStream.toByteArray();
+  }
 
-    @Override
-    public int hashCode() {
-        return Arrays.hashCode(this.bytes);
-    }
+  public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
+    return fromXdrByteArray(bytes, maxSize);
+  }
 
-    @Override
-    public boolean equals(Object object) {
-        if (object == null || !(object instanceof XdrString)) {
-          return false;
-        }
+  public static XdrString fromXdrBase64(String xdr) throws IOException {
+    return fromXdrBase64(xdr, Integer.MAX_VALUE);
+  }
 
-        XdrString other = (XdrString) object;
-        return Arrays.equals(this.bytes, other.bytes);
-    }
+  public static XdrString fromXdrByteArray(byte[] xdr, int maxSize) throws IOException {
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
+    XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
+    return decode(xdrDataInputStream, maxSize);
+  }
 
-    @Override
-    public String toString() {
-        return new String(bytes, Charset.forName("UTF-8"));
-    }
+  public static XdrString fromXdrByteArray(byte[] xdr) throws IOException {
+    return fromXdrByteArray(xdr, Integer.MAX_VALUE);
+  }
+
+  @Override
+  public String toString() {
+    return new String(bytes, StandardCharsets.UTF_8);
+  }
 }

--- a/spec/output/generator_spec_java/const.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/const.x/XdrUnsignedHyperInteger.java
@@ -1,10 +1,10 @@
-package org.stellar.sdk.xdr;
+package MyXDR;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Objects;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
 /**
@@ -13,10 +13,11 @@ import org.stellar.sdk.Base64Factory;
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc4506#section-4.5">XDR: External Data
  *     Representation Standard</a>
  */
+@Value
 public class XdrUnsignedHyperInteger implements XdrElement {
   public static final BigInteger MAX_VALUE = new BigInteger("18446744073709551615");
   public static final BigInteger MIN_VALUE = BigInteger.ZERO;
-  private final BigInteger number;
+  BigInteger number;
 
   public XdrUnsignedHyperInteger(BigInteger number) {
     if (number.compareTo(MIN_VALUE) < 0 || number.compareTo(MAX_VALUE) > 0) {
@@ -55,10 +56,6 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     return paddedBytes;
   }
 
-  public BigInteger getNumber() {
-    return number;
-  }
-
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());
@@ -81,24 +78,5 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.number);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof XdrUnsignedHyperInteger)) {
-      return false;
-    }
-
-    XdrUnsignedHyperInteger other = (XdrUnsignedHyperInteger) object;
-    return Objects.equals(this.number, other.number);
-  }
-
-  public String toString() {
-    return "XdrUnsignedInteger(number=" + this.getNumber() + ")";
   }
 }

--- a/spec/output/generator_spec_java/const.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/const.x/XdrUnsignedInteger.java
@@ -1,9 +1,9 @@
-package org.stellar.sdk.xdr;
+package MyXDR;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Objects;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
 /**
@@ -12,10 +12,11 @@ import org.stellar.sdk.Base64Factory;
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc4506#section-4.2">XDR: External Data
  *     Representation Standard</a>
  */
+@Value
 public class XdrUnsignedInteger implements XdrElement {
   public static final long MAX_VALUE = (1L << 32) - 1;
   public static final long MIN_VALUE = 0;
-  private final Long number;
+  Long number;
 
   public XdrUnsignedInteger(Long number) {
     if (number < MIN_VALUE || number > MAX_VALUE) {
@@ -30,10 +31,6 @@ public class XdrUnsignedInteger implements XdrElement {
           "number must be greater than or equal to 0 if you want to construct it from Integer");
     }
     this.number = number.longValue();
-  }
-
-  public Long getNumber() {
-    return number;
   }
 
   public static XdrUnsignedInteger decode(XdrDataInputStream stream) throws IOException {
@@ -69,24 +66,5 @@ public class XdrUnsignedInteger implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.number);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof XdrUnsignedInteger)) {
-      return false;
-    }
-
-    XdrUnsignedInteger other = (XdrUnsignedInteger) object;
-    return Objects.equals(this.number, other.number);
-  }
-
-  public String toString() {
-    return "XdrUnsignedInteger(number=" + this.getNumber() + ")";
   }
 }

--- a/spec/output/generator_spec_java/enum.x/Color.java
+++ b/spec/output/generator_spec_java/enum.x/Color.java
@@ -5,7 +5,6 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -23,16 +22,16 @@ import java.io.ByteArrayOutputStream;
 public enum Color implements XdrElement {
   RED(0),
   GREEN(1),
-  BLUE(2),
-  ;
-  private int mValue;
+  BLUE(2);
+
+  private final int value;
 
   Color(int value) {
-      mValue = value;
+      this.value = value;
   }
 
   public int getValue() {
-      return mValue;
+      return value;
   }
 
   public static Color decode(XdrDataInputStream stream) throws IOException {

--- a/spec/output/generator_spec_java/enum.x/Color2.java
+++ b/spec/output/generator_spec_java/enum.x/Color2.java
@@ -5,7 +5,6 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -23,16 +22,16 @@ import java.io.ByteArrayOutputStream;
 public enum Color2 implements XdrElement {
   RED2(0),
   GREEN2(1),
-  BLUE2(2),
-  ;
-  private int mValue;
+  BLUE2(2);
+
+  private final int value;
 
   Color2(int value) {
-      mValue = value;
+      this.value = value;
   }
 
   public int getValue() {
-      return mValue;
+      return value;
   }
 
   public static Color2 decode(XdrDataInputStream stream) throws IOException {

--- a/spec/output/generator_spec_java/enum.x/MessageType.java
+++ b/spec/output/generator_spec_java/enum.x/MessageType.java
@@ -5,7 +5,6 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -52,16 +51,16 @@ public enum MessageType implements XdrElement {
   JSON_TRANSACTION(10),
   GET_FBA_QUORUMSET(11),
   FBA_QUORUMSET(12),
-  FBA_MESSAGE(13),
-  ;
-  private int mValue;
+  FBA_MESSAGE(13);
+
+  private final int value;
 
   MessageType(int value) {
-      mValue = value;
+      this.value = value;
   }
 
   public int getValue() {
-      return mValue;
+      return value;
   }
 
   public static MessageType decode(XdrDataInputStream stream) throws IOException {

--- a/spec/output/generator_spec_java/enum.x/XdrString.java
+++ b/spec/output/generator_spec_java/enum.x/XdrString.java
@@ -4,90 +4,72 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
-import java.nio.charset.Charset;
-import java.util.Arrays;
+import java.nio.charset.StandardCharsets;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
+@Value
 public class XdrString implements XdrElement {
-    private byte[] bytes;
+  byte[] bytes;
 
-    public XdrString(byte[] bytes) {
-        this.bytes = bytes;
-    }
+  public XdrString(byte[] bytes) {
+    this.bytes = bytes;
+  }
 
-    public XdrString(String text) {
-        this.bytes = text.getBytes(Charset.forName("UTF-8"));
-    }
+  public XdrString(String text) {
+    this.bytes = text.getBytes(StandardCharsets.UTF_8);
+  }
 
-    @Override
-    public void encode(XdrDataOutputStream stream) throws IOException {
-        stream.writeInt(this.bytes.length);
-        stream.write(this.bytes, 0, this.bytes.length);
-    }
+  @Override
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    stream.writeInt(this.bytes.length);
+    stream.write(this.bytes, 0, this.bytes.length);
+  }
 
-    public static XdrString decode(XdrDataInputStream stream, int maxSize) throws IOException {
-        int size = stream.readInt();
-        if (size > maxSize) {
-            throw new InvalidClassException("String length "+size+" exceeds max size "+maxSize);
-        }
-        byte[] bytes = new byte[size];
-        stream.read(bytes);
-        return new XdrString(bytes);
+  public static XdrString decode(XdrDataInputStream stream, int maxSize) throws IOException {
+    int size = stream.readInt();
+    if (size > maxSize) {
+      throw new InvalidClassException("String length " + size + " exceeds max size " + maxSize);
     }
+    byte[] bytes = new byte[size];
+    stream.read(bytes);
+    return new XdrString(bytes);
+  }
 
-    public byte[] getBytes() {
-        return this.bytes;
-    }
+  @Override
+  public String toXdrBase64() throws IOException {
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
+  }
 
-    @Override
-    public String toXdrBase64() throws IOException {
-        return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-    }
-    
-    @Override
-    public byte[] toXdrByteArray() throws IOException {
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-        encode(xdrDataOutputStream);
-        return byteArrayOutputStream.toByteArray();
-    }
-    
-    public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64Factory.getInstance().decode(xdr);
-        return fromXdrByteArray(bytes, maxSize);
-    }
-    
-    public static XdrString fromXdrBase64(String xdr) throws IOException {
-        return fromXdrBase64(xdr, Integer.MAX_VALUE);
-    }
-    
-    public static XdrString fromXdrByteArray(byte[] xdr, int maxSize) throws IOException {
-        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
-        XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
-        return decode(xdrDataInputStream, maxSize);
-    }
-    
-    public static XdrString fromXdrByteArray(byte[] xdr) throws IOException {
-        return fromXdrByteArray(xdr, Integer.MAX_VALUE);
-    }
+  @Override
+  public byte[] toXdrByteArray() throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
+    encode(xdrDataOutputStream);
+    return byteArrayOutputStream.toByteArray();
+  }
 
-    @Override
-    public int hashCode() {
-        return Arrays.hashCode(this.bytes);
-    }
+  public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
+    return fromXdrByteArray(bytes, maxSize);
+  }
 
-    @Override
-    public boolean equals(Object object) {
-        if (object == null || !(object instanceof XdrString)) {
-          return false;
-        }
+  public static XdrString fromXdrBase64(String xdr) throws IOException {
+    return fromXdrBase64(xdr, Integer.MAX_VALUE);
+  }
 
-        XdrString other = (XdrString) object;
-        return Arrays.equals(this.bytes, other.bytes);
-    }
+  public static XdrString fromXdrByteArray(byte[] xdr, int maxSize) throws IOException {
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
+    XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
+    return decode(xdrDataInputStream, maxSize);
+  }
 
-    @Override
-    public String toString() {
-        return new String(bytes, Charset.forName("UTF-8"));
-    }
+  public static XdrString fromXdrByteArray(byte[] xdr) throws IOException {
+    return fromXdrByteArray(xdr, Integer.MAX_VALUE);
+  }
+
+  @Override
+  public String toString() {
+    return new String(bytes, StandardCharsets.UTF_8);
+  }
 }

--- a/spec/output/generator_spec_java/enum.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/enum.x/XdrUnsignedHyperInteger.java
@@ -1,10 +1,10 @@
-package org.stellar.sdk.xdr;
+package MyXDR;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Objects;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
 /**
@@ -13,10 +13,11 @@ import org.stellar.sdk.Base64Factory;
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc4506#section-4.5">XDR: External Data
  *     Representation Standard</a>
  */
+@Value
 public class XdrUnsignedHyperInteger implements XdrElement {
   public static final BigInteger MAX_VALUE = new BigInteger("18446744073709551615");
   public static final BigInteger MIN_VALUE = BigInteger.ZERO;
-  private final BigInteger number;
+  BigInteger number;
 
   public XdrUnsignedHyperInteger(BigInteger number) {
     if (number.compareTo(MIN_VALUE) < 0 || number.compareTo(MAX_VALUE) > 0) {
@@ -55,10 +56,6 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     return paddedBytes;
   }
 
-  public BigInteger getNumber() {
-    return number;
-  }
-
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());
@@ -81,24 +78,5 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.number);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof XdrUnsignedHyperInteger)) {
-      return false;
-    }
-
-    XdrUnsignedHyperInteger other = (XdrUnsignedHyperInteger) object;
-    return Objects.equals(this.number, other.number);
-  }
-
-  public String toString() {
-    return "XdrUnsignedInteger(number=" + this.getNumber() + ")";
   }
 }

--- a/spec/output/generator_spec_java/enum.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/enum.x/XdrUnsignedInteger.java
@@ -1,9 +1,9 @@
-package org.stellar.sdk.xdr;
+package MyXDR;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Objects;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
 /**
@@ -12,10 +12,11 @@ import org.stellar.sdk.Base64Factory;
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc4506#section-4.2">XDR: External Data
  *     Representation Standard</a>
  */
+@Value
 public class XdrUnsignedInteger implements XdrElement {
   public static final long MAX_VALUE = (1L << 32) - 1;
   public static final long MIN_VALUE = 0;
-  private final Long number;
+  Long number;
 
   public XdrUnsignedInteger(Long number) {
     if (number < MIN_VALUE || number > MAX_VALUE) {
@@ -30,10 +31,6 @@ public class XdrUnsignedInteger implements XdrElement {
           "number must be greater than or equal to 0 if you want to construct it from Integer");
     }
     this.number = number.longValue();
-  }
-
-  public Long getNumber() {
-    return number;
   }
 
   public static XdrUnsignedInteger decode(XdrDataInputStream stream) throws IOException {
@@ -69,24 +66,5 @@ public class XdrUnsignedInteger implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.number);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof XdrUnsignedInteger)) {
-      return false;
-    }
-
-    XdrUnsignedInteger other = (XdrUnsignedInteger) object;
-    return Objects.equals(this.number, other.number);
-  }
-
-  public String toString() {
-    return "XdrUnsignedInteger(number=" + this.getNumber() + ")";
   }
 }

--- a/spec/output/generator_spec_java/nesting.x/Foo.java
+++ b/spec/output/generator_spec_java/nesting.x/Foo.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Objects;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * Foo's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Objects;
  * typedef int Foo;
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Foo implements XdrElement {
   private Integer Foo;
-
-  public Foo() {}
-
-  public Foo(Integer Foo) {
-    this.Foo = Foo;
-  }
-
-  public Integer getFoo() {
-    return this.Foo;
-  }
-
-  public void setFoo(Integer value) {
-    this.Foo = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, Foo  encodedFoo) throws IOException {
     stream.writeInt(encodedFoo.Foo);
   }
@@ -47,20 +37,6 @@ public class Foo implements XdrElement {
     return decodedFoo;
   }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.Foo);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof Foo)) {
-      return false;
-    }
-
-    Foo other = (Foo) object;
-    return Objects.equals(this.Foo, other.Foo);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/nesting.x/MyUnion.java
+++ b/spec/output/generator_spec_java/nesting.x/MyUnion.java
@@ -5,11 +5,14 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Objects;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import static MyXDR.Constants.*;
 
 /**
  * MyUnion's original definition in the XDR file is:
@@ -32,58 +35,14 @@ import java.util.Objects;
  * };
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
 public class MyUnion implements XdrElement {
-  public MyUnion () {}
-  UnionKey type;
-  public UnionKey getDiscriminant() {
-    return this.type;
-  }
-  public void setDiscriminant(UnionKey value) {
-    this.type = value;
-  }
+  private UnionKey discriminant;
   private MyUnionOne one;
-  public MyUnionOne getOne() {
-    return this.one;
-  }
-  public void setOne(MyUnionOne value) {
-    this.one = value;
-  }
   private MyUnionTwo two;
-  public MyUnionTwo getTwo() {
-    return this.two;
-  }
-  public void setTwo(MyUnionTwo value) {
-    this.two = value;
-  }
-
-  public static final class Builder {
-    private UnionKey discriminant;
-    private MyUnionOne one;
-    private MyUnionTwo two;
-
-    public Builder discriminant(UnionKey discriminant) {
-      this.discriminant = discriminant;
-      return this;
-    }
-
-    public Builder one(MyUnionOne one) {
-      this.one = one;
-      return this;
-    }
-
-    public Builder two(MyUnionTwo two) {
-      this.two = two;
-      return this;
-    }
-
-    public MyUnion build() {
-      MyUnion val = new MyUnion();
-      val.setDiscriminant(discriminant);
-      val.setOne(this.one);
-      val.setTwo(this.two);
-      return val;
-    }
-  }
 
   public static void encode(XdrDataOutputStream stream, MyUnion encodedMyUnion) throws IOException {
   //Xdrgen::AST::Identifier
@@ -120,19 +79,6 @@ public class MyUnion implements XdrElement {
     return decodedMyUnion;
   }
   @Override
-  public int hashCode() {
-    return Objects.hash(this.one, this.two, this.type);
-  }
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof MyUnion)) {
-      return false;
-    }
-
-    MyUnion other = (MyUnion) object;
-    return Objects.equals(this.one, other.one) && Objects.equals(this.two, other.two) && Objects.equals(this.type, other.type);
-  }
-  @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
@@ -164,15 +110,12 @@ public class MyUnion implements XdrElement {
    *         }
    * </pre>
    */
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder(toBuilder = true)
   public static class MyUnionOne implements XdrElement {
-    public MyUnionOne () {}
     private Integer someInt;
-    public Integer getSomeInt() {
-      return this.someInt;
-    }
-    public void setSomeInt(Integer value) {
-      this.someInt = value;
-    }
     public static void encode(XdrDataOutputStream stream, MyUnionOne encodedMyUnionOne) throws IOException{
       stream.writeInt(encodedMyUnionOne.someInt);
     }
@@ -184,20 +127,6 @@ public class MyUnion implements XdrElement {
       decodedMyUnionOne.someInt = stream.readInt();
       return decodedMyUnionOne;
     }
-    @Override
-    public int hashCode() {
-      return Objects.hash(this.someInt);
-    }
-    @Override
-    public boolean equals(Object object) {
-      if (!(object instanceof MyUnionOne)) {
-        return false;
-      }
-
-      MyUnionOne other = (MyUnionOne) object;
-      return Objects.equals(this.someInt, other.someInt);
-    }
-
     @Override
     public String toXdrBase64() throws IOException {
       return Base64Factory.getInstance().encodeToString(toXdrByteArray());
@@ -221,20 +150,6 @@ public class MyUnion implements XdrElement {
       XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
       return decode(xdrDataInputStream);
     }
-    public static final class Builder {
-      private Integer someInt;
-
-      public Builder someInt(Integer someInt) {
-        this.someInt = someInt;
-        return this;
-      }
-
-      public MyUnionOne build() {
-        MyUnionOne val = new MyUnionOne();
-        val.setSomeInt(this.someInt);
-        return val;
-      }
-    }
 
   }
   /**
@@ -246,22 +161,13 @@ public class MyUnion implements XdrElement {
    *         }
    * </pre>
    */
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder(toBuilder = true)
   public static class MyUnionTwo implements XdrElement {
-    public MyUnionTwo () {}
     private Integer someInt;
-    public Integer getSomeInt() {
-      return this.someInt;
-    }
-    public void setSomeInt(Integer value) {
-      this.someInt = value;
-    }
     private Foo foo;
-    public Foo getFoo() {
-      return this.foo;
-    }
-    public void setFoo(Foo value) {
-      this.foo = value;
-    }
     public static void encode(XdrDataOutputStream stream, MyUnionTwo encodedMyUnionTwo) throws IOException{
       stream.writeInt(encodedMyUnionTwo.someInt);
       Foo.encode(stream, encodedMyUnionTwo.foo);
@@ -275,20 +181,6 @@ public class MyUnion implements XdrElement {
       decodedMyUnionTwo.foo = Foo.decode(stream);
       return decodedMyUnionTwo;
     }
-    @Override
-    public int hashCode() {
-      return Objects.hash(this.someInt, this.foo);
-    }
-    @Override
-    public boolean equals(Object object) {
-      if (!(object instanceof MyUnionTwo)) {
-        return false;
-      }
-
-      MyUnionTwo other = (MyUnionTwo) object;
-      return Objects.equals(this.someInt, other.someInt) && Objects.equals(this.foo, other.foo);
-    }
-
     @Override
     public String toXdrBase64() throws IOException {
       return Base64Factory.getInstance().encodeToString(toXdrByteArray());
@@ -311,27 +203,6 @@ public class MyUnion implements XdrElement {
       ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
       XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
       return decode(xdrDataInputStream);
-    }
-    public static final class Builder {
-      private Integer someInt;
-      private Foo foo;
-
-      public Builder someInt(Integer someInt) {
-        this.someInt = someInt;
-        return this;
-      }
-
-      public Builder foo(Foo foo) {
-        this.foo = foo;
-        return this;
-      }
-
-      public MyUnionTwo build() {
-        MyUnionTwo val = new MyUnionTwo();
-        val.setSomeInt(this.someInt);
-        val.setFoo(this.foo);
-        return val;
-      }
     }
 
   }

--- a/spec/output/generator_spec_java/nesting.x/UnionKey.java
+++ b/spec/output/generator_spec_java/nesting.x/UnionKey.java
@@ -5,7 +5,6 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -23,16 +22,16 @@ import java.io.ByteArrayOutputStream;
 public enum UnionKey implements XdrElement {
   ONE(1),
   TWO(2),
-  OFFER(3),
-  ;
-  private int mValue;
+  OFFER(3);
+
+  private final int value;
 
   UnionKey(int value) {
-      mValue = value;
+      this.value = value;
   }
 
   public int getValue() {
-      return mValue;
+      return value;
   }
 
   public static UnionKey decode(XdrDataInputStream stream) throws IOException {

--- a/spec/output/generator_spec_java/nesting.x/XdrString.java
+++ b/spec/output/generator_spec_java/nesting.x/XdrString.java
@@ -4,90 +4,72 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
-import java.nio.charset.Charset;
-import java.util.Arrays;
+import java.nio.charset.StandardCharsets;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
+@Value
 public class XdrString implements XdrElement {
-    private byte[] bytes;
+  byte[] bytes;
 
-    public XdrString(byte[] bytes) {
-        this.bytes = bytes;
-    }
+  public XdrString(byte[] bytes) {
+    this.bytes = bytes;
+  }
 
-    public XdrString(String text) {
-        this.bytes = text.getBytes(Charset.forName("UTF-8"));
-    }
+  public XdrString(String text) {
+    this.bytes = text.getBytes(StandardCharsets.UTF_8);
+  }
 
-    @Override
-    public void encode(XdrDataOutputStream stream) throws IOException {
-        stream.writeInt(this.bytes.length);
-        stream.write(this.bytes, 0, this.bytes.length);
-    }
+  @Override
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    stream.writeInt(this.bytes.length);
+    stream.write(this.bytes, 0, this.bytes.length);
+  }
 
-    public static XdrString decode(XdrDataInputStream stream, int maxSize) throws IOException {
-        int size = stream.readInt();
-        if (size > maxSize) {
-            throw new InvalidClassException("String length "+size+" exceeds max size "+maxSize);
-        }
-        byte[] bytes = new byte[size];
-        stream.read(bytes);
-        return new XdrString(bytes);
+  public static XdrString decode(XdrDataInputStream stream, int maxSize) throws IOException {
+    int size = stream.readInt();
+    if (size > maxSize) {
+      throw new InvalidClassException("String length " + size + " exceeds max size " + maxSize);
     }
+    byte[] bytes = new byte[size];
+    stream.read(bytes);
+    return new XdrString(bytes);
+  }
 
-    public byte[] getBytes() {
-        return this.bytes;
-    }
+  @Override
+  public String toXdrBase64() throws IOException {
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
+  }
 
-    @Override
-    public String toXdrBase64() throws IOException {
-        return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-    }
-    
-    @Override
-    public byte[] toXdrByteArray() throws IOException {
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-        encode(xdrDataOutputStream);
-        return byteArrayOutputStream.toByteArray();
-    }
-    
-    public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64Factory.getInstance().decode(xdr);
-        return fromXdrByteArray(bytes, maxSize);
-    }
-    
-    public static XdrString fromXdrBase64(String xdr) throws IOException {
-        return fromXdrBase64(xdr, Integer.MAX_VALUE);
-    }
-    
-    public static XdrString fromXdrByteArray(byte[] xdr, int maxSize) throws IOException {
-        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
-        XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
-        return decode(xdrDataInputStream, maxSize);
-    }
-    
-    public static XdrString fromXdrByteArray(byte[] xdr) throws IOException {
-        return fromXdrByteArray(xdr, Integer.MAX_VALUE);
-    }
+  @Override
+  public byte[] toXdrByteArray() throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
+    encode(xdrDataOutputStream);
+    return byteArrayOutputStream.toByteArray();
+  }
 
-    @Override
-    public int hashCode() {
-        return Arrays.hashCode(this.bytes);
-    }
+  public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
+    return fromXdrByteArray(bytes, maxSize);
+  }
 
-    @Override
-    public boolean equals(Object object) {
-        if (object == null || !(object instanceof XdrString)) {
-          return false;
-        }
+  public static XdrString fromXdrBase64(String xdr) throws IOException {
+    return fromXdrBase64(xdr, Integer.MAX_VALUE);
+  }
 
-        XdrString other = (XdrString) object;
-        return Arrays.equals(this.bytes, other.bytes);
-    }
+  public static XdrString fromXdrByteArray(byte[] xdr, int maxSize) throws IOException {
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
+    XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
+    return decode(xdrDataInputStream, maxSize);
+  }
 
-    @Override
-    public String toString() {
-        return new String(bytes, Charset.forName("UTF-8"));
-    }
+  public static XdrString fromXdrByteArray(byte[] xdr) throws IOException {
+    return fromXdrByteArray(xdr, Integer.MAX_VALUE);
+  }
+
+  @Override
+  public String toString() {
+    return new String(bytes, StandardCharsets.UTF_8);
+  }
 }

--- a/spec/output/generator_spec_java/nesting.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/nesting.x/XdrUnsignedHyperInteger.java
@@ -1,10 +1,10 @@
-package org.stellar.sdk.xdr;
+package MyXDR;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Objects;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
 /**
@@ -13,10 +13,11 @@ import org.stellar.sdk.Base64Factory;
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc4506#section-4.5">XDR: External Data
  *     Representation Standard</a>
  */
+@Value
 public class XdrUnsignedHyperInteger implements XdrElement {
   public static final BigInteger MAX_VALUE = new BigInteger("18446744073709551615");
   public static final BigInteger MIN_VALUE = BigInteger.ZERO;
-  private final BigInteger number;
+  BigInteger number;
 
   public XdrUnsignedHyperInteger(BigInteger number) {
     if (number.compareTo(MIN_VALUE) < 0 || number.compareTo(MAX_VALUE) > 0) {
@@ -55,10 +56,6 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     return paddedBytes;
   }
 
-  public BigInteger getNumber() {
-    return number;
-  }
-
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());
@@ -81,24 +78,5 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.number);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof XdrUnsignedHyperInteger)) {
-      return false;
-    }
-
-    XdrUnsignedHyperInteger other = (XdrUnsignedHyperInteger) object;
-    return Objects.equals(this.number, other.number);
-  }
-
-  public String toString() {
-    return "XdrUnsignedInteger(number=" + this.getNumber() + ")";
   }
 }

--- a/spec/output/generator_spec_java/nesting.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/nesting.x/XdrUnsignedInteger.java
@@ -1,9 +1,9 @@
-package org.stellar.sdk.xdr;
+package MyXDR;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Objects;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
 /**
@@ -12,10 +12,11 @@ import org.stellar.sdk.Base64Factory;
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc4506#section-4.2">XDR: External Data
  *     Representation Standard</a>
  */
+@Value
 public class XdrUnsignedInteger implements XdrElement {
   public static final long MAX_VALUE = (1L << 32) - 1;
   public static final long MIN_VALUE = 0;
-  private final Long number;
+  Long number;
 
   public XdrUnsignedInteger(Long number) {
     if (number < MIN_VALUE || number > MAX_VALUE) {
@@ -30,10 +31,6 @@ public class XdrUnsignedInteger implements XdrElement {
           "number must be greater than or equal to 0 if you want to construct it from Integer");
     }
     this.number = number.longValue();
-  }
-
-  public Long getNumber() {
-    return number;
   }
 
   public static XdrUnsignedInteger decode(XdrDataInputStream stream) throws IOException {
@@ -69,24 +66,5 @@ public class XdrUnsignedInteger implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.number);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof XdrUnsignedInteger)) {
-      return false;
-    }
-
-    XdrUnsignedInteger other = (XdrUnsignedInteger) object;
-    return Objects.equals(this.number, other.number);
-  }
-
-  public String toString() {
-    return "XdrUnsignedInteger(number=" + this.getNumber() + ")";
   }
 }

--- a/spec/output/generator_spec_java/optional.x/Arr.java
+++ b/spec/output/generator_spec_java/optional.x/Arr.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Arrays;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * Arr's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Arrays;
  * typedef int Arr[2];
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Arr implements XdrElement {
   private Integer[] Arr;
-
-  public Arr() {}
-
-  public Arr(Integer[] Arr) {
-    this.Arr = Arr;
-  }
-
-  public Integer[] getArr() {
-    return this.Arr;
-  }
-
-  public void setArr(Integer[] value) {
-    this.Arr = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, Arr  encodedArr) throws IOException {
     int Arrsize = encodedArr.getArr().length;
     for (int i = 0; i < Arrsize; i++) {
@@ -54,20 +44,6 @@ public class Arr implements XdrElement {
     return decodedArr;
   }
 
-  @Override
-  public int hashCode() {
-    return Arrays.hashCode(this.Arr);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof Arr)) {
-      return false;
-    }
-
-    Arr other = (Arr) object;
-    return Arrays.equals(this.Arr, other.Arr);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/optional.x/Arr.java
+++ b/spec/output/generator_spec_java/optional.x/Arr.java
@@ -25,8 +25,8 @@ import static MyXDR.Constants.*;
 public class Arr implements XdrElement {
   private Integer[] Arr;
   public static void encode(XdrDataOutputStream stream, Arr  encodedArr) throws IOException {
-    int Arrsize = encodedArr.getArr().length;
-    for (int i = 0; i < Arrsize; i++) {
+    int ArrSize = encodedArr.getArr().length;
+    for (int i = 0; i < ArrSize; i++) {
       stream.writeInt(encodedArr.Arr[i]);
     }
   }
@@ -36,9 +36,9 @@ public class Arr implements XdrElement {
   }
   public static Arr decode(XdrDataInputStream stream) throws IOException {
     Arr decodedArr = new Arr();
-    int Arrsize = 2;
-    decodedArr.Arr = new Integer[Arrsize];
-    for (int i = 0; i < Arrsize; i++) {
+    int ArrSize = 2;
+    decodedArr.Arr = new Integer[ArrSize];
+    for (int i = 0; i < ArrSize; i++) {
       decodedArr.Arr[i] = stream.readInt();
     }
     return decodedArr;

--- a/spec/output/generator_spec_java/optional.x/HasOptions.java
+++ b/spec/output/generator_spec_java/optional.x/HasOptions.java
@@ -5,11 +5,14 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Objects;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import static MyXDR.Constants.*;
 
 /**
  * HasOptions's original definition in the XDR file is:
@@ -22,29 +25,14 @@ import java.util.Objects;
  * };
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
 public class HasOptions implements XdrElement {
-  public HasOptions () {}
   private Integer firstOption;
-  public Integer getFirstOption() {
-    return this.firstOption;
-  }
-  public void setFirstOption(Integer value) {
-    this.firstOption = value;
-  }
   private Integer secondOption;
-  public Integer getSecondOption() {
-    return this.secondOption;
-  }
-  public void setSecondOption(Integer value) {
-    this.secondOption = value;
-  }
   private Arr thirdOption;
-  public Arr getThirdOption() {
-    return this.thirdOption;
-  }
-  public void setThirdOption(Arr value) {
-    this.thirdOption = value;
-  }
   public static void encode(XdrDataOutputStream stream, HasOptions encodedHasOptions) throws IOException{
     if (encodedHasOptions.firstOption != null) {
     stream.writeInt(1);
@@ -85,20 +73,6 @@ public class HasOptions implements XdrElement {
     return decodedHasOptions;
   }
   @Override
-  public int hashCode() {
-    return Objects.hash(this.firstOption, this.secondOption, this.thirdOption);
-  }
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof HasOptions)) {
-      return false;
-    }
-
-    HasOptions other = (HasOptions) object;
-    return Objects.equals(this.firstOption, other.firstOption) && Objects.equals(this.secondOption, other.secondOption) && Objects.equals(this.thirdOption, other.thirdOption);
-  }
-
-  @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
@@ -120,33 +94,5 @@ public class HasOptions implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-  public static final class Builder {
-    private Integer firstOption;
-    private Integer secondOption;
-    private Arr thirdOption;
-
-    public Builder firstOption(Integer firstOption) {
-      this.firstOption = firstOption;
-      return this;
-    }
-
-    public Builder secondOption(Integer secondOption) {
-      this.secondOption = secondOption;
-      return this;
-    }
-
-    public Builder thirdOption(Arr thirdOption) {
-      this.thirdOption = thirdOption;
-      return this;
-    }
-
-    public HasOptions build() {
-      HasOptions val = new HasOptions();
-      val.setFirstOption(this.firstOption);
-      val.setSecondOption(this.secondOption);
-      val.setThirdOption(this.thirdOption);
-      return val;
-    }
   }
 }

--- a/spec/output/generator_spec_java/optional.x/XdrString.java
+++ b/spec/output/generator_spec_java/optional.x/XdrString.java
@@ -4,90 +4,72 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
-import java.nio.charset.Charset;
-import java.util.Arrays;
+import java.nio.charset.StandardCharsets;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
+@Value
 public class XdrString implements XdrElement {
-    private byte[] bytes;
+  byte[] bytes;
 
-    public XdrString(byte[] bytes) {
-        this.bytes = bytes;
-    }
+  public XdrString(byte[] bytes) {
+    this.bytes = bytes;
+  }
 
-    public XdrString(String text) {
-        this.bytes = text.getBytes(Charset.forName("UTF-8"));
-    }
+  public XdrString(String text) {
+    this.bytes = text.getBytes(StandardCharsets.UTF_8);
+  }
 
-    @Override
-    public void encode(XdrDataOutputStream stream) throws IOException {
-        stream.writeInt(this.bytes.length);
-        stream.write(this.bytes, 0, this.bytes.length);
-    }
+  @Override
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    stream.writeInt(this.bytes.length);
+    stream.write(this.bytes, 0, this.bytes.length);
+  }
 
-    public static XdrString decode(XdrDataInputStream stream, int maxSize) throws IOException {
-        int size = stream.readInt();
-        if (size > maxSize) {
-            throw new InvalidClassException("String length "+size+" exceeds max size "+maxSize);
-        }
-        byte[] bytes = new byte[size];
-        stream.read(bytes);
-        return new XdrString(bytes);
+  public static XdrString decode(XdrDataInputStream stream, int maxSize) throws IOException {
+    int size = stream.readInt();
+    if (size > maxSize) {
+      throw new InvalidClassException("String length " + size + " exceeds max size " + maxSize);
     }
+    byte[] bytes = new byte[size];
+    stream.read(bytes);
+    return new XdrString(bytes);
+  }
 
-    public byte[] getBytes() {
-        return this.bytes;
-    }
+  @Override
+  public String toXdrBase64() throws IOException {
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
+  }
 
-    @Override
-    public String toXdrBase64() throws IOException {
-        return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-    }
-    
-    @Override
-    public byte[] toXdrByteArray() throws IOException {
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-        encode(xdrDataOutputStream);
-        return byteArrayOutputStream.toByteArray();
-    }
-    
-    public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64Factory.getInstance().decode(xdr);
-        return fromXdrByteArray(bytes, maxSize);
-    }
-    
-    public static XdrString fromXdrBase64(String xdr) throws IOException {
-        return fromXdrBase64(xdr, Integer.MAX_VALUE);
-    }
-    
-    public static XdrString fromXdrByteArray(byte[] xdr, int maxSize) throws IOException {
-        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
-        XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
-        return decode(xdrDataInputStream, maxSize);
-    }
-    
-    public static XdrString fromXdrByteArray(byte[] xdr) throws IOException {
-        return fromXdrByteArray(xdr, Integer.MAX_VALUE);
-    }
+  @Override
+  public byte[] toXdrByteArray() throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
+    encode(xdrDataOutputStream);
+    return byteArrayOutputStream.toByteArray();
+  }
 
-    @Override
-    public int hashCode() {
-        return Arrays.hashCode(this.bytes);
-    }
+  public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
+    return fromXdrByteArray(bytes, maxSize);
+  }
 
-    @Override
-    public boolean equals(Object object) {
-        if (object == null || !(object instanceof XdrString)) {
-          return false;
-        }
+  public static XdrString fromXdrBase64(String xdr) throws IOException {
+    return fromXdrBase64(xdr, Integer.MAX_VALUE);
+  }
 
-        XdrString other = (XdrString) object;
-        return Arrays.equals(this.bytes, other.bytes);
-    }
+  public static XdrString fromXdrByteArray(byte[] xdr, int maxSize) throws IOException {
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
+    XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
+    return decode(xdrDataInputStream, maxSize);
+  }
 
-    @Override
-    public String toString() {
-        return new String(bytes, Charset.forName("UTF-8"));
-    }
+  public static XdrString fromXdrByteArray(byte[] xdr) throws IOException {
+    return fromXdrByteArray(xdr, Integer.MAX_VALUE);
+  }
+
+  @Override
+  public String toString() {
+    return new String(bytes, StandardCharsets.UTF_8);
+  }
 }

--- a/spec/output/generator_spec_java/optional.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/optional.x/XdrUnsignedHyperInteger.java
@@ -1,10 +1,10 @@
-package org.stellar.sdk.xdr;
+package MyXDR;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Objects;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
 /**
@@ -13,10 +13,11 @@ import org.stellar.sdk.Base64Factory;
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc4506#section-4.5">XDR: External Data
  *     Representation Standard</a>
  */
+@Value
 public class XdrUnsignedHyperInteger implements XdrElement {
   public static final BigInteger MAX_VALUE = new BigInteger("18446744073709551615");
   public static final BigInteger MIN_VALUE = BigInteger.ZERO;
-  private final BigInteger number;
+  BigInteger number;
 
   public XdrUnsignedHyperInteger(BigInteger number) {
     if (number.compareTo(MIN_VALUE) < 0 || number.compareTo(MAX_VALUE) > 0) {
@@ -55,10 +56,6 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     return paddedBytes;
   }
 
-  public BigInteger getNumber() {
-    return number;
-  }
-
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());
@@ -81,24 +78,5 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.number);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof XdrUnsignedHyperInteger)) {
-      return false;
-    }
-
-    XdrUnsignedHyperInteger other = (XdrUnsignedHyperInteger) object;
-    return Objects.equals(this.number, other.number);
-  }
-
-  public String toString() {
-    return "XdrUnsignedInteger(number=" + this.getNumber() + ")";
   }
 }

--- a/spec/output/generator_spec_java/optional.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/optional.x/XdrUnsignedInteger.java
@@ -1,9 +1,9 @@
-package org.stellar.sdk.xdr;
+package MyXDR;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Objects;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
 /**
@@ -12,10 +12,11 @@ import org.stellar.sdk.Base64Factory;
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc4506#section-4.2">XDR: External Data
  *     Representation Standard</a>
  */
+@Value
 public class XdrUnsignedInteger implements XdrElement {
   public static final long MAX_VALUE = (1L << 32) - 1;
   public static final long MIN_VALUE = 0;
-  private final Long number;
+  Long number;
 
   public XdrUnsignedInteger(Long number) {
     if (number < MIN_VALUE || number > MAX_VALUE) {
@@ -30,10 +31,6 @@ public class XdrUnsignedInteger implements XdrElement {
           "number must be greater than or equal to 0 if you want to construct it from Integer");
     }
     this.number = number.longValue();
-  }
-
-  public Long getNumber() {
-    return number;
   }
 
   public static XdrUnsignedInteger decode(XdrDataInputStream stream) throws IOException {
@@ -69,24 +66,5 @@ public class XdrUnsignedInteger implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.number);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof XdrUnsignedInteger)) {
-      return false;
-    }
-
-    XdrUnsignedInteger other = (XdrUnsignedInteger) object;
-    return Objects.equals(this.number, other.number);
-  }
-
-  public String toString() {
-    return "XdrUnsignedInteger(number=" + this.getNumber() + ")";
   }
 }

--- a/spec/output/generator_spec_java/struct.x/Int64.java
+++ b/spec/output/generator_spec_java/struct.x/Int64.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Objects;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * Int64's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Objects;
  * typedef hyper int64;
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Int64 implements XdrElement {
   private Long int64;
-
-  public Int64() {}
-
-  public Int64(Long int64) {
-    this.int64 = int64;
-  }
-
-  public Long getInt64() {
-    return this.int64;
-  }
-
-  public void setInt64(Long value) {
-    this.int64 = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, Int64  encodedInt64) throws IOException {
     stream.writeLong(encodedInt64.int64);
   }
@@ -47,20 +37,6 @@ public class Int64 implements XdrElement {
     return decodedInt64;
   }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.int64);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof Int64)) {
-      return false;
-    }
-
-    Int64 other = (Int64) object;
-    return Objects.equals(this.int64, other.int64);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/struct.x/MyStruct.java
+++ b/spec/output/generator_spec_java/struct.x/MyStruct.java
@@ -5,12 +5,14 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Objects;
-import java.util.Arrays;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import static MyXDR.Constants.*;
 
 /**
  * MyStruct's original definition in the XDR file is:
@@ -25,43 +27,16 @@ import java.util.Arrays;
  * };
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
 public class MyStruct implements XdrElement {
-  public MyStruct () {}
   private Integer someInt;
-  public Integer getSomeInt() {
-    return this.someInt;
-  }
-  public void setSomeInt(Integer value) {
-    this.someInt = value;
-  }
   private Int64 aBigInt;
-  public Int64 getABigInt() {
-    return this.aBigInt;
-  }
-  public void setABigInt(Int64 value) {
-    this.aBigInt = value;
-  }
   private byte[] someOpaque;
-  public byte[] getSomeOpaque() {
-    return this.someOpaque;
-  }
-  public void setSomeOpaque(byte[] value) {
-    this.someOpaque = value;
-  }
   private XdrString someString;
-  public XdrString getSomeString() {
-    return this.someString;
-  }
-  public void setSomeString(XdrString value) {
-    this.someString = value;
-  }
   private XdrString maxString;
-  public XdrString getMaxString() {
-    return this.maxString;
-  }
-  public void setMaxString(XdrString value) {
-    this.maxString = value;
-  }
   public static void encode(XdrDataOutputStream stream, MyStruct encodedMyStruct) throws IOException{
     stream.writeInt(encodedMyStruct.someInt);
     Int64.encode(stream, encodedMyStruct.aBigInt);
@@ -85,20 +60,6 @@ public class MyStruct implements XdrElement {
     return decodedMyStruct;
   }
   @Override
-  public int hashCode() {
-    return Objects.hash(this.someInt, this.aBigInt, Arrays.hashCode(this.someOpaque), this.someString, this.maxString);
-  }
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof MyStruct)) {
-      return false;
-    }
-
-    MyStruct other = (MyStruct) object;
-    return Objects.equals(this.someInt, other.someInt) && Objects.equals(this.aBigInt, other.aBigInt) && Arrays.equals(this.someOpaque, other.someOpaque) && Objects.equals(this.someString, other.someString) && Objects.equals(this.maxString, other.maxString);
-  }
-
-  @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
@@ -120,47 +81,5 @@ public class MyStruct implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-  public static final class Builder {
-    private Integer someInt;
-    private Int64 aBigInt;
-    private byte[] someOpaque;
-    private XdrString someString;
-    private XdrString maxString;
-
-    public Builder someInt(Integer someInt) {
-      this.someInt = someInt;
-      return this;
-    }
-
-    public Builder aBigInt(Int64 aBigInt) {
-      this.aBigInt = aBigInt;
-      return this;
-    }
-
-    public Builder someOpaque(byte[] someOpaque) {
-      this.someOpaque = someOpaque;
-      return this;
-    }
-
-    public Builder someString(XdrString someString) {
-      this.someString = someString;
-      return this;
-    }
-
-    public Builder maxString(XdrString maxString) {
-      this.maxString = maxString;
-      return this;
-    }
-
-    public MyStruct build() {
-      MyStruct val = new MyStruct();
-      val.setSomeInt(this.someInt);
-      val.setABigInt(this.aBigInt);
-      val.setSomeOpaque(this.someOpaque);
-      val.setSomeString(this.someString);
-      val.setMaxString(this.maxString);
-      return val;
-    }
   }
 }

--- a/spec/output/generator_spec_java/struct.x/MyStruct.java
+++ b/spec/output/generator_spec_java/struct.x/MyStruct.java
@@ -40,8 +40,8 @@ public class MyStruct implements XdrElement {
   public static void encode(XdrDataOutputStream stream, MyStruct encodedMyStruct) throws IOException{
     stream.writeInt(encodedMyStruct.someInt);
     Int64.encode(stream, encodedMyStruct.aBigInt);
-    int someOpaquesize = encodedMyStruct.someOpaque.length;
-    stream.write(encodedMyStruct.getSomeOpaque(), 0, someOpaquesize);
+    int someOpaqueSize = encodedMyStruct.someOpaque.length;
+    stream.write(encodedMyStruct.getSomeOpaque(), 0, someOpaqueSize);
     encodedMyStruct.someString.encode(stream);
     encodedMyStruct.maxString.encode(stream);
   }
@@ -52,9 +52,9 @@ public class MyStruct implements XdrElement {
     MyStruct decodedMyStruct = new MyStruct();
     decodedMyStruct.someInt = stream.readInt();
     decodedMyStruct.aBigInt = Int64.decode(stream);
-    int someOpaquesize = 10;
-    decodedMyStruct.someOpaque = new byte[someOpaquesize];
-    stream.read(decodedMyStruct.someOpaque, 0, someOpaquesize);
+    int someOpaqueSize = 10;
+    decodedMyStruct.someOpaque = new byte[someOpaqueSize];
+    stream.read(decodedMyStruct.someOpaque, 0, someOpaqueSize);
     decodedMyStruct.someString = XdrString.decode(stream, Integer.MAX_VALUE);
     decodedMyStruct.maxString = XdrString.decode(stream, 100);
     return decodedMyStruct;

--- a/spec/output/generator_spec_java/struct.x/XdrString.java
+++ b/spec/output/generator_spec_java/struct.x/XdrString.java
@@ -4,90 +4,72 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
-import java.nio.charset.Charset;
-import java.util.Arrays;
+import java.nio.charset.StandardCharsets;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
+@Value
 public class XdrString implements XdrElement {
-    private byte[] bytes;
+  byte[] bytes;
 
-    public XdrString(byte[] bytes) {
-        this.bytes = bytes;
-    }
+  public XdrString(byte[] bytes) {
+    this.bytes = bytes;
+  }
 
-    public XdrString(String text) {
-        this.bytes = text.getBytes(Charset.forName("UTF-8"));
-    }
+  public XdrString(String text) {
+    this.bytes = text.getBytes(StandardCharsets.UTF_8);
+  }
 
-    @Override
-    public void encode(XdrDataOutputStream stream) throws IOException {
-        stream.writeInt(this.bytes.length);
-        stream.write(this.bytes, 0, this.bytes.length);
-    }
+  @Override
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    stream.writeInt(this.bytes.length);
+    stream.write(this.bytes, 0, this.bytes.length);
+  }
 
-    public static XdrString decode(XdrDataInputStream stream, int maxSize) throws IOException {
-        int size = stream.readInt();
-        if (size > maxSize) {
-            throw new InvalidClassException("String length "+size+" exceeds max size "+maxSize);
-        }
-        byte[] bytes = new byte[size];
-        stream.read(bytes);
-        return new XdrString(bytes);
+  public static XdrString decode(XdrDataInputStream stream, int maxSize) throws IOException {
+    int size = stream.readInt();
+    if (size > maxSize) {
+      throw new InvalidClassException("String length " + size + " exceeds max size " + maxSize);
     }
+    byte[] bytes = new byte[size];
+    stream.read(bytes);
+    return new XdrString(bytes);
+  }
 
-    public byte[] getBytes() {
-        return this.bytes;
-    }
+  @Override
+  public String toXdrBase64() throws IOException {
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
+  }
 
-    @Override
-    public String toXdrBase64() throws IOException {
-        return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-    }
-    
-    @Override
-    public byte[] toXdrByteArray() throws IOException {
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-        encode(xdrDataOutputStream);
-        return byteArrayOutputStream.toByteArray();
-    }
-    
-    public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64Factory.getInstance().decode(xdr);
-        return fromXdrByteArray(bytes, maxSize);
-    }
-    
-    public static XdrString fromXdrBase64(String xdr) throws IOException {
-        return fromXdrBase64(xdr, Integer.MAX_VALUE);
-    }
-    
-    public static XdrString fromXdrByteArray(byte[] xdr, int maxSize) throws IOException {
-        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
-        XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
-        return decode(xdrDataInputStream, maxSize);
-    }
-    
-    public static XdrString fromXdrByteArray(byte[] xdr) throws IOException {
-        return fromXdrByteArray(xdr, Integer.MAX_VALUE);
-    }
+  @Override
+  public byte[] toXdrByteArray() throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
+    encode(xdrDataOutputStream);
+    return byteArrayOutputStream.toByteArray();
+  }
 
-    @Override
-    public int hashCode() {
-        return Arrays.hashCode(this.bytes);
-    }
+  public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
+    return fromXdrByteArray(bytes, maxSize);
+  }
 
-    @Override
-    public boolean equals(Object object) {
-        if (object == null || !(object instanceof XdrString)) {
-          return false;
-        }
+  public static XdrString fromXdrBase64(String xdr) throws IOException {
+    return fromXdrBase64(xdr, Integer.MAX_VALUE);
+  }
 
-        XdrString other = (XdrString) object;
-        return Arrays.equals(this.bytes, other.bytes);
-    }
+  public static XdrString fromXdrByteArray(byte[] xdr, int maxSize) throws IOException {
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
+    XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
+    return decode(xdrDataInputStream, maxSize);
+  }
 
-    @Override
-    public String toString() {
-        return new String(bytes, Charset.forName("UTF-8"));
-    }
+  public static XdrString fromXdrByteArray(byte[] xdr) throws IOException {
+    return fromXdrByteArray(xdr, Integer.MAX_VALUE);
+  }
+
+  @Override
+  public String toString() {
+    return new String(bytes, StandardCharsets.UTF_8);
+  }
 }

--- a/spec/output/generator_spec_java/struct.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/struct.x/XdrUnsignedHyperInteger.java
@@ -1,10 +1,10 @@
-package org.stellar.sdk.xdr;
+package MyXDR;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Objects;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
 /**
@@ -13,10 +13,11 @@ import org.stellar.sdk.Base64Factory;
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc4506#section-4.5">XDR: External Data
  *     Representation Standard</a>
  */
+@Value
 public class XdrUnsignedHyperInteger implements XdrElement {
   public static final BigInteger MAX_VALUE = new BigInteger("18446744073709551615");
   public static final BigInteger MIN_VALUE = BigInteger.ZERO;
-  private final BigInteger number;
+  BigInteger number;
 
   public XdrUnsignedHyperInteger(BigInteger number) {
     if (number.compareTo(MIN_VALUE) < 0 || number.compareTo(MAX_VALUE) > 0) {
@@ -55,10 +56,6 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     return paddedBytes;
   }
 
-  public BigInteger getNumber() {
-    return number;
-  }
-
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());
@@ -81,24 +78,5 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.number);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof XdrUnsignedHyperInteger)) {
-      return false;
-    }
-
-    XdrUnsignedHyperInteger other = (XdrUnsignedHyperInteger) object;
-    return Objects.equals(this.number, other.number);
-  }
-
-  public String toString() {
-    return "XdrUnsignedInteger(number=" + this.getNumber() + ")";
   }
 }

--- a/spec/output/generator_spec_java/struct.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/struct.x/XdrUnsignedInteger.java
@@ -1,9 +1,9 @@
-package org.stellar.sdk.xdr;
+package MyXDR;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Objects;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
 /**
@@ -12,10 +12,11 @@ import org.stellar.sdk.Base64Factory;
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc4506#section-4.2">XDR: External Data
  *     Representation Standard</a>
  */
+@Value
 public class XdrUnsignedInteger implements XdrElement {
   public static final long MAX_VALUE = (1L << 32) - 1;
   public static final long MIN_VALUE = 0;
-  private final Long number;
+  Long number;
 
   public XdrUnsignedInteger(Long number) {
     if (number < MIN_VALUE || number > MAX_VALUE) {
@@ -30,10 +31,6 @@ public class XdrUnsignedInteger implements XdrElement {
           "number must be greater than or equal to 0 if you want to construct it from Integer");
     }
     this.number = number.longValue();
-  }
-
-  public Long getNumber() {
-    return number;
   }
 
   public static XdrUnsignedInteger decode(XdrDataInputStream stream) throws IOException {
@@ -69,24 +66,5 @@ public class XdrUnsignedInteger implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.number);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof XdrUnsignedInteger)) {
-      return false;
-    }
-
-    XdrUnsignedInteger other = (XdrUnsignedInteger) object;
-    return Objects.equals(this.number, other.number);
-  }
-
-  public String toString() {
-    return "XdrUnsignedInteger(number=" + this.getNumber() + ")";
   }
 }

--- a/spec/output/generator_spec_java/test.x/Color.java
+++ b/spec/output/generator_spec_java/test.x/Color.java
@@ -5,7 +5,6 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -23,16 +22,16 @@ import java.io.ByteArrayOutputStream;
 public enum Color implements XdrElement {
   RED(0),
   BLUE(5),
-  GREEN(6),
-  ;
-  private int mValue;
+  GREEN(6);
+
+  private final int value;
 
   Color(int value) {
-      mValue = value;
+      this.value = value;
   }
 
   public int getValue() {
-      return mValue;
+      return value;
   }
 
   public static Color decode(XdrDataInputStream stream) throws IOException {

--- a/spec/output/generator_spec_java/test.x/HasStuff.java
+++ b/spec/output/generator_spec_java/test.x/HasStuff.java
@@ -5,11 +5,14 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Objects;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import static MyXDR.Constants.*;
 
 /**
  * HasStuff's original definition in the XDR file is:
@@ -20,15 +23,12 @@ import java.util.Objects;
  * };
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
 public class HasStuff implements XdrElement {
-  public HasStuff () {}
   private LotsOfMyStructs data;
-  public LotsOfMyStructs getData() {
-    return this.data;
-  }
-  public void setData(LotsOfMyStructs value) {
-    this.data = value;
-  }
   public static void encode(XdrDataOutputStream stream, HasStuff encodedHasStuff) throws IOException{
     LotsOfMyStructs.encode(stream, encodedHasStuff.data);
   }
@@ -40,20 +40,6 @@ public class HasStuff implements XdrElement {
     decodedHasStuff.data = LotsOfMyStructs.decode(stream);
     return decodedHasStuff;
   }
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.data);
-  }
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof HasStuff)) {
-      return false;
-    }
-
-    HasStuff other = (HasStuff) object;
-    return Objects.equals(this.data, other.data);
-  }
-
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());
@@ -76,19 +62,5 @@ public class HasStuff implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-  public static final class Builder {
-    private LotsOfMyStructs data;
-
-    public Builder data(LotsOfMyStructs data) {
-      this.data = data;
-      return this;
-    }
-
-    public HasStuff build() {
-      HasStuff val = new HasStuff();
-      val.setData(this.data);
-      return val;
-    }
   }
 }

--- a/spec/output/generator_spec_java/test.x/Hash.java
+++ b/spec/output/generator_spec_java/test.x/Hash.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Arrays;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * Hash's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Arrays;
  * typedef opaque Hash[32];
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Hash implements XdrElement {
   private byte[] Hash;
-
-  public Hash() {}
-
-  public Hash(byte[] Hash) {
-    this.Hash = Hash;
-  }
-
-  public byte[] getHash() {
-    return this.Hash;
-  }
-
-  public void setHash(byte[] value) {
-    this.Hash = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, Hash  encodedHash) throws IOException {
     int Hashsize = encodedHash.Hash.length;
     stream.write(encodedHash.getHash(), 0, Hashsize);
@@ -50,20 +40,6 @@ public class Hash implements XdrElement {
     return decodedHash;
   }
 
-  @Override
-  public int hashCode() {
-    return Arrays.hashCode(this.Hash);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof Hash)) {
-      return false;
-    }
-
-    Hash other = (Hash) object;
-    return Arrays.equals(this.Hash, other.Hash);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/test.x/Hash.java
+++ b/spec/output/generator_spec_java/test.x/Hash.java
@@ -25,8 +25,8 @@ import static MyXDR.Constants.*;
 public class Hash implements XdrElement {
   private byte[] Hash;
   public static void encode(XdrDataOutputStream stream, Hash  encodedHash) throws IOException {
-    int Hashsize = encodedHash.Hash.length;
-    stream.write(encodedHash.getHash(), 0, Hashsize);
+    int HashSize = encodedHash.Hash.length;
+    stream.write(encodedHash.getHash(), 0, HashSize);
   }
 
   public void encode(XdrDataOutputStream stream) throws IOException {
@@ -34,9 +34,9 @@ public class Hash implements XdrElement {
   }
   public static Hash decode(XdrDataInputStream stream) throws IOException {
     Hash decodedHash = new Hash();
-    int Hashsize = 32;
-    decodedHash.Hash = new byte[Hashsize];
-    stream.read(decodedHash.Hash, 0, Hashsize);
+    int HashSize = 32;
+    decodedHash.Hash = new byte[HashSize];
+    stream.read(decodedHash.Hash, 0, HashSize);
     return decodedHash;
   }
 

--- a/spec/output/generator_spec_java/test.x/Hashes1.java
+++ b/spec/output/generator_spec_java/test.x/Hashes1.java
@@ -25,8 +25,8 @@ import static MyXDR.Constants.*;
 public class Hashes1 implements XdrElement {
   private Hash[] Hashes1;
   public static void encode(XdrDataOutputStream stream, Hashes1  encodedHashes1) throws IOException {
-    int Hashes1size = encodedHashes1.getHashes1().length;
-    for (int i = 0; i < Hashes1size; i++) {
+    int Hashes1Size = encodedHashes1.getHashes1().length;
+    for (int i = 0; i < Hashes1Size; i++) {
       Hash.encode(stream, encodedHashes1.Hashes1[i]);
     }
   }
@@ -36,9 +36,9 @@ public class Hashes1 implements XdrElement {
   }
   public static Hashes1 decode(XdrDataInputStream stream) throws IOException {
     Hashes1 decodedHashes1 = new Hashes1();
-    int Hashes1size = 12;
-    decodedHashes1.Hashes1 = new Hash[Hashes1size];
-    for (int i = 0; i < Hashes1size; i++) {
+    int Hashes1Size = 12;
+    decodedHashes1.Hashes1 = new Hash[Hashes1Size];
+    for (int i = 0; i < Hashes1Size; i++) {
       decodedHashes1.Hashes1[i] = Hash.decode(stream);
     }
     return decodedHashes1;

--- a/spec/output/generator_spec_java/test.x/Hashes1.java
+++ b/spec/output/generator_spec_java/test.x/Hashes1.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Arrays;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * Hashes1's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Arrays;
  * typedef Hash Hashes1[12];
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Hashes1 implements XdrElement {
   private Hash[] Hashes1;
-
-  public Hashes1() {}
-
-  public Hashes1(Hash[] Hashes1) {
-    this.Hashes1 = Hashes1;
-  }
-
-  public Hash[] getHashes1() {
-    return this.Hashes1;
-  }
-
-  public void setHashes1(Hash[] value) {
-    this.Hashes1 = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, Hashes1  encodedHashes1) throws IOException {
     int Hashes1size = encodedHashes1.getHashes1().length;
     for (int i = 0; i < Hashes1size; i++) {
@@ -54,20 +44,6 @@ public class Hashes1 implements XdrElement {
     return decodedHashes1;
   }
 
-  @Override
-  public int hashCode() {
-    return Arrays.hashCode(this.Hashes1);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof Hashes1)) {
-      return false;
-    }
-
-    Hashes1 other = (Hashes1) object;
-    return Arrays.equals(this.Hashes1, other.Hashes1);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/test.x/Hashes2.java
+++ b/spec/output/generator_spec_java/test.x/Hashes2.java
@@ -25,9 +25,9 @@ import static MyXDR.Constants.*;
 public class Hashes2 implements XdrElement {
   private Hash[] Hashes2;
   public static void encode(XdrDataOutputStream stream, Hashes2  encodedHashes2) throws IOException {
-    int Hashes2size = encodedHashes2.getHashes2().length;
-    stream.writeInt(Hashes2size);
-    for (int i = 0; i < Hashes2size; i++) {
+    int Hashes2Size = encodedHashes2.getHashes2().length;
+    stream.writeInt(Hashes2Size);
+    for (int i = 0; i < Hashes2Size; i++) {
       Hash.encode(stream, encodedHashes2.Hashes2[i]);
     }
   }
@@ -37,9 +37,9 @@ public class Hashes2 implements XdrElement {
   }
   public static Hashes2 decode(XdrDataInputStream stream) throws IOException {
     Hashes2 decodedHashes2 = new Hashes2();
-    int Hashes2size = stream.readInt();
-    decodedHashes2.Hashes2 = new Hash[Hashes2size];
-    for (int i = 0; i < Hashes2size; i++) {
+    int Hashes2Size = stream.readInt();
+    decodedHashes2.Hashes2 = new Hash[Hashes2Size];
+    for (int i = 0; i < Hashes2Size; i++) {
       decodedHashes2.Hashes2[i] = Hash.decode(stream);
     }
     return decodedHashes2;

--- a/spec/output/generator_spec_java/test.x/Hashes2.java
+++ b/spec/output/generator_spec_java/test.x/Hashes2.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Arrays;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * Hashes2's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Arrays;
  * typedef Hash Hashes2&lt;12&gt;;
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Hashes2 implements XdrElement {
   private Hash[] Hashes2;
-
-  public Hashes2() {}
-
-  public Hashes2(Hash[] Hashes2) {
-    this.Hashes2 = Hashes2;
-  }
-
-  public Hash[] getHashes2() {
-    return this.Hashes2;
-  }
-
-  public void setHashes2(Hash[] value) {
-    this.Hashes2 = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, Hashes2  encodedHashes2) throws IOException {
     int Hashes2size = encodedHashes2.getHashes2().length;
     stream.writeInt(Hashes2size);
@@ -55,20 +45,6 @@ public class Hashes2 implements XdrElement {
     return decodedHashes2;
   }
 
-  @Override
-  public int hashCode() {
-    return Arrays.hashCode(this.Hashes2);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof Hashes2)) {
-      return false;
-    }
-
-    Hashes2 other = (Hashes2) object;
-    return Arrays.equals(this.Hashes2, other.Hashes2);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/test.x/Hashes3.java
+++ b/spec/output/generator_spec_java/test.x/Hashes3.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Arrays;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * Hashes3's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Arrays;
  * typedef Hash Hashes3&lt;&gt;;
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Hashes3 implements XdrElement {
   private Hash[] Hashes3;
-
-  public Hashes3() {}
-
-  public Hashes3(Hash[] Hashes3) {
-    this.Hashes3 = Hashes3;
-  }
-
-  public Hash[] getHashes3() {
-    return this.Hashes3;
-  }
-
-  public void setHashes3(Hash[] value) {
-    this.Hashes3 = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, Hashes3  encodedHashes3) throws IOException {
     int Hashes3size = encodedHashes3.getHashes3().length;
     stream.writeInt(Hashes3size);
@@ -55,20 +45,6 @@ public class Hashes3 implements XdrElement {
     return decodedHashes3;
   }
 
-  @Override
-  public int hashCode() {
-    return Arrays.hashCode(this.Hashes3);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof Hashes3)) {
-      return false;
-    }
-
-    Hashes3 other = (Hashes3) object;
-    return Arrays.equals(this.Hashes3, other.Hashes3);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/test.x/Hashes3.java
+++ b/spec/output/generator_spec_java/test.x/Hashes3.java
@@ -25,9 +25,9 @@ import static MyXDR.Constants.*;
 public class Hashes3 implements XdrElement {
   private Hash[] Hashes3;
   public static void encode(XdrDataOutputStream stream, Hashes3  encodedHashes3) throws IOException {
-    int Hashes3size = encodedHashes3.getHashes3().length;
-    stream.writeInt(Hashes3size);
-    for (int i = 0; i < Hashes3size; i++) {
+    int Hashes3Size = encodedHashes3.getHashes3().length;
+    stream.writeInt(Hashes3Size);
+    for (int i = 0; i < Hashes3Size; i++) {
       Hash.encode(stream, encodedHashes3.Hashes3[i]);
     }
   }
@@ -37,9 +37,9 @@ public class Hashes3 implements XdrElement {
   }
   public static Hashes3 decode(XdrDataInputStream stream) throws IOException {
     Hashes3 decodedHashes3 = new Hashes3();
-    int Hashes3size = stream.readInt();
-    decodedHashes3.Hashes3 = new Hash[Hashes3size];
-    for (int i = 0; i < Hashes3size; i++) {
+    int Hashes3Size = stream.readInt();
+    decodedHashes3.Hashes3 = new Hash[Hashes3Size];
+    for (int i = 0; i < Hashes3Size; i++) {
       decodedHashes3.Hashes3[i] = Hash.decode(stream);
     }
     return decodedHashes3;

--- a/spec/output/generator_spec_java/test.x/Int1.java
+++ b/spec/output/generator_spec_java/test.x/Int1.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Objects;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * Int1's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Objects;
  * typedef int             int1;
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Int1 implements XdrElement {
   private Integer int1;
-
-  public Int1() {}
-
-  public Int1(Integer int1) {
-    this.int1 = int1;
-  }
-
-  public Integer getInt1() {
-    return this.int1;
-  }
-
-  public void setInt1(Integer value) {
-    this.int1 = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, Int1  encodedInt1) throws IOException {
     stream.writeInt(encodedInt1.int1);
   }
@@ -47,20 +37,6 @@ public class Int1 implements XdrElement {
     return decodedInt1;
   }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.int1);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof Int1)) {
-      return false;
-    }
-
-    Int1 other = (Int1) object;
-    return Objects.equals(this.int1, other.int1);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/test.x/Int2.java
+++ b/spec/output/generator_spec_java/test.x/Int2.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Objects;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * Int2's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Objects;
  * typedef hyper           int2;
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Int2 implements XdrElement {
   private Long int2;
-
-  public Int2() {}
-
-  public Int2(Long int2) {
-    this.int2 = int2;
-  }
-
-  public Long getInt2() {
-    return this.int2;
-  }
-
-  public void setInt2(Long value) {
-    this.int2 = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, Int2  encodedInt2) throws IOException {
     stream.writeLong(encodedInt2.int2);
   }
@@ -47,20 +37,6 @@ public class Int2 implements XdrElement {
     return decodedInt2;
   }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.int2);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof Int2)) {
-      return false;
-    }
-
-    Int2 other = (Int2) object;
-    return Objects.equals(this.int2, other.int2);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/test.x/Int3.java
+++ b/spec/output/generator_spec_java/test.x/Int3.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Objects;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * Int3's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Objects;
  * typedef unsigned int    int3;
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Int3 implements XdrElement {
   private XdrUnsignedInteger int3;
-
-  public Int3() {}
-
-  public Int3(XdrUnsignedInteger int3) {
-    this.int3 = int3;
-  }
-
-  public XdrUnsignedInteger getInt3() {
-    return this.int3;
-  }
-
-  public void setInt3(XdrUnsignedInteger value) {
-    this.int3 = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, Int3  encodedInt3) throws IOException {
     encodedInt3.int3.encode(stream);
   }
@@ -47,20 +37,6 @@ public class Int3 implements XdrElement {
     return decodedInt3;
   }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.int3);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof Int3)) {
-      return false;
-    }
-
-    Int3 other = (Int3) object;
-    return Objects.equals(this.int3, other.int3);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/test.x/Int4.java
+++ b/spec/output/generator_spec_java/test.x/Int4.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Objects;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * Int4's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Objects;
  * typedef unsigned hyper  int4;
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Int4 implements XdrElement {
   private XdrUnsignedHyperInteger int4;
-
-  public Int4() {}
-
-  public Int4(XdrUnsignedHyperInteger int4) {
-    this.int4 = int4;
-  }
-
-  public XdrUnsignedHyperInteger getInt4() {
-    return this.int4;
-  }
-
-  public void setInt4(XdrUnsignedHyperInteger value) {
-    this.int4 = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, Int4  encodedInt4) throws IOException {
     encodedInt4.int4.encode(stream);
   }
@@ -47,20 +37,6 @@ public class Int4 implements XdrElement {
     return decodedInt4;
   }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.int4);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof Int4)) {
-      return false;
-    }
-
-    Int4 other = (Int4) object;
-    return Objects.equals(this.int4, other.int4);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/test.x/LotsOfMyStructs.java
+++ b/spec/output/generator_spec_java/test.x/LotsOfMyStructs.java
@@ -30,9 +30,9 @@ import static MyXDR.Constants.*;
 public class LotsOfMyStructs implements XdrElement {
   private MyStruct[] members;
   public static void encode(XdrDataOutputStream stream, LotsOfMyStructs encodedLotsOfMyStructs) throws IOException{
-    int memberssize = encodedLotsOfMyStructs.getMembers().length;
-    stream.writeInt(memberssize);
-    for (int i = 0; i < memberssize; i++) {
+    int membersSize = encodedLotsOfMyStructs.getMembers().length;
+    stream.writeInt(membersSize);
+    for (int i = 0; i < membersSize; i++) {
       MyStruct.encode(stream, encodedLotsOfMyStructs.members[i]);
     }
   }
@@ -41,9 +41,9 @@ public class LotsOfMyStructs implements XdrElement {
   }
   public static LotsOfMyStructs decode(XdrDataInputStream stream) throws IOException {
     LotsOfMyStructs decodedLotsOfMyStructs = new LotsOfMyStructs();
-    int memberssize = stream.readInt();
-    decodedLotsOfMyStructs.members = new MyStruct[memberssize];
-    for (int i = 0; i < memberssize; i++) {
+    int membersSize = stream.readInt();
+    decodedLotsOfMyStructs.members = new MyStruct[membersSize];
+    for (int i = 0; i < membersSize; i++) {
       decodedLotsOfMyStructs.members[i] = MyStruct.decode(stream);
     }
     return decodedLotsOfMyStructs;

--- a/spec/output/generator_spec_java/test.x/LotsOfMyStructs.java
+++ b/spec/output/generator_spec_java/test.x/LotsOfMyStructs.java
@@ -5,11 +5,14 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Arrays;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import static MyXDR.Constants.*;
 
 /**
  * LotsOfMyStructs's original definition in the XDR file is:
@@ -20,15 +23,12 @@ import java.util.Arrays;
  * };
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
 public class LotsOfMyStructs implements XdrElement {
-  public LotsOfMyStructs () {}
   private MyStruct[] members;
-  public MyStruct[] getMembers() {
-    return this.members;
-  }
-  public void setMembers(MyStruct[] value) {
-    this.members = value;
-  }
   public static void encode(XdrDataOutputStream stream, LotsOfMyStructs encodedLotsOfMyStructs) throws IOException{
     int memberssize = encodedLotsOfMyStructs.getMembers().length;
     stream.writeInt(memberssize);
@@ -48,20 +48,6 @@ public class LotsOfMyStructs implements XdrElement {
     }
     return decodedLotsOfMyStructs;
   }
-  @Override
-  public int hashCode() {
-    return Arrays.hashCode(this.members);
-  }
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof LotsOfMyStructs)) {
-      return false;
-    }
-
-    LotsOfMyStructs other = (LotsOfMyStructs) object;
-    return Arrays.equals(this.members, other.members);
-  }
-
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());
@@ -84,19 +70,5 @@ public class LotsOfMyStructs implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-  public static final class Builder {
-    private MyStruct[] members;
-
-    public Builder members(MyStruct[] members) {
-      this.members = members;
-      return this;
-    }
-
-    public LotsOfMyStructs build() {
-      LotsOfMyStructs val = new LotsOfMyStructs();
-      val.setMembers(this.members);
-      return val;
-    }
   }
 }

--- a/spec/output/generator_spec_java/test.x/MyStruct.java
+++ b/spec/output/generator_spec_java/test.x/MyStruct.java
@@ -5,11 +5,14 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Objects;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import static MyXDR.Constants.*;
 
 /**
  * MyStruct's original definition in the XDR file is:
@@ -26,57 +29,18 @@ import java.util.Objects;
  * };
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
 public class MyStruct implements XdrElement {
-  public MyStruct () {}
   private Uint512 field1;
-  public Uint512 getField1() {
-    return this.field1;
-  }
-  public void setField1(Uint512 value) {
-    this.field1 = value;
-  }
   private OptHash1 field2;
-  public OptHash1 getField2() {
-    return this.field2;
-  }
-  public void setField2(OptHash1 value) {
-    this.field2 = value;
-  }
   private Int1 field3;
-  public Int1 getField3() {
-    return this.field3;
-  }
-  public void setField3(Int1 value) {
-    this.field3 = value;
-  }
   private XdrUnsignedInteger field4;
-  public XdrUnsignedInteger getField4() {
-    return this.field4;
-  }
-  public void setField4(XdrUnsignedInteger value) {
-    this.field4 = value;
-  }
   private Float field5;
-  public Float getField5() {
-    return this.field5;
-  }
-  public void setField5(Float value) {
-    this.field5 = value;
-  }
   private Double field6;
-  public Double getField6() {
-    return this.field6;
-  }
-  public void setField6(Double value) {
-    this.field6 = value;
-  }
   private Boolean field7;
-  public Boolean getField7() {
-    return this.field7;
-  }
-  public void setField7(Boolean value) {
-    this.field7 = value;
-  }
   public static void encode(XdrDataOutputStream stream, MyStruct encodedMyStruct) throws IOException{
     Uint512.encode(stream, encodedMyStruct.field1);
     OptHash1.encode(stream, encodedMyStruct.field2);
@@ -101,20 +65,6 @@ public class MyStruct implements XdrElement {
     return decodedMyStruct;
   }
   @Override
-  public int hashCode() {
-    return Objects.hash(this.field1, this.field2, this.field3, this.field4, this.field5, this.field6, this.field7);
-  }
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof MyStruct)) {
-      return false;
-    }
-
-    MyStruct other = (MyStruct) object;
-    return Objects.equals(this.field1, other.field1) && Objects.equals(this.field2, other.field2) && Objects.equals(this.field3, other.field3) && Objects.equals(this.field4, other.field4) && Objects.equals(this.field5, other.field5) && Objects.equals(this.field6, other.field6) && Objects.equals(this.field7, other.field7);
-  }
-
-  @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());
   }
@@ -136,61 +86,5 @@ public class MyStruct implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-  public static final class Builder {
-    private Uint512 field1;
-    private OptHash1 field2;
-    private Int1 field3;
-    private XdrUnsignedInteger field4;
-    private Float field5;
-    private Double field6;
-    private Boolean field7;
-
-    public Builder field1(Uint512 field1) {
-      this.field1 = field1;
-      return this;
-    }
-
-    public Builder field2(OptHash1 field2) {
-      this.field2 = field2;
-      return this;
-    }
-
-    public Builder field3(Int1 field3) {
-      this.field3 = field3;
-      return this;
-    }
-
-    public Builder field4(XdrUnsignedInteger field4) {
-      this.field4 = field4;
-      return this;
-    }
-
-    public Builder field5(Float field5) {
-      this.field5 = field5;
-      return this;
-    }
-
-    public Builder field6(Double field6) {
-      this.field6 = field6;
-      return this;
-    }
-
-    public Builder field7(Boolean field7) {
-      this.field7 = field7;
-      return this;
-    }
-
-    public MyStruct build() {
-      MyStruct val = new MyStruct();
-      val.setField1(this.field1);
-      val.setField2(this.field2);
-      val.setField3(this.field3);
-      val.setField4(this.field4);
-      val.setField5(this.field5);
-      val.setField6(this.field6);
-      val.setField7(this.field7);
-      return val;
-    }
   }
 }

--- a/spec/output/generator_spec_java/test.x/Nester.java
+++ b/spec/output/generator_spec_java/test.x/Nester.java
@@ -5,11 +5,14 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Objects;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import static MyXDR.Constants.*;
 
 /**
  * Nester's original definition in the XDR file is:
@@ -36,29 +39,14 @@ import java.util.Objects;
  * };
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
 public class Nester implements XdrElement {
-  public Nester () {}
   private NesterNestedEnum nestedEnum;
-  public NesterNestedEnum getNestedEnum() {
-    return this.nestedEnum;
-  }
-  public void setNestedEnum(NesterNestedEnum value) {
-    this.nestedEnum = value;
-  }
   private NesterNestedStruct nestedStruct;
-  public NesterNestedStruct getNestedStruct() {
-    return this.nestedStruct;
-  }
-  public void setNestedStruct(NesterNestedStruct value) {
-    this.nestedStruct = value;
-  }
   private NesterNestedUnion nestedUnion;
-  public NesterNestedUnion getNestedUnion() {
-    return this.nestedUnion;
-  }
-  public void setNestedUnion(NesterNestedUnion value) {
-    this.nestedUnion = value;
-  }
   public static void encode(XdrDataOutputStream stream, Nester encodedNester) throws IOException{
     NesterNestedEnum.encode(stream, encodedNester.nestedEnum);
     NesterNestedStruct.encode(stream, encodedNester.nestedStruct);
@@ -74,20 +62,6 @@ public class Nester implements XdrElement {
     decodedNester.nestedUnion = NesterNestedUnion.decode(stream);
     return decodedNester;
   }
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.nestedEnum, this.nestedStruct, this.nestedUnion);
-  }
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof Nester)) {
-      return false;
-    }
-
-    Nester other = (Nester) object;
-    return Objects.equals(this.nestedEnum, other.nestedEnum) && Objects.equals(this.nestedStruct, other.nestedStruct) && Objects.equals(this.nestedUnion, other.nestedUnion);
-  }
-
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());
@@ -111,34 +85,6 @@ public class Nester implements XdrElement {
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
   }
-  public static final class Builder {
-    private NesterNestedEnum nestedEnum;
-    private NesterNestedStruct nestedStruct;
-    private NesterNestedUnion nestedUnion;
-
-    public Builder nestedEnum(NesterNestedEnum nestedEnum) {
-      this.nestedEnum = nestedEnum;
-      return this;
-    }
-
-    public Builder nestedStruct(NesterNestedStruct nestedStruct) {
-      this.nestedStruct = nestedStruct;
-      return this;
-    }
-
-    public Builder nestedUnion(NesterNestedUnion nestedUnion) {
-      this.nestedUnion = nestedUnion;
-      return this;
-    }
-
-    public Nester build() {
-      Nester val = new Nester();
-      val.setNestedEnum(this.nestedEnum);
-      val.setNestedStruct(this.nestedStruct);
-      val.setNestedUnion(this.nestedUnion);
-      return val;
-    }
-  }
 
   /**
    * NesterNestedEnum's original definition in the XDR file is:
@@ -151,16 +97,16 @@ public class Nester implements XdrElement {
    */
   public static enum NesterNestedEnum implements XdrElement {
     BLAH_1(0),
-    BLAH_2(1),
-    ;
-    private int mValue;
+    BLAH_2(1);
+
+    private final int value;
 
     NestedEnum(int value) {
-        mValue = value;
+        this.value = value;
     }
 
     public int getValue() {
-        return mValue;
+        return value;
     }
 
     public static NestedEnum decode(XdrDataInputStream stream) throws IOException {
@@ -213,15 +159,12 @@ public class Nester implements XdrElement {
    *   }
    * </pre>
    */
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder(toBuilder = true)
   public static class NesterNestedStruct implements XdrElement {
-    public NesterNestedStruct () {}
     private Integer blah;
-    public Integer getBlah() {
-      return this.blah;
-    }
-    public void setBlah(Integer value) {
-      this.blah = value;
-    }
     public static void encode(XdrDataOutputStream stream, NesterNestedStruct encodedNesterNestedStruct) throws IOException{
       stream.writeInt(encodedNesterNestedStruct.blah);
     }
@@ -233,20 +176,6 @@ public class Nester implements XdrElement {
       decodedNesterNestedStruct.blah = stream.readInt();
       return decodedNesterNestedStruct;
     }
-    @Override
-    public int hashCode() {
-      return Objects.hash(this.blah);
-    }
-    @Override
-    public boolean equals(Object object) {
-      if (!(object instanceof NesterNestedStruct)) {
-        return false;
-      }
-
-      NesterNestedStruct other = (NesterNestedStruct) object;
-      return Objects.equals(this.blah, other.blah);
-    }
-
     @Override
     public String toXdrBase64() throws IOException {
       return Base64Factory.getInstance().encodeToString(toXdrByteArray());
@@ -270,20 +199,6 @@ public class Nester implements XdrElement {
       XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
       return decode(xdrDataInputStream);
     }
-    public static final class Builder {
-      private Integer blah;
-
-      public Builder blah(Integer blah) {
-        this.blah = blah;
-        return this;
-      }
-
-      public NesterNestedStruct build() {
-        NesterNestedStruct val = new NesterNestedStruct();
-        val.setBlah(this.blah);
-        return val;
-      }
-    }
 
   }
   /**
@@ -297,44 +212,13 @@ public class Nester implements XdrElement {
    *   }
    * </pre>
    */
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder(toBuilder = true)
   public static class NesterNestedUnion implements XdrElement {
-    public NesterNestedUnion () {}
-    Color color;
-    public Color getDiscriminant() {
-      return this.color;
-    }
-    public void setDiscriminant(Color value) {
-      this.color = value;
-    }
+    private Color discriminant;
     private Integer blah2;
-    public Integer getBlah2() {
-      return this.blah2;
-    }
-    public void setBlah2(Integer value) {
-      this.blah2 = value;
-    }
-
-    public static final class Builder {
-      private Color discriminant;
-      private Integer blah2;
-
-      public Builder discriminant(Color discriminant) {
-        this.discriminant = discriminant;
-        return this;
-      }
-
-      public Builder blah2(Integer blah2) {
-        this.blah2 = blah2;
-        return this;
-      }
-
-      public NesterNestedUnion build() {
-        NesterNestedUnion val = new NesterNestedUnion();
-        val.setDiscriminant(discriminant);
-        val.setBlah2(this.blah2);
-        return val;
-      }
-    }
 
     public static void encode(XdrDataOutputStream stream, NesterNestedUnion encodedNesterNestedUnion) throws IOException {
     //Xdrgen::AST::Identifier
@@ -363,19 +247,6 @@ public class Nester implements XdrElement {
     break;
     }
       return decodedNesterNestedUnion;
-    }
-    @Override
-    public int hashCode() {
-      return Objects.hash(this.blah2, this.color);
-    }
-    @Override
-    public boolean equals(Object object) {
-      if (!(object instanceof NesterNestedUnion)) {
-        return false;
-      }
-
-      NesterNestedUnion other = (NesterNestedUnion) object;
-      return Objects.equals(this.blah2, other.blah2) && Objects.equals(this.color, other.color);
     }
     @Override
     public String toXdrBase64() throws IOException {

--- a/spec/output/generator_spec_java/test.x/OptHash1.java
+++ b/spec/output/generator_spec_java/test.x/OptHash1.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Objects;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * OptHash1's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Objects;
  * typedef Hash &#42;optHash1;
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class OptHash1 implements XdrElement {
   private Hash optHash1;
-
-  public OptHash1() {}
-
-  public OptHash1(Hash optHash1) {
-    this.optHash1 = optHash1;
-  }
-
-  public Hash getOptHash1() {
-    return this.optHash1;
-  }
-
-  public void setOptHash1(Hash value) {
-    this.optHash1 = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, OptHash1  encodedOptHash1) throws IOException {
     if (encodedOptHash1.optHash1 != null) {
     stream.writeInt(1);
@@ -55,20 +45,6 @@ public class OptHash1 implements XdrElement {
     return decodedOptHash1;
   }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.optHash1);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof OptHash1)) {
-      return false;
-    }
-
-    OptHash1 other = (OptHash1) object;
-    return Objects.equals(this.optHash1, other.optHash1);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/test.x/OptHash2.java
+++ b/spec/output/generator_spec_java/test.x/OptHash2.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Objects;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * OptHash2's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Objects;
  * typedef Hash&#42; optHash2;
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class OptHash2 implements XdrElement {
   private Hash optHash2;
-
-  public OptHash2() {}
-
-  public OptHash2(Hash optHash2) {
-    this.optHash2 = optHash2;
-  }
-
-  public Hash getOptHash2() {
-    return this.optHash2;
-  }
-
-  public void setOptHash2(Hash value) {
-    this.optHash2 = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, OptHash2  encodedOptHash2) throws IOException {
     if (encodedOptHash2.optHash2 != null) {
     stream.writeInt(1);
@@ -55,20 +45,6 @@ public class OptHash2 implements XdrElement {
     return decodedOptHash2;
   }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.optHash2);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof OptHash2)) {
-      return false;
-    }
-
-    OptHash2 other = (OptHash2) object;
-    return Objects.equals(this.optHash2, other.optHash2);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/test.x/Str.java
+++ b/spec/output/generator_spec_java/test.x/Str.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Objects;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * Str's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Objects;
  * typedef string str&lt;64&gt;;
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Str implements XdrElement {
   private XdrString str;
-
-  public Str() {}
-
-  public Str(XdrString str) {
-    this.str = str;
-  }
-
-  public XdrString getStr() {
-    return this.str;
-  }
-
-  public void setStr(XdrString value) {
-    this.str = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, Str  encodedStr) throws IOException {
     encodedStr.str.encode(stream);
   }
@@ -47,20 +37,6 @@ public class Str implements XdrElement {
     return decodedStr;
   }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.str);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof Str)) {
-      return false;
-    }
-
-    Str other = (Str) object;
-    return Objects.equals(this.str, other.str);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/test.x/Str2.java
+++ b/spec/output/generator_spec_java/test.x/Str2.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Objects;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * Str2's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Objects;
  * typedef string str2&lt;&gt;;
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Str2 implements XdrElement {
   private XdrString str2;
-
-  public Str2() {}
-
-  public Str2(XdrString str2) {
-    this.str2 = str2;
-  }
-
-  public XdrString getStr2() {
-    return this.str2;
-  }
-
-  public void setStr2(XdrString value) {
-    this.str2 = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, Str2  encodedStr2) throws IOException {
     encodedStr2.str2.encode(stream);
   }
@@ -47,20 +37,6 @@ public class Str2 implements XdrElement {
     return decodedStr2;
   }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.str2);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof Str2)) {
-      return false;
-    }
-
-    Str2 other = (Str2) object;
-    return Objects.equals(this.str2, other.str2);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/test.x/Uint512.java
+++ b/spec/output/generator_spec_java/test.x/Uint512.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Arrays;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * Uint512's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Arrays;
  * typedef opaque uint512[64];
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Uint512 implements XdrElement {
   private byte[] uint512;
-
-  public Uint512() {}
-
-  public Uint512(byte[] uint512) {
-    this.uint512 = uint512;
-  }
-
-  public byte[] getUint512() {
-    return this.uint512;
-  }
-
-  public void setUint512(byte[] value) {
-    this.uint512 = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, Uint512  encodedUint512) throws IOException {
     int uint512size = encodedUint512.uint512.length;
     stream.write(encodedUint512.getUint512(), 0, uint512size);
@@ -50,20 +40,6 @@ public class Uint512 implements XdrElement {
     return decodedUint512;
   }
 
-  @Override
-  public int hashCode() {
-    return Arrays.hashCode(this.uint512);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof Uint512)) {
-      return false;
-    }
-
-    Uint512 other = (Uint512) object;
-    return Arrays.equals(this.uint512, other.uint512);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/test.x/Uint512.java
+++ b/spec/output/generator_spec_java/test.x/Uint512.java
@@ -25,8 +25,8 @@ import static MyXDR.Constants.*;
 public class Uint512 implements XdrElement {
   private byte[] uint512;
   public static void encode(XdrDataOutputStream stream, Uint512  encodedUint512) throws IOException {
-    int uint512size = encodedUint512.uint512.length;
-    stream.write(encodedUint512.getUint512(), 0, uint512size);
+    int uint512Size = encodedUint512.uint512.length;
+    stream.write(encodedUint512.getUint512(), 0, uint512Size);
   }
 
   public void encode(XdrDataOutputStream stream) throws IOException {
@@ -34,9 +34,9 @@ public class Uint512 implements XdrElement {
   }
   public static Uint512 decode(XdrDataInputStream stream) throws IOException {
     Uint512 decodedUint512 = new Uint512();
-    int uint512size = 64;
-    decodedUint512.uint512 = new byte[uint512size];
-    stream.read(decodedUint512.uint512, 0, uint512size);
+    int uint512Size = 64;
+    decodedUint512.uint512 = new byte[uint512Size];
+    stream.read(decodedUint512.uint512, 0, uint512Size);
     return decodedUint512;
   }
 

--- a/spec/output/generator_spec_java/test.x/Uint513.java
+++ b/spec/output/generator_spec_java/test.x/Uint513.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Arrays;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * Uint513's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Arrays;
  * typedef opaque uint513&lt;64&gt;;
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Uint513 implements XdrElement {
   private byte[] uint513;
-
-  public Uint513() {}
-
-  public Uint513(byte[] uint513) {
-    this.uint513 = uint513;
-  }
-
-  public byte[] getUint513() {
-    return this.uint513;
-  }
-
-  public void setUint513(byte[] value) {
-    this.uint513 = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, Uint513  encodedUint513) throws IOException {
     int uint513size = encodedUint513.uint513.length;
     stream.writeInt(uint513size);
@@ -51,20 +41,6 @@ public class Uint513 implements XdrElement {
     return decodedUint513;
   }
 
-  @Override
-  public int hashCode() {
-    return Arrays.hashCode(this.uint513);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof Uint513)) {
-      return false;
-    }
-
-    Uint513 other = (Uint513) object;
-    return Arrays.equals(this.uint513, other.uint513);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/test.x/Uint513.java
+++ b/spec/output/generator_spec_java/test.x/Uint513.java
@@ -25,9 +25,9 @@ import static MyXDR.Constants.*;
 public class Uint513 implements XdrElement {
   private byte[] uint513;
   public static void encode(XdrDataOutputStream stream, Uint513  encodedUint513) throws IOException {
-    int uint513size = encodedUint513.uint513.length;
-    stream.writeInt(uint513size);
-    stream.write(encodedUint513.getUint513(), 0, uint513size);
+    int uint513Size = encodedUint513.uint513.length;
+    stream.writeInt(uint513Size);
+    stream.write(encodedUint513.getUint513(), 0, uint513Size);
   }
 
   public void encode(XdrDataOutputStream stream) throws IOException {
@@ -35,9 +35,9 @@ public class Uint513 implements XdrElement {
   }
   public static Uint513 decode(XdrDataInputStream stream) throws IOException {
     Uint513 decodedUint513 = new Uint513();
-    int uint513size = stream.readInt();
-    decodedUint513.uint513 = new byte[uint513size];
-    stream.read(decodedUint513.uint513, 0, uint513size);
+    int uint513Size = stream.readInt();
+    decodedUint513.uint513 = new byte[uint513Size];
+    stream.read(decodedUint513.uint513, 0, uint513Size);
     return decodedUint513;
   }
 

--- a/spec/output/generator_spec_java/test.x/Uint514.java
+++ b/spec/output/generator_spec_java/test.x/Uint514.java
@@ -25,9 +25,9 @@ import static MyXDR.Constants.*;
 public class Uint514 implements XdrElement {
   private byte[] uint514;
   public static void encode(XdrDataOutputStream stream, Uint514  encodedUint514) throws IOException {
-    int uint514size = encodedUint514.uint514.length;
-    stream.writeInt(uint514size);
-    stream.write(encodedUint514.getUint514(), 0, uint514size);
+    int uint514Size = encodedUint514.uint514.length;
+    stream.writeInt(uint514Size);
+    stream.write(encodedUint514.getUint514(), 0, uint514Size);
   }
 
   public void encode(XdrDataOutputStream stream) throws IOException {
@@ -35,9 +35,9 @@ public class Uint514 implements XdrElement {
   }
   public static Uint514 decode(XdrDataInputStream stream) throws IOException {
     Uint514 decodedUint514 = new Uint514();
-    int uint514size = stream.readInt();
-    decodedUint514.uint514 = new byte[uint514size];
-    stream.read(decodedUint514.uint514, 0, uint514size);
+    int uint514Size = stream.readInt();
+    decodedUint514.uint514 = new byte[uint514Size];
+    stream.read(decodedUint514.uint514, 0, uint514Size);
     return decodedUint514;
   }
 

--- a/spec/output/generator_spec_java/test.x/Uint514.java
+++ b/spec/output/generator_spec_java/test.x/Uint514.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Arrays;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * Uint514's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Arrays;
  * typedef opaque uint514&lt;&gt;;
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Uint514 implements XdrElement {
   private byte[] uint514;
-
-  public Uint514() {}
-
-  public Uint514(byte[] uint514) {
-    this.uint514 = uint514;
-  }
-
-  public byte[] getUint514() {
-    return this.uint514;
-  }
-
-  public void setUint514(byte[] value) {
-    this.uint514 = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, Uint514  encodedUint514) throws IOException {
     int uint514size = encodedUint514.uint514.length;
     stream.writeInt(uint514size);
@@ -51,20 +41,6 @@ public class Uint514 implements XdrElement {
     return decodedUint514;
   }
 
-  @Override
-  public int hashCode() {
-    return Arrays.hashCode(this.uint514);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof Uint514)) {
-      return false;
-    }
-
-    Uint514 other = (Uint514) object;
-    return Arrays.equals(this.uint514, other.uint514);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/test.x/XdrString.java
+++ b/spec/output/generator_spec_java/test.x/XdrString.java
@@ -4,90 +4,72 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
-import java.nio.charset.Charset;
-import java.util.Arrays;
+import java.nio.charset.StandardCharsets;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
+@Value
 public class XdrString implements XdrElement {
-    private byte[] bytes;
+  byte[] bytes;
 
-    public XdrString(byte[] bytes) {
-        this.bytes = bytes;
-    }
+  public XdrString(byte[] bytes) {
+    this.bytes = bytes;
+  }
 
-    public XdrString(String text) {
-        this.bytes = text.getBytes(Charset.forName("UTF-8"));
-    }
+  public XdrString(String text) {
+    this.bytes = text.getBytes(StandardCharsets.UTF_8);
+  }
 
-    @Override
-    public void encode(XdrDataOutputStream stream) throws IOException {
-        stream.writeInt(this.bytes.length);
-        stream.write(this.bytes, 0, this.bytes.length);
-    }
+  @Override
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    stream.writeInt(this.bytes.length);
+    stream.write(this.bytes, 0, this.bytes.length);
+  }
 
-    public static XdrString decode(XdrDataInputStream stream, int maxSize) throws IOException {
-        int size = stream.readInt();
-        if (size > maxSize) {
-            throw new InvalidClassException("String length "+size+" exceeds max size "+maxSize);
-        }
-        byte[] bytes = new byte[size];
-        stream.read(bytes);
-        return new XdrString(bytes);
+  public static XdrString decode(XdrDataInputStream stream, int maxSize) throws IOException {
+    int size = stream.readInt();
+    if (size > maxSize) {
+      throw new InvalidClassException("String length " + size + " exceeds max size " + maxSize);
     }
+    byte[] bytes = new byte[size];
+    stream.read(bytes);
+    return new XdrString(bytes);
+  }
 
-    public byte[] getBytes() {
-        return this.bytes;
-    }
+  @Override
+  public String toXdrBase64() throws IOException {
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
+  }
 
-    @Override
-    public String toXdrBase64() throws IOException {
-        return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-    }
-    
-    @Override
-    public byte[] toXdrByteArray() throws IOException {
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-        encode(xdrDataOutputStream);
-        return byteArrayOutputStream.toByteArray();
-    }
-    
-    public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64Factory.getInstance().decode(xdr);
-        return fromXdrByteArray(bytes, maxSize);
-    }
-    
-    public static XdrString fromXdrBase64(String xdr) throws IOException {
-        return fromXdrBase64(xdr, Integer.MAX_VALUE);
-    }
-    
-    public static XdrString fromXdrByteArray(byte[] xdr, int maxSize) throws IOException {
-        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
-        XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
-        return decode(xdrDataInputStream, maxSize);
-    }
-    
-    public static XdrString fromXdrByteArray(byte[] xdr) throws IOException {
-        return fromXdrByteArray(xdr, Integer.MAX_VALUE);
-    }
+  @Override
+  public byte[] toXdrByteArray() throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
+    encode(xdrDataOutputStream);
+    return byteArrayOutputStream.toByteArray();
+  }
 
-    @Override
-    public int hashCode() {
-        return Arrays.hashCode(this.bytes);
-    }
+  public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
+    return fromXdrByteArray(bytes, maxSize);
+  }
 
-    @Override
-    public boolean equals(Object object) {
-        if (object == null || !(object instanceof XdrString)) {
-          return false;
-        }
+  public static XdrString fromXdrBase64(String xdr) throws IOException {
+    return fromXdrBase64(xdr, Integer.MAX_VALUE);
+  }
 
-        XdrString other = (XdrString) object;
-        return Arrays.equals(this.bytes, other.bytes);
-    }
+  public static XdrString fromXdrByteArray(byte[] xdr, int maxSize) throws IOException {
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
+    XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
+    return decode(xdrDataInputStream, maxSize);
+  }
 
-    @Override
-    public String toString() {
-        return new String(bytes, Charset.forName("UTF-8"));
-    }
+  public static XdrString fromXdrByteArray(byte[] xdr) throws IOException {
+    return fromXdrByteArray(xdr, Integer.MAX_VALUE);
+  }
+
+  @Override
+  public String toString() {
+    return new String(bytes, StandardCharsets.UTF_8);
+  }
 }

--- a/spec/output/generator_spec_java/test.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/test.x/XdrUnsignedHyperInteger.java
@@ -1,10 +1,10 @@
-package org.stellar.sdk.xdr;
+package MyXDR;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Objects;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
 /**
@@ -13,10 +13,11 @@ import org.stellar.sdk.Base64Factory;
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc4506#section-4.5">XDR: External Data
  *     Representation Standard</a>
  */
+@Value
 public class XdrUnsignedHyperInteger implements XdrElement {
   public static final BigInteger MAX_VALUE = new BigInteger("18446744073709551615");
   public static final BigInteger MIN_VALUE = BigInteger.ZERO;
-  private final BigInteger number;
+  BigInteger number;
 
   public XdrUnsignedHyperInteger(BigInteger number) {
     if (number.compareTo(MIN_VALUE) < 0 || number.compareTo(MAX_VALUE) > 0) {
@@ -55,10 +56,6 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     return paddedBytes;
   }
 
-  public BigInteger getNumber() {
-    return number;
-  }
-
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());
@@ -81,24 +78,5 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.number);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof XdrUnsignedHyperInteger)) {
-      return false;
-    }
-
-    XdrUnsignedHyperInteger other = (XdrUnsignedHyperInteger) object;
-    return Objects.equals(this.number, other.number);
-  }
-
-  public String toString() {
-    return "XdrUnsignedInteger(number=" + this.getNumber() + ")";
   }
 }

--- a/spec/output/generator_spec_java/test.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/test.x/XdrUnsignedInteger.java
@@ -1,9 +1,9 @@
-package org.stellar.sdk.xdr;
+package MyXDR;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Objects;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
 /**
@@ -12,10 +12,11 @@ import org.stellar.sdk.Base64Factory;
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc4506#section-4.2">XDR: External Data
  *     Representation Standard</a>
  */
+@Value
 public class XdrUnsignedInteger implements XdrElement {
   public static final long MAX_VALUE = (1L << 32) - 1;
   public static final long MIN_VALUE = 0;
-  private final Long number;
+  Long number;
 
   public XdrUnsignedInteger(Long number) {
     if (number < MIN_VALUE || number > MAX_VALUE) {
@@ -30,10 +31,6 @@ public class XdrUnsignedInteger implements XdrElement {
           "number must be greater than or equal to 0 if you want to construct it from Integer");
     }
     this.number = number.longValue();
-  }
-
-  public Long getNumber() {
-    return number;
   }
 
   public static XdrUnsignedInteger decode(XdrDataInputStream stream) throws IOException {
@@ -69,24 +66,5 @@ public class XdrUnsignedInteger implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.number);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof XdrUnsignedInteger)) {
-      return false;
-    }
-
-    XdrUnsignedInteger other = (XdrUnsignedInteger) object;
-    return Objects.equals(this.number, other.number);
-  }
-
-  public String toString() {
-    return "XdrUnsignedInteger(number=" + this.getNumber() + ")";
   }
 }

--- a/spec/output/generator_spec_java/union.x/Error.java
+++ b/spec/output/generator_spec_java/union.x/Error.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Objects;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * Error's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Objects;
  * typedef int Error;
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Error implements XdrElement {
   private Integer Error;
-
-  public Error() {}
-
-  public Error(Integer Error) {
-    this.Error = Error;
-  }
-
-  public Integer getError() {
-    return this.Error;
-  }
-
-  public void setError(Integer value) {
-    this.Error = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, Error  encodedError) throws IOException {
     stream.writeInt(encodedError.Error);
   }
@@ -47,20 +37,6 @@ public class Error implements XdrElement {
     return decodedError;
   }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.Error);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof Error)) {
-      return false;
-    }
-
-    Error other = (Error) object;
-    return Objects.equals(this.Error, other.Error);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/union.x/IntUnion.java
+++ b/spec/output/generator_spec_java/union.x/IntUnion.java
@@ -45,9 +45,9 @@ public class IntUnion implements XdrElement {
   Error.encode(stream, encodedIntUnion.error);
   break;
   case 1:
-  int thingssize = encodedIntUnion.getThings().length;
-  stream.writeInt(thingssize);
-  for (int i = 0; i < thingssize; i++) {
+  int thingsSize = encodedIntUnion.getThings().length;
+  stream.writeInt(thingsSize);
+  for (int i = 0; i < thingsSize; i++) {
     Multi.encode(stream, encodedIntUnion.things[i]);
   }
   break;
@@ -65,9 +65,9 @@ public class IntUnion implements XdrElement {
   decodedIntUnion.error = Error.decode(stream);
   break;
   case 1:
-  int thingssize = stream.readInt();
-  decodedIntUnion.things = new Multi[thingssize];
-  for (int i = 0; i < thingssize; i++) {
+  int thingsSize = stream.readInt();
+  decodedIntUnion.things = new Multi[thingsSize];
+  for (int i = 0; i < thingsSize; i++) {
     decodedIntUnion.things[i] = Multi.decode(stream);
   }
   break;

--- a/spec/output/generator_spec_java/union.x/IntUnion.java
+++ b/spec/output/generator_spec_java/union.x/IntUnion.java
@@ -5,12 +5,14 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Objects;
-import java.util.Arrays;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import static MyXDR.Constants.*;
 
 /**
  * IntUnion's original definition in the XDR file is:
@@ -25,58 +27,14 @@ import java.util.Arrays;
  * };
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
 public class IntUnion implements XdrElement {
-  public IntUnion () {}
-  Integer type;
-  public Integer getDiscriminant() {
-    return this.type;
-  }
-  public void setDiscriminant(Integer value) {
-    this.type = value;
-  }
+  private Integer discriminant;
   private Error error;
-  public Error getError() {
-    return this.error;
-  }
-  public void setError(Error value) {
-    this.error = value;
-  }
   private Multi[] things;
-  public Multi[] getThings() {
-    return this.things;
-  }
-  public void setThings(Multi[] value) {
-    this.things = value;
-  }
-
-  public static final class Builder {
-    private Integer discriminant;
-    private Error error;
-    private Multi[] things;
-
-    public Builder discriminant(Integer discriminant) {
-      this.discriminant = discriminant;
-      return this;
-    }
-
-    public Builder error(Error error) {
-      this.error = error;
-      return this;
-    }
-
-    public Builder things(Multi[] things) {
-      this.things = things;
-      return this;
-    }
-
-    public IntUnion build() {
-      IntUnion val = new IntUnion();
-      val.setDiscriminant(discriminant);
-      val.setError(this.error);
-      val.setThings(this.things);
-      return val;
-    }
-  }
 
   public static void encode(XdrDataOutputStream stream, IntUnion encodedIntUnion) throws IOException {
   //Xdrgen::AST::Typespecs::Int
@@ -115,19 +73,6 @@ public class IntUnion implements XdrElement {
   break;
   }
     return decodedIntUnion;
-  }
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.error, Arrays.hashCode(this.things), this.type);
-  }
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof IntUnion)) {
-      return false;
-    }
-
-    IntUnion other = (IntUnion) object;
-    return Objects.equals(this.error, other.error) && Arrays.equals(this.things, other.things) && Objects.equals(this.type, other.type);
   }
   @Override
   public String toXdrBase64() throws IOException {

--- a/spec/output/generator_spec_java/union.x/IntUnion2.java
+++ b/spec/output/generator_spec_java/union.x/IntUnion2.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Objects;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * IntUnion2's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Objects;
  * typedef IntUnion IntUnion2;
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class IntUnion2 implements XdrElement {
   private IntUnion IntUnion2;
-
-  public IntUnion2() {}
-
-  public IntUnion2(IntUnion IntUnion2) {
-    this.IntUnion2 = IntUnion2;
-  }
-
-  public IntUnion getIntUnion2() {
-    return this.IntUnion2;
-  }
-
-  public void setIntUnion2(IntUnion value) {
-    this.IntUnion2 = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, IntUnion2  encodedIntUnion2) throws IOException {
     IntUnion.encode(stream, encodedIntUnion2.IntUnion2);
   }
@@ -47,20 +37,6 @@ public class IntUnion2 implements XdrElement {
     return decodedIntUnion2;
   }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.IntUnion2);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof IntUnion2)) {
-      return false;
-    }
-
-    IntUnion2 other = (IntUnion2) object;
-    return Objects.equals(this.IntUnion2, other.IntUnion2);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/union.x/Multi.java
+++ b/spec/output/generator_spec_java/union.x/Multi.java
@@ -5,11 +5,13 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Objects;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import static MyXDR.Constants.*;
 
 /**
  * Multi's original definition in the XDR file is:
@@ -17,23 +19,11 @@ import java.util.Objects;
  * typedef int Multi;
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Multi implements XdrElement {
   private Integer Multi;
-
-  public Multi() {}
-
-  public Multi(Integer Multi) {
-    this.Multi = Multi;
-  }
-
-  public Integer getMulti() {
-    return this.Multi;
-  }
-
-  public void setMulti(Integer value) {
-    this.Multi = value;
-  }
-
   public static void encode(XdrDataOutputStream stream, Multi  encodedMulti) throws IOException {
     stream.writeInt(encodedMulti.Multi);
   }
@@ -47,20 +37,6 @@ public class Multi implements XdrElement {
     return decodedMulti;
   }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.Multi);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof Multi)) {
-      return false;
-    }
-
-    Multi other = (Multi) object;
-    return Objects.equals(this.Multi, other.Multi);
-  }
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());

--- a/spec/output/generator_spec_java/union.x/MyUnion.java
+++ b/spec/output/generator_spec_java/union.x/MyUnion.java
@@ -5,12 +5,14 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Objects;
-import java.util.Arrays;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import static MyXDR.Constants.*;
 
 /**
  * MyUnion's original definition in the XDR file is:
@@ -26,58 +28,14 @@ import java.util.Arrays;
  * };
  * </pre>
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
 public class MyUnion implements XdrElement {
-  public MyUnion () {}
-  UnionKey type;
-  public UnionKey getDiscriminant() {
-    return this.type;
-  }
-  public void setDiscriminant(UnionKey value) {
-    this.type = value;
-  }
+  private UnionKey discriminant;
   private Error error;
-  public Error getError() {
-    return this.error;
-  }
-  public void setError(Error value) {
-    this.error = value;
-  }
   private Multi[] things;
-  public Multi[] getThings() {
-    return this.things;
-  }
-  public void setThings(Multi[] value) {
-    this.things = value;
-  }
-
-  public static final class Builder {
-    private UnionKey discriminant;
-    private Error error;
-    private Multi[] things;
-
-    public Builder discriminant(UnionKey discriminant) {
-      this.discriminant = discriminant;
-      return this;
-    }
-
-    public Builder error(Error error) {
-      this.error = error;
-      return this;
-    }
-
-    public Builder things(Multi[] things) {
-      this.things = things;
-      return this;
-    }
-
-    public MyUnion build() {
-      MyUnion val = new MyUnion();
-      val.setDiscriminant(discriminant);
-      val.setError(this.error);
-      val.setThings(this.things);
-      return val;
-    }
-  }
 
   public static void encode(XdrDataOutputStream stream, MyUnion encodedMyUnion) throws IOException {
   //Xdrgen::AST::Identifier
@@ -116,19 +74,6 @@ public class MyUnion implements XdrElement {
   break;
   }
     return decodedMyUnion;
-  }
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.error, Arrays.hashCode(this.things), this.type);
-  }
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof MyUnion)) {
-      return false;
-    }
-
-    MyUnion other = (MyUnion) object;
-    return Objects.equals(this.error, other.error) && Arrays.equals(this.things, other.things) && Objects.equals(this.type, other.type);
   }
   @Override
   public String toXdrBase64() throws IOException {

--- a/spec/output/generator_spec_java/union.x/MyUnion.java
+++ b/spec/output/generator_spec_java/union.x/MyUnion.java
@@ -46,9 +46,9 @@ public class MyUnion implements XdrElement {
   Error.encode(stream, encodedMyUnion.error);
   break;
   case MULTI:
-  int thingssize = encodedMyUnion.getThings().length;
-  stream.writeInt(thingssize);
-  for (int i = 0; i < thingssize; i++) {
+  int thingsSize = encodedMyUnion.getThings().length;
+  stream.writeInt(thingsSize);
+  for (int i = 0; i < thingsSize; i++) {
     Multi.encode(stream, encodedMyUnion.things[i]);
   }
   break;
@@ -66,9 +66,9 @@ public class MyUnion implements XdrElement {
   decodedMyUnion.error = Error.decode(stream);
   break;
   case MULTI:
-  int thingssize = stream.readInt();
-  decodedMyUnion.things = new Multi[thingssize];
-  for (int i = 0; i < thingssize; i++) {
+  int thingsSize = stream.readInt();
+  decodedMyUnion.things = new Multi[thingsSize];
+  for (int i = 0; i < thingsSize; i++) {
     decodedMyUnion.things[i] = Multi.decode(stream);
   }
   break;

--- a/spec/output/generator_spec_java/union.x/UnionKey.java
+++ b/spec/output/generator_spec_java/union.x/UnionKey.java
@@ -5,7 +5,6 @@ package MyXDR;
 
 import java.io.IOException;
 
-import static MyXDR.Constants.*;
 import org.stellar.sdk.Base64Factory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -21,16 +20,16 @@ import java.io.ByteArrayOutputStream;
  */
 public enum UnionKey implements XdrElement {
   ERROR(0),
-  MULTI(1),
-  ;
-  private int mValue;
+  MULTI(1);
+
+  private final int value;
 
   UnionKey(int value) {
-      mValue = value;
+      this.value = value;
   }
 
   public int getValue() {
-      return mValue;
+      return value;
   }
 
   public static UnionKey decode(XdrDataInputStream stream) throws IOException {

--- a/spec/output/generator_spec_java/union.x/XdrString.java
+++ b/spec/output/generator_spec_java/union.x/XdrString.java
@@ -4,90 +4,72 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
-import java.nio.charset.Charset;
-import java.util.Arrays;
+import java.nio.charset.StandardCharsets;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
+@Value
 public class XdrString implements XdrElement {
-    private byte[] bytes;
+  byte[] bytes;
 
-    public XdrString(byte[] bytes) {
-        this.bytes = bytes;
-    }
+  public XdrString(byte[] bytes) {
+    this.bytes = bytes;
+  }
 
-    public XdrString(String text) {
-        this.bytes = text.getBytes(Charset.forName("UTF-8"));
-    }
+  public XdrString(String text) {
+    this.bytes = text.getBytes(StandardCharsets.UTF_8);
+  }
 
-    @Override
-    public void encode(XdrDataOutputStream stream) throws IOException {
-        stream.writeInt(this.bytes.length);
-        stream.write(this.bytes, 0, this.bytes.length);
-    }
+  @Override
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    stream.writeInt(this.bytes.length);
+    stream.write(this.bytes, 0, this.bytes.length);
+  }
 
-    public static XdrString decode(XdrDataInputStream stream, int maxSize) throws IOException {
-        int size = stream.readInt();
-        if (size > maxSize) {
-            throw new InvalidClassException("String length "+size+" exceeds max size "+maxSize);
-        }
-        byte[] bytes = new byte[size];
-        stream.read(bytes);
-        return new XdrString(bytes);
+  public static XdrString decode(XdrDataInputStream stream, int maxSize) throws IOException {
+    int size = stream.readInt();
+    if (size > maxSize) {
+      throw new InvalidClassException("String length " + size + " exceeds max size " + maxSize);
     }
+    byte[] bytes = new byte[size];
+    stream.read(bytes);
+    return new XdrString(bytes);
+  }
 
-    public byte[] getBytes() {
-        return this.bytes;
-    }
+  @Override
+  public String toXdrBase64() throws IOException {
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
+  }
 
-    @Override
-    public String toXdrBase64() throws IOException {
-        return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-    }
-    
-    @Override
-    public byte[] toXdrByteArray() throws IOException {
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-        encode(xdrDataOutputStream);
-        return byteArrayOutputStream.toByteArray();
-    }
-    
-    public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
-        byte[] bytes = Base64Factory.getInstance().decode(xdr);
-        return fromXdrByteArray(bytes, maxSize);
-    }
-    
-    public static XdrString fromXdrBase64(String xdr) throws IOException {
-        return fromXdrBase64(xdr, Integer.MAX_VALUE);
-    }
-    
-    public static XdrString fromXdrByteArray(byte[] xdr, int maxSize) throws IOException {
-        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
-        XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
-        return decode(xdrDataInputStream, maxSize);
-    }
-    
-    public static XdrString fromXdrByteArray(byte[] xdr) throws IOException {
-        return fromXdrByteArray(xdr, Integer.MAX_VALUE);
-    }
+  @Override
+  public byte[] toXdrByteArray() throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
+    encode(xdrDataOutputStream);
+    return byteArrayOutputStream.toByteArray();
+  }
 
-    @Override
-    public int hashCode() {
-        return Arrays.hashCode(this.bytes);
-    }
+  public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
+    byte[] bytes = Base64Factory.getInstance().decode(xdr);
+    return fromXdrByteArray(bytes, maxSize);
+  }
 
-    @Override
-    public boolean equals(Object object) {
-        if (object == null || !(object instanceof XdrString)) {
-          return false;
-        }
+  public static XdrString fromXdrBase64(String xdr) throws IOException {
+    return fromXdrBase64(xdr, Integer.MAX_VALUE);
+  }
 
-        XdrString other = (XdrString) object;
-        return Arrays.equals(this.bytes, other.bytes);
-    }
+  public static XdrString fromXdrByteArray(byte[] xdr, int maxSize) throws IOException {
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
+    XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
+    return decode(xdrDataInputStream, maxSize);
+  }
 
-    @Override
-    public String toString() {
-        return new String(bytes, Charset.forName("UTF-8"));
-    }
+  public static XdrString fromXdrByteArray(byte[] xdr) throws IOException {
+    return fromXdrByteArray(xdr, Integer.MAX_VALUE);
+  }
+
+  @Override
+  public String toString() {
+    return new String(bytes, StandardCharsets.UTF_8);
+  }
 }

--- a/spec/output/generator_spec_java/union.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/union.x/XdrUnsignedHyperInteger.java
@@ -1,10 +1,10 @@
-package org.stellar.sdk.xdr;
+package MyXDR;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Objects;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
 /**
@@ -13,10 +13,11 @@ import org.stellar.sdk.Base64Factory;
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc4506#section-4.5">XDR: External Data
  *     Representation Standard</a>
  */
+@Value
 public class XdrUnsignedHyperInteger implements XdrElement {
   public static final BigInteger MAX_VALUE = new BigInteger("18446744073709551615");
   public static final BigInteger MIN_VALUE = BigInteger.ZERO;
-  private final BigInteger number;
+  BigInteger number;
 
   public XdrUnsignedHyperInteger(BigInteger number) {
     if (number.compareTo(MIN_VALUE) < 0 || number.compareTo(MAX_VALUE) > 0) {
@@ -55,10 +56,6 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     return paddedBytes;
   }
 
-  public BigInteger getNumber() {
-    return number;
-  }
-
   @Override
   public String toXdrBase64() throws IOException {
     return Base64Factory.getInstance().encodeToString(toXdrByteArray());
@@ -81,24 +78,5 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.number);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof XdrUnsignedHyperInteger)) {
-      return false;
-    }
-
-    XdrUnsignedHyperInteger other = (XdrUnsignedHyperInteger) object;
-    return Objects.equals(this.number, other.number);
-  }
-
-  public String toString() {
-    return "XdrUnsignedInteger(number=" + this.getNumber() + ")";
   }
 }

--- a/spec/output/generator_spec_java/union.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/union.x/XdrUnsignedInteger.java
@@ -1,9 +1,9 @@
-package org.stellar.sdk.xdr;
+package MyXDR;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Objects;
+import lombok.Value;
 import org.stellar.sdk.Base64Factory;
 
 /**
@@ -12,10 +12,11 @@ import org.stellar.sdk.Base64Factory;
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc4506#section-4.2">XDR: External Data
  *     Representation Standard</a>
  */
+@Value
 public class XdrUnsignedInteger implements XdrElement {
   public static final long MAX_VALUE = (1L << 32) - 1;
   public static final long MIN_VALUE = 0;
-  private final Long number;
+  Long number;
 
   public XdrUnsignedInteger(Long number) {
     if (number < MIN_VALUE || number > MAX_VALUE) {
@@ -30,10 +31,6 @@ public class XdrUnsignedInteger implements XdrElement {
           "number must be greater than or equal to 0 if you want to construct it from Integer");
     }
     this.number = number.longValue();
-  }
-
-  public Long getNumber() {
-    return number;
   }
 
   public static XdrUnsignedInteger decode(XdrDataInputStream stream) throws IOException {
@@ -69,24 +66,5 @@ public class XdrUnsignedInteger implements XdrElement {
     ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(xdr);
     XdrDataInputStream xdrDataInputStream = new XdrDataInputStream(byteArrayInputStream);
     return decode(xdrDataInputStream);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.number);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (!(object instanceof XdrUnsignedInteger)) {
-      return false;
-    }
-
-    XdrUnsignedInteger other = (XdrUnsignedInteger) object;
-    return Objects.equals(this.number, other.number);
-  }
-
-  public String toString() {
-    return "XdrUnsignedInteger(number=" + this.getNumber() + ")";
   }
 }


### PR DESCRIPTION
This PR simplified the code using Lombok.

Currently, lombok has been used in the Java SDK. However, for other projects that directly use code generated by xdrgen, they need to introduce lombok.


https://github.com/lightsail-network/java-stellar-sdk/pull/596