### PR TITLE
Java: simplify the generated XDR code.

### DIFF
--- a/lib/xdrgen/generators/java/XdrElement.erb
+++ b/lib/xdrgen/generators/java/XdrElement.erb
@@ -1,14 +1,21 @@
 package <%= @namespace %>;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import org.stellar.sdk.Base64Factory;
 
-/**
- * Common parent interface for all generated classes. 
- */
+/** Common parent interface for all generated classes. */
 interface XdrElement {
-    void encode(XdrDataOutputStream stream) throws IOException;
+  void encode(XdrDataOutputStream stream) throws IOException;
 
-    String toXdrBase64() throws IOException;
+  default String toXdrBase64() throws IOException {
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
+  }
 
-    byte[] toXdrByteArray() throws IOException;
+  default byte[] toXdrByteArray() throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
+    encode(xdrDataOutputStream);
+    return byteArrayOutputStream.toByteArray();
+  }
 }

--- a/lib/xdrgen/generators/java/XdrString.erb
+++ b/lib/xdrgen/generators/java/XdrString.erb
@@ -36,19 +36,6 @@ public class XdrString implements XdrElement {
     return new XdrString(bytes);
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes, maxSize);

--- a/lib/xdrgen/generators/java/XdrUnsignedHyperInteger.erb
+++ b/lib/xdrgen/generators/java/XdrUnsignedHyperInteger.erb
@@ -56,19 +56,6 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     return paddedBytes;
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/lib/xdrgen/generators/java/XdrUnsignedInteger.erb
+++ b/lib/xdrgen/generators/java/XdrUnsignedInteger.erb
@@ -44,19 +44,6 @@ public class XdrUnsignedInteger implements XdrElement {
     stream.writeInt(number.intValue());
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/block_comments.x/AccountFlags.java
+++ b/spec/output/generator_spec_java/block_comments.x/AccountFlags.java
@@ -40,26 +40,9 @@ public enum AccountFlags implements XdrElement {
     }
   }
 
-  public static void encode(XdrDataOutputStream stream, AccountFlags value) throws IOException {
-    stream.writeInt(value.getValue());
-  }
-
   public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
+    stream.writeInt(value);
   }
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static AccountFlags fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/block_comments.x/XdrElement.java
+++ b/spec/output/generator_spec_java/block_comments.x/XdrElement.java
@@ -1,14 +1,21 @@
 package MyXDR;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import org.stellar.sdk.Base64Factory;
 
-/**
- * Common parent interface for all generated classes. 
- */
+/** Common parent interface for all generated classes. */
 interface XdrElement {
-    void encode(XdrDataOutputStream stream) throws IOException;
+  void encode(XdrDataOutputStream stream) throws IOException;
 
-    String toXdrBase64() throws IOException;
+  default String toXdrBase64() throws IOException {
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
+  }
 
-    byte[] toXdrByteArray() throws IOException;
+  default byte[] toXdrByteArray() throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
+    encode(xdrDataOutputStream);
+    return byteArrayOutputStream.toByteArray();
+  }
 }

--- a/spec/output/generator_spec_java/block_comments.x/XdrString.java
+++ b/spec/output/generator_spec_java/block_comments.x/XdrString.java
@@ -36,19 +36,6 @@ public class XdrString implements XdrElement {
     return new XdrString(bytes);
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes, maxSize);

--- a/spec/output/generator_spec_java/block_comments.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/block_comments.x/XdrUnsignedHyperInteger.java
@@ -56,19 +56,6 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     return paddedBytes;
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/block_comments.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/block_comments.x/XdrUnsignedInteger.java
@@ -44,19 +44,6 @@ public class XdrUnsignedInteger implements XdrElement {
     stream.writeInt(number.intValue());
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/const.x/TestArray.java
+++ b/spec/output/generator_spec_java/const.x/TestArray.java
@@ -24,16 +24,13 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class TestArray implements XdrElement {
   private Integer[] TestArray;
-  public static void encode(XdrDataOutputStream stream, TestArray  encodedTestArray) throws IOException {
-    int TestArraySize = encodedTestArray.getTestArray().length;
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    int TestArraySize = getTestArray().length;
     for (int i = 0; i < TestArraySize; i++) {
-      stream.writeInt(encodedTestArray.TestArray[i]);
+      stream.writeInt(TestArray[i]);
     }
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static TestArray decode(XdrDataInputStream stream) throws IOException {
     TestArray decodedTestArray = new TestArray();
     int TestArraySize = FOO;
@@ -42,19 +39,6 @@ public class TestArray implements XdrElement {
       decodedTestArray.TestArray[i] = stream.readInt();
     }
     return decodedTestArray;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static TestArray fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/const.x/TestArray.java
+++ b/spec/output/generator_spec_java/const.x/TestArray.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * TestArray's original definition in the XDR file is:
@@ -33,7 +32,7 @@ public class TestArray implements XdrElement {
 
   public static TestArray decode(XdrDataInputStream stream) throws IOException {
     TestArray decodedTestArray = new TestArray();
-    int TestArraySize = FOO;
+    int TestArraySize = Constants.FOO;
     decodedTestArray.TestArray = new Integer[TestArraySize];
     for (int i = 0; i < TestArraySize; i++) {
       decodedTestArray.TestArray[i] = stream.readInt();

--- a/spec/output/generator_spec_java/const.x/TestArray2.java
+++ b/spec/output/generator_spec_java/const.x/TestArray2.java
@@ -24,17 +24,14 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class TestArray2 implements XdrElement {
   private Integer[] TestArray2;
-  public static void encode(XdrDataOutputStream stream, TestArray2  encodedTestArray2) throws IOException {
-    int TestArray2Size = encodedTestArray2.getTestArray2().length;
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    int TestArray2Size = getTestArray2().length;
     stream.writeInt(TestArray2Size);
     for (int i = 0; i < TestArray2Size; i++) {
-      stream.writeInt(encodedTestArray2.TestArray2[i]);
+      stream.writeInt(TestArray2[i]);
     }
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static TestArray2 decode(XdrDataInputStream stream) throws IOException {
     TestArray2 decodedTestArray2 = new TestArray2();
     int TestArray2Size = stream.readInt();
@@ -43,19 +40,6 @@ public class TestArray2 implements XdrElement {
       decodedTestArray2.TestArray2[i] = stream.readInt();
     }
     return decodedTestArray2;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static TestArray2 fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/const.x/TestArray2.java
+++ b/spec/output/generator_spec_java/const.x/TestArray2.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * TestArray2's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/const.x/XdrElement.java
+++ b/spec/output/generator_spec_java/const.x/XdrElement.java
@@ -1,14 +1,21 @@
 package MyXDR;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import org.stellar.sdk.Base64Factory;
 
-/**
- * Common parent interface for all generated classes. 
- */
+/** Common parent interface for all generated classes. */
 interface XdrElement {
-    void encode(XdrDataOutputStream stream) throws IOException;
+  void encode(XdrDataOutputStream stream) throws IOException;
 
-    String toXdrBase64() throws IOException;
+  default String toXdrBase64() throws IOException {
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
+  }
 
-    byte[] toXdrByteArray() throws IOException;
+  default byte[] toXdrByteArray() throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
+    encode(xdrDataOutputStream);
+    return byteArrayOutputStream.toByteArray();
+  }
 }

--- a/spec/output/generator_spec_java/const.x/XdrString.java
+++ b/spec/output/generator_spec_java/const.x/XdrString.java
@@ -36,19 +36,6 @@ public class XdrString implements XdrElement {
     return new XdrString(bytes);
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes, maxSize);

--- a/spec/output/generator_spec_java/const.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/const.x/XdrUnsignedHyperInteger.java
@@ -56,19 +56,6 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     return paddedBytes;
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/const.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/const.x/XdrUnsignedInteger.java
@@ -44,19 +44,6 @@ public class XdrUnsignedInteger implements XdrElement {
     stream.writeInt(number.intValue());
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/enum.x/Color.java
+++ b/spec/output/generator_spec_java/enum.x/Color.java
@@ -45,26 +45,9 @@ public enum Color implements XdrElement {
     }
   }
 
-  public static void encode(XdrDataOutputStream stream, Color value) throws IOException {
-    stream.writeInt(value.getValue());
-  }
-
   public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
+    stream.writeInt(value);
   }
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static Color fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/enum.x/Color2.java
+++ b/spec/output/generator_spec_java/enum.x/Color2.java
@@ -45,26 +45,9 @@ public enum Color2 implements XdrElement {
     }
   }
 
-  public static void encode(XdrDataOutputStream stream, Color2 value) throws IOException {
-    stream.writeInt(value.getValue());
-  }
-
   public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
+    stream.writeInt(value);
   }
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static Color2 fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/enum.x/MessageType.java
+++ b/spec/output/generator_spec_java/enum.x/MessageType.java
@@ -85,26 +85,9 @@ public enum MessageType implements XdrElement {
     }
   }
 
-  public static void encode(XdrDataOutputStream stream, MessageType value) throws IOException {
-    stream.writeInt(value.getValue());
-  }
-
   public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
+    stream.writeInt(value);
   }
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static MessageType fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/enum.x/XdrElement.java
+++ b/spec/output/generator_spec_java/enum.x/XdrElement.java
@@ -1,14 +1,21 @@
 package MyXDR;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import org.stellar.sdk.Base64Factory;
 
-/**
- * Common parent interface for all generated classes. 
- */
+/** Common parent interface for all generated classes. */
 interface XdrElement {
-    void encode(XdrDataOutputStream stream) throws IOException;
+  void encode(XdrDataOutputStream stream) throws IOException;
 
-    String toXdrBase64() throws IOException;
+  default String toXdrBase64() throws IOException {
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
+  }
 
-    byte[] toXdrByteArray() throws IOException;
+  default byte[] toXdrByteArray() throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
+    encode(xdrDataOutputStream);
+    return byteArrayOutputStream.toByteArray();
+  }
 }

--- a/spec/output/generator_spec_java/enum.x/XdrString.java
+++ b/spec/output/generator_spec_java/enum.x/XdrString.java
@@ -36,19 +36,6 @@ public class XdrString implements XdrElement {
     return new XdrString(bytes);
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes, maxSize);

--- a/spec/output/generator_spec_java/enum.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/enum.x/XdrUnsignedHyperInteger.java
@@ -56,19 +56,6 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     return paddedBytes;
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/enum.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/enum.x/XdrUnsignedInteger.java
@@ -44,19 +44,6 @@ public class XdrUnsignedInteger implements XdrElement {
     stream.writeInt(number.intValue());
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/nesting.x/Foo.java
+++ b/spec/output/generator_spec_java/nesting.x/Foo.java
@@ -24,30 +24,14 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class Foo implements XdrElement {
   private Integer Foo;
-  public static void encode(XdrDataOutputStream stream, Foo  encodedFoo) throws IOException {
-    stream.writeInt(encodedFoo.Foo);
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    stream.writeInt(Foo);
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static Foo decode(XdrDataInputStream stream) throws IOException {
     Foo decodedFoo = new Foo();
     decodedFoo.Foo = stream.readInt();
     return decodedFoo;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static Foo fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/nesting.x/Foo.java
+++ b/spec/output/generator_spec_java/nesting.x/Foo.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * Foo's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/nesting.x/MyUnion.java
+++ b/spec/output/generator_spec_java/nesting.x/MyUnion.java
@@ -44,23 +44,18 @@ public class MyUnion implements XdrElement {
   private MyUnionOne one;
   private MyUnionTwo two;
 
-  public static void encode(XdrDataOutputStream stream, MyUnion encodedMyUnion) throws IOException {
-  //Xdrgen::AST::Identifier
-  //UnionKey
-  stream.writeInt(encodedMyUnion.getDiscriminant().getValue());
-  switch (encodedMyUnion.getDiscriminant()) {
+  public void encode(XdrDataOutputStream stream) throws IOException {
+  stream.writeInt(discriminant.getValue());
+  switch (discriminant) {
   case ONE:
-  MyUnionOne.encode(stream, encodedMyUnion.one);
+  one.encode(stream);
   break;
   case TWO:
-  MyUnionTwo.encode(stream, encodedMyUnion.two);
+  two.encode(stream);
   break;
   case OFFER:
   break;
   }
-  }
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
   }
   public static MyUnion decode(XdrDataInputStream stream) throws IOException {
   MyUnion decodedMyUnion = new MyUnion();
@@ -78,19 +73,6 @@ public class MyUnion implements XdrElement {
   }
     return decodedMyUnion;
   }
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static MyUnion fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
@@ -116,30 +98,14 @@ public class MyUnion implements XdrElement {
   @Builder(toBuilder = true)
   public static class MyUnionOne implements XdrElement {
     private Integer someInt;
-    public static void encode(XdrDataOutputStream stream, MyUnionOne encodedMyUnionOne) throws IOException{
-      stream.writeInt(encodedMyUnionOne.someInt);
-    }
-    public void encode(XdrDataOutputStream stream) throws IOException {
-      encode(stream, this);
+    public void encode(XdrDataOutputStream stream) throws IOException{
+      stream.writeInt(someInt);
     }
     public static MyUnionOne decode(XdrDataInputStream stream) throws IOException {
       MyUnionOne decodedMyUnionOne = new MyUnionOne();
       decodedMyUnionOne.someInt = stream.readInt();
       return decodedMyUnionOne;
     }
-    @Override
-    public String toXdrBase64() throws IOException {
-      return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-    }
-
-    @Override
-    public byte[] toXdrByteArray() throws IOException {
-      ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-      XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-      encode(xdrDataOutputStream);
-      return byteArrayOutputStream.toByteArray();
-    }
-
     public static MyUnionOne fromXdrBase64(String xdr) throws IOException {
       byte[] bytes = Base64Factory.getInstance().decode(xdr);
       return fromXdrByteArray(bytes);
@@ -168,12 +134,9 @@ public class MyUnion implements XdrElement {
   public static class MyUnionTwo implements XdrElement {
     private Integer someInt;
     private Foo foo;
-    public static void encode(XdrDataOutputStream stream, MyUnionTwo encodedMyUnionTwo) throws IOException{
-      stream.writeInt(encodedMyUnionTwo.someInt);
-      Foo.encode(stream, encodedMyUnionTwo.foo);
-    }
-    public void encode(XdrDataOutputStream stream) throws IOException {
-      encode(stream, this);
+    public void encode(XdrDataOutputStream stream) throws IOException{
+      stream.writeInt(someInt);
+      foo.encode(stream);
     }
     public static MyUnionTwo decode(XdrDataInputStream stream) throws IOException {
       MyUnionTwo decodedMyUnionTwo = new MyUnionTwo();
@@ -181,19 +144,6 @@ public class MyUnion implements XdrElement {
       decodedMyUnionTwo.foo = Foo.decode(stream);
       return decodedMyUnionTwo;
     }
-    @Override
-    public String toXdrBase64() throws IOException {
-      return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-    }
-
-    @Override
-    public byte[] toXdrByteArray() throws IOException {
-      ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-      XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-      encode(xdrDataOutputStream);
-      return byteArrayOutputStream.toByteArray();
-    }
-
     public static MyUnionTwo fromXdrBase64(String xdr) throws IOException {
       byte[] bytes = Base64Factory.getInstance().decode(xdr);
       return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/nesting.x/MyUnion.java
+++ b/spec/output/generator_spec_java/nesting.x/MyUnion.java
@@ -12,7 +12,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import static MyXDR.Constants.*;
 
 /**
  * MyUnion's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/nesting.x/UnionKey.java
+++ b/spec/output/generator_spec_java/nesting.x/UnionKey.java
@@ -45,26 +45,9 @@ public enum UnionKey implements XdrElement {
     }
   }
 
-  public static void encode(XdrDataOutputStream stream, UnionKey value) throws IOException {
-    stream.writeInt(value.getValue());
-  }
-
   public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
+    stream.writeInt(value);
   }
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static UnionKey fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/nesting.x/XdrElement.java
+++ b/spec/output/generator_spec_java/nesting.x/XdrElement.java
@@ -1,14 +1,21 @@
 package MyXDR;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import org.stellar.sdk.Base64Factory;
 
-/**
- * Common parent interface for all generated classes. 
- */
+/** Common parent interface for all generated classes. */
 interface XdrElement {
-    void encode(XdrDataOutputStream stream) throws IOException;
+  void encode(XdrDataOutputStream stream) throws IOException;
 
-    String toXdrBase64() throws IOException;
+  default String toXdrBase64() throws IOException {
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
+  }
 
-    byte[] toXdrByteArray() throws IOException;
+  default byte[] toXdrByteArray() throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
+    encode(xdrDataOutputStream);
+    return byteArrayOutputStream.toByteArray();
+  }
 }

--- a/spec/output/generator_spec_java/nesting.x/XdrString.java
+++ b/spec/output/generator_spec_java/nesting.x/XdrString.java
@@ -36,19 +36,6 @@ public class XdrString implements XdrElement {
     return new XdrString(bytes);
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes, maxSize);

--- a/spec/output/generator_spec_java/nesting.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/nesting.x/XdrUnsignedHyperInteger.java
@@ -56,19 +56,6 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     return paddedBytes;
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/nesting.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/nesting.x/XdrUnsignedInteger.java
@@ -44,19 +44,6 @@ public class XdrUnsignedInteger implements XdrElement {
     stream.writeInt(number.intValue());
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/optional.x/Arr.java
+++ b/spec/output/generator_spec_java/optional.x/Arr.java
@@ -24,16 +24,13 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class Arr implements XdrElement {
   private Integer[] Arr;
-  public static void encode(XdrDataOutputStream stream, Arr  encodedArr) throws IOException {
-    int ArrSize = encodedArr.getArr().length;
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    int ArrSize = getArr().length;
     for (int i = 0; i < ArrSize; i++) {
-      stream.writeInt(encodedArr.Arr[i]);
+      stream.writeInt(Arr[i]);
     }
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static Arr decode(XdrDataInputStream stream) throws IOException {
     Arr decodedArr = new Arr();
     int ArrSize = 2;
@@ -42,19 +39,6 @@ public class Arr implements XdrElement {
       decodedArr.Arr[i] = stream.readInt();
     }
     return decodedArr;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static Arr fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/optional.x/Arr.java
+++ b/spec/output/generator_spec_java/optional.x/Arr.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * Arr's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/optional.x/HasOptions.java
+++ b/spec/output/generator_spec_java/optional.x/HasOptions.java
@@ -12,7 +12,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import static MyXDR.Constants.*;
 
 /**
  * HasOptions's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/optional.x/HasOptions.java
+++ b/spec/output/generator_spec_java/optional.x/HasOptions.java
@@ -33,28 +33,25 @@ public class HasOptions implements XdrElement {
   private Integer firstOption;
   private Integer secondOption;
   private Arr thirdOption;
-  public static void encode(XdrDataOutputStream stream, HasOptions encodedHasOptions) throws IOException{
-    if (encodedHasOptions.firstOption != null) {
+  public void encode(XdrDataOutputStream stream) throws IOException{
+    if (firstOption != null) {
     stream.writeInt(1);
-    stream.writeInt(encodedHasOptions.firstOption);
+    stream.writeInt(firstOption);
     } else {
     stream.writeInt(0);
     }
-    if (encodedHasOptions.secondOption != null) {
+    if (secondOption != null) {
     stream.writeInt(1);
-    stream.writeInt(encodedHasOptions.secondOption);
+    stream.writeInt(secondOption);
     } else {
     stream.writeInt(0);
     }
-    if (encodedHasOptions.thirdOption != null) {
+    if (thirdOption != null) {
     stream.writeInt(1);
-    Arr.encode(stream, encodedHasOptions.thirdOption);
+    thirdOption.encode(stream);
     } else {
     stream.writeInt(0);
     }
-  }
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
   }
   public static HasOptions decode(XdrDataInputStream stream) throws IOException {
     HasOptions decodedHasOptions = new HasOptions();
@@ -72,19 +69,6 @@ public class HasOptions implements XdrElement {
     }
     return decodedHasOptions;
   }
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static HasOptions fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/optional.x/XdrElement.java
+++ b/spec/output/generator_spec_java/optional.x/XdrElement.java
@@ -1,14 +1,21 @@
 package MyXDR;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import org.stellar.sdk.Base64Factory;
 
-/**
- * Common parent interface for all generated classes. 
- */
+/** Common parent interface for all generated classes. */
 interface XdrElement {
-    void encode(XdrDataOutputStream stream) throws IOException;
+  void encode(XdrDataOutputStream stream) throws IOException;
 
-    String toXdrBase64() throws IOException;
+  default String toXdrBase64() throws IOException {
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
+  }
 
-    byte[] toXdrByteArray() throws IOException;
+  default byte[] toXdrByteArray() throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
+    encode(xdrDataOutputStream);
+    return byteArrayOutputStream.toByteArray();
+  }
 }

--- a/spec/output/generator_spec_java/optional.x/XdrString.java
+++ b/spec/output/generator_spec_java/optional.x/XdrString.java
@@ -36,19 +36,6 @@ public class XdrString implements XdrElement {
     return new XdrString(bytes);
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes, maxSize);

--- a/spec/output/generator_spec_java/optional.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/optional.x/XdrUnsignedHyperInteger.java
@@ -56,19 +56,6 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     return paddedBytes;
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/optional.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/optional.x/XdrUnsignedInteger.java
@@ -44,19 +44,6 @@ public class XdrUnsignedInteger implements XdrElement {
     stream.writeInt(number.intValue());
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/struct.x/Int64.java
+++ b/spec/output/generator_spec_java/struct.x/Int64.java
@@ -24,30 +24,14 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class Int64 implements XdrElement {
   private Long int64;
-  public static void encode(XdrDataOutputStream stream, Int64  encodedInt64) throws IOException {
-    stream.writeLong(encodedInt64.int64);
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    stream.writeLong(int64);
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static Int64 decode(XdrDataInputStream stream) throws IOException {
     Int64 decodedInt64 = new Int64();
     decodedInt64.int64 = stream.readLong();
     return decodedInt64;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static Int64 fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/struct.x/Int64.java
+++ b/spec/output/generator_spec_java/struct.x/Int64.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * Int64's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/struct.x/MyStruct.java
+++ b/spec/output/generator_spec_java/struct.x/MyStruct.java
@@ -37,16 +37,13 @@ public class MyStruct implements XdrElement {
   private byte[] someOpaque;
   private XdrString someString;
   private XdrString maxString;
-  public static void encode(XdrDataOutputStream stream, MyStruct encodedMyStruct) throws IOException{
-    stream.writeInt(encodedMyStruct.someInt);
-    Int64.encode(stream, encodedMyStruct.aBigInt);
-    int someOpaqueSize = encodedMyStruct.someOpaque.length;
-    stream.write(encodedMyStruct.getSomeOpaque(), 0, someOpaqueSize);
-    encodedMyStruct.someString.encode(stream);
-    encodedMyStruct.maxString.encode(stream);
-  }
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
+  public void encode(XdrDataOutputStream stream) throws IOException{
+    stream.writeInt(someInt);
+    aBigInt.encode(stream);
+    int someOpaqueSize = someOpaque.length;
+    stream.write(getSomeOpaque(), 0, someOpaqueSize);
+    someString.encode(stream);
+    maxString.encode(stream);
   }
   public static MyStruct decode(XdrDataInputStream stream) throws IOException {
     MyStruct decodedMyStruct = new MyStruct();
@@ -59,19 +56,6 @@ public class MyStruct implements XdrElement {
     decodedMyStruct.maxString = XdrString.decode(stream, 100);
     return decodedMyStruct;
   }
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static MyStruct fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/struct.x/MyStruct.java
+++ b/spec/output/generator_spec_java/struct.x/MyStruct.java
@@ -12,7 +12,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import static MyXDR.Constants.*;
 
 /**
  * MyStruct's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/struct.x/XdrElement.java
+++ b/spec/output/generator_spec_java/struct.x/XdrElement.java
@@ -1,14 +1,21 @@
 package MyXDR;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import org.stellar.sdk.Base64Factory;
 
-/**
- * Common parent interface for all generated classes. 
- */
+/** Common parent interface for all generated classes. */
 interface XdrElement {
-    void encode(XdrDataOutputStream stream) throws IOException;
+  void encode(XdrDataOutputStream stream) throws IOException;
 
-    String toXdrBase64() throws IOException;
+  default String toXdrBase64() throws IOException {
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
+  }
 
-    byte[] toXdrByteArray() throws IOException;
+  default byte[] toXdrByteArray() throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
+    encode(xdrDataOutputStream);
+    return byteArrayOutputStream.toByteArray();
+  }
 }

--- a/spec/output/generator_spec_java/struct.x/XdrString.java
+++ b/spec/output/generator_spec_java/struct.x/XdrString.java
@@ -36,19 +36,6 @@ public class XdrString implements XdrElement {
     return new XdrString(bytes);
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes, maxSize);

--- a/spec/output/generator_spec_java/struct.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/struct.x/XdrUnsignedHyperInteger.java
@@ -56,19 +56,6 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     return paddedBytes;
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/struct.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/struct.x/XdrUnsignedInteger.java
@@ -44,19 +44,6 @@ public class XdrUnsignedInteger implements XdrElement {
     stream.writeInt(number.intValue());
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/test.x/Color.java
+++ b/spec/output/generator_spec_java/test.x/Color.java
@@ -45,26 +45,9 @@ public enum Color implements XdrElement {
     }
   }
 
-  public static void encode(XdrDataOutputStream stream, Color value) throws IOException {
-    stream.writeInt(value.getValue());
-  }
-
   public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
+    stream.writeInt(value);
   }
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static Color fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/test.x/HasStuff.java
+++ b/spec/output/generator_spec_java/test.x/HasStuff.java
@@ -29,30 +29,14 @@ import static MyXDR.Constants.*;
 @Builder(toBuilder = true)
 public class HasStuff implements XdrElement {
   private LotsOfMyStructs data;
-  public static void encode(XdrDataOutputStream stream, HasStuff encodedHasStuff) throws IOException{
-    LotsOfMyStructs.encode(stream, encodedHasStuff.data);
-  }
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
+  public void encode(XdrDataOutputStream stream) throws IOException{
+    data.encode(stream);
   }
   public static HasStuff decode(XdrDataInputStream stream) throws IOException {
     HasStuff decodedHasStuff = new HasStuff();
     decodedHasStuff.data = LotsOfMyStructs.decode(stream);
     return decodedHasStuff;
   }
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static HasStuff fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/test.x/HasStuff.java
+++ b/spec/output/generator_spec_java/test.x/HasStuff.java
@@ -12,7 +12,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import static MyXDR.Constants.*;
 
 /**
  * HasStuff's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/test.x/Hash.java
+++ b/spec/output/generator_spec_java/test.x/Hash.java
@@ -24,33 +24,17 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class Hash implements XdrElement {
   private byte[] Hash;
-  public static void encode(XdrDataOutputStream stream, Hash  encodedHash) throws IOException {
-    int HashSize = encodedHash.Hash.length;
-    stream.write(encodedHash.getHash(), 0, HashSize);
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    int HashSize = Hash.length;
+    stream.write(getHash(), 0, HashSize);
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static Hash decode(XdrDataInputStream stream) throws IOException {
     Hash decodedHash = new Hash();
     int HashSize = 32;
     decodedHash.Hash = new byte[HashSize];
     stream.read(decodedHash.Hash, 0, HashSize);
     return decodedHash;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static Hash fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/test.x/Hash.java
+++ b/spec/output/generator_spec_java/test.x/Hash.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * Hash's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/test.x/Hashes1.java
+++ b/spec/output/generator_spec_java/test.x/Hashes1.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * Hashes1's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/test.x/Hashes1.java
+++ b/spec/output/generator_spec_java/test.x/Hashes1.java
@@ -24,16 +24,13 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class Hashes1 implements XdrElement {
   private Hash[] Hashes1;
-  public static void encode(XdrDataOutputStream stream, Hashes1  encodedHashes1) throws IOException {
-    int Hashes1Size = encodedHashes1.getHashes1().length;
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    int Hashes1Size = getHashes1().length;
     for (int i = 0; i < Hashes1Size; i++) {
-      Hash.encode(stream, encodedHashes1.Hashes1[i]);
+      Hashes1[i].encode(stream);
     }
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static Hashes1 decode(XdrDataInputStream stream) throws IOException {
     Hashes1 decodedHashes1 = new Hashes1();
     int Hashes1Size = 12;
@@ -42,19 +39,6 @@ public class Hashes1 implements XdrElement {
       decodedHashes1.Hashes1[i] = Hash.decode(stream);
     }
     return decodedHashes1;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static Hashes1 fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/test.x/Hashes2.java
+++ b/spec/output/generator_spec_java/test.x/Hashes2.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * Hashes2's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/test.x/Hashes2.java
+++ b/spec/output/generator_spec_java/test.x/Hashes2.java
@@ -24,17 +24,14 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class Hashes2 implements XdrElement {
   private Hash[] Hashes2;
-  public static void encode(XdrDataOutputStream stream, Hashes2  encodedHashes2) throws IOException {
-    int Hashes2Size = encodedHashes2.getHashes2().length;
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    int Hashes2Size = getHashes2().length;
     stream.writeInt(Hashes2Size);
     for (int i = 0; i < Hashes2Size; i++) {
-      Hash.encode(stream, encodedHashes2.Hashes2[i]);
+      Hashes2[i].encode(stream);
     }
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static Hashes2 decode(XdrDataInputStream stream) throws IOException {
     Hashes2 decodedHashes2 = new Hashes2();
     int Hashes2Size = stream.readInt();
@@ -43,19 +40,6 @@ public class Hashes2 implements XdrElement {
       decodedHashes2.Hashes2[i] = Hash.decode(stream);
     }
     return decodedHashes2;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static Hashes2 fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/test.x/Hashes3.java
+++ b/spec/output/generator_spec_java/test.x/Hashes3.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * Hashes3's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/test.x/Hashes3.java
+++ b/spec/output/generator_spec_java/test.x/Hashes3.java
@@ -24,17 +24,14 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class Hashes3 implements XdrElement {
   private Hash[] Hashes3;
-  public static void encode(XdrDataOutputStream stream, Hashes3  encodedHashes3) throws IOException {
-    int Hashes3Size = encodedHashes3.getHashes3().length;
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    int Hashes3Size = getHashes3().length;
     stream.writeInt(Hashes3Size);
     for (int i = 0; i < Hashes3Size; i++) {
-      Hash.encode(stream, encodedHashes3.Hashes3[i]);
+      Hashes3[i].encode(stream);
     }
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static Hashes3 decode(XdrDataInputStream stream) throws IOException {
     Hashes3 decodedHashes3 = new Hashes3();
     int Hashes3Size = stream.readInt();
@@ -43,19 +40,6 @@ public class Hashes3 implements XdrElement {
       decodedHashes3.Hashes3[i] = Hash.decode(stream);
     }
     return decodedHashes3;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static Hashes3 fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/test.x/Int1.java
+++ b/spec/output/generator_spec_java/test.x/Int1.java
@@ -24,30 +24,14 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class Int1 implements XdrElement {
   private Integer int1;
-  public static void encode(XdrDataOutputStream stream, Int1  encodedInt1) throws IOException {
-    stream.writeInt(encodedInt1.int1);
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    stream.writeInt(int1);
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static Int1 decode(XdrDataInputStream stream) throws IOException {
     Int1 decodedInt1 = new Int1();
     decodedInt1.int1 = stream.readInt();
     return decodedInt1;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static Int1 fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/test.x/Int1.java
+++ b/spec/output/generator_spec_java/test.x/Int1.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * Int1's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/test.x/Int2.java
+++ b/spec/output/generator_spec_java/test.x/Int2.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * Int2's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/test.x/Int2.java
+++ b/spec/output/generator_spec_java/test.x/Int2.java
@@ -24,30 +24,14 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class Int2 implements XdrElement {
   private Long int2;
-  public static void encode(XdrDataOutputStream stream, Int2  encodedInt2) throws IOException {
-    stream.writeLong(encodedInt2.int2);
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    stream.writeLong(int2);
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static Int2 decode(XdrDataInputStream stream) throws IOException {
     Int2 decodedInt2 = new Int2();
     decodedInt2.int2 = stream.readLong();
     return decodedInt2;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static Int2 fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/test.x/Int3.java
+++ b/spec/output/generator_spec_java/test.x/Int3.java
@@ -24,30 +24,14 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class Int3 implements XdrElement {
   private XdrUnsignedInteger int3;
-  public static void encode(XdrDataOutputStream stream, Int3  encodedInt3) throws IOException {
-    encodedInt3.int3.encode(stream);
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    int3.encode(stream);
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static Int3 decode(XdrDataInputStream stream) throws IOException {
     Int3 decodedInt3 = new Int3();
     decodedInt3.int3 = XdrUnsignedInteger.decode(stream);
     return decodedInt3;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static Int3 fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/test.x/Int3.java
+++ b/spec/output/generator_spec_java/test.x/Int3.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * Int3's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/test.x/Int4.java
+++ b/spec/output/generator_spec_java/test.x/Int4.java
@@ -24,30 +24,14 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class Int4 implements XdrElement {
   private XdrUnsignedHyperInteger int4;
-  public static void encode(XdrDataOutputStream stream, Int4  encodedInt4) throws IOException {
-    encodedInt4.int4.encode(stream);
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    int4.encode(stream);
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static Int4 decode(XdrDataInputStream stream) throws IOException {
     Int4 decodedInt4 = new Int4();
     decodedInt4.int4 = XdrUnsignedHyperInteger.decode(stream);
     return decodedInt4;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static Int4 fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/test.x/Int4.java
+++ b/spec/output/generator_spec_java/test.x/Int4.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * Int4's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/test.x/LotsOfMyStructs.java
+++ b/spec/output/generator_spec_java/test.x/LotsOfMyStructs.java
@@ -12,7 +12,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import static MyXDR.Constants.*;
 
 /**
  * LotsOfMyStructs's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/test.x/LotsOfMyStructs.java
+++ b/spec/output/generator_spec_java/test.x/LotsOfMyStructs.java
@@ -29,15 +29,12 @@ import static MyXDR.Constants.*;
 @Builder(toBuilder = true)
 public class LotsOfMyStructs implements XdrElement {
   private MyStruct[] members;
-  public static void encode(XdrDataOutputStream stream, LotsOfMyStructs encodedLotsOfMyStructs) throws IOException{
-    int membersSize = encodedLotsOfMyStructs.getMembers().length;
+  public void encode(XdrDataOutputStream stream) throws IOException{
+    int membersSize = getMembers().length;
     stream.writeInt(membersSize);
     for (int i = 0; i < membersSize; i++) {
-      MyStruct.encode(stream, encodedLotsOfMyStructs.members[i]);
+      members[i].encode(stream);
     }
-  }
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
   }
   public static LotsOfMyStructs decode(XdrDataInputStream stream) throws IOException {
     LotsOfMyStructs decodedLotsOfMyStructs = new LotsOfMyStructs();
@@ -48,19 +45,6 @@ public class LotsOfMyStructs implements XdrElement {
     }
     return decodedLotsOfMyStructs;
   }
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static LotsOfMyStructs fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/test.x/MyStruct.java
+++ b/spec/output/generator_spec_java/test.x/MyStruct.java
@@ -12,7 +12,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import static MyXDR.Constants.*;
 
 /**
  * MyStruct's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/test.x/MyStruct.java
+++ b/spec/output/generator_spec_java/test.x/MyStruct.java
@@ -41,17 +41,14 @@ public class MyStruct implements XdrElement {
   private Float field5;
   private Double field6;
   private Boolean field7;
-  public static void encode(XdrDataOutputStream stream, MyStruct encodedMyStruct) throws IOException{
-    Uint512.encode(stream, encodedMyStruct.field1);
-    OptHash1.encode(stream, encodedMyStruct.field2);
-    Int1.encode(stream, encodedMyStruct.field3);
-    encodedMyStruct.field4.encode(stream);
-    stream.writeFloat(encodedMyStruct.field5);
-    stream.writeDouble(encodedMyStruct.field6);
-    stream.writeInt(encodedMyStruct.field7 ? 1 : 0);
-  }
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
+  public void encode(XdrDataOutputStream stream) throws IOException{
+    field1.encode(stream);
+    field2.encode(stream);
+    field3.encode(stream);
+    field4.encode(stream);
+    stream.writeFloat(field5);
+    stream.writeDouble(field6);
+    stream.writeInt(field7 ? 1 : 0);
   }
   public static MyStruct decode(XdrDataInputStream stream) throws IOException {
     MyStruct decodedMyStruct = new MyStruct();
@@ -64,19 +61,6 @@ public class MyStruct implements XdrElement {
     decodedMyStruct.field7 = stream.readInt() == 1 ? true : false;
     return decodedMyStruct;
   }
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static MyStruct fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/test.x/Nester.java
+++ b/spec/output/generator_spec_java/test.x/Nester.java
@@ -12,7 +12,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import static MyXDR.Constants.*;
 
 /**
  * Nester's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/test.x/Nester.java
+++ b/spec/output/generator_spec_java/test.x/Nester.java
@@ -47,13 +47,10 @@ public class Nester implements XdrElement {
   private NesterNestedEnum nestedEnum;
   private NesterNestedStruct nestedStruct;
   private NesterNestedUnion nestedUnion;
-  public static void encode(XdrDataOutputStream stream, Nester encodedNester) throws IOException{
-    NesterNestedEnum.encode(stream, encodedNester.nestedEnum);
-    NesterNestedStruct.encode(stream, encodedNester.nestedStruct);
-    NesterNestedUnion.encode(stream, encodedNester.nestedUnion);
-  }
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
+  public void encode(XdrDataOutputStream stream) throws IOException{
+    nestedEnum.encode(stream);
+    nestedStruct.encode(stream);
+    nestedUnion.encode(stream);
   }
   public static Nester decode(XdrDataInputStream stream) throws IOException {
     Nester decodedNester = new Nester();
@@ -62,19 +59,6 @@ public class Nester implements XdrElement {
     decodedNester.nestedUnion = NesterNestedUnion.decode(stream);
     return decodedNester;
   }
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static Nester fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);
@@ -119,26 +103,9 @@ public class Nester implements XdrElement {
       }
     }
 
-    public static void encode(XdrDataOutputStream stream, NestedEnum value) throws IOException {
-      stream.writeInt(value.getValue());
-    }
-
     public void encode(XdrDataOutputStream stream) throws IOException {
-      encode(stream, this);
+      stream.writeInt(value);
     }
-    @Override
-    public String toXdrBase64() throws IOException {
-      return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-    }
-
-    @Override
-    public byte[] toXdrByteArray() throws IOException {
-      ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-      XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-      encode(xdrDataOutputStream);
-      return byteArrayOutputStream.toByteArray();
-    }
-
     public static NestedEnum fromXdrBase64(String xdr) throws IOException {
       byte[] bytes = Base64Factory.getInstance().decode(xdr);
       return fromXdrByteArray(bytes);
@@ -165,30 +132,14 @@ public class Nester implements XdrElement {
   @Builder(toBuilder = true)
   public static class NesterNestedStruct implements XdrElement {
     private Integer blah;
-    public static void encode(XdrDataOutputStream stream, NesterNestedStruct encodedNesterNestedStruct) throws IOException{
-      stream.writeInt(encodedNesterNestedStruct.blah);
-    }
-    public void encode(XdrDataOutputStream stream) throws IOException {
-      encode(stream, this);
+    public void encode(XdrDataOutputStream stream) throws IOException{
+      stream.writeInt(blah);
     }
     public static NesterNestedStruct decode(XdrDataInputStream stream) throws IOException {
       NesterNestedStruct decodedNesterNestedStruct = new NesterNestedStruct();
       decodedNesterNestedStruct.blah = stream.readInt();
       return decodedNesterNestedStruct;
     }
-    @Override
-    public String toXdrBase64() throws IOException {
-      return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-    }
-
-    @Override
-    public byte[] toXdrByteArray() throws IOException {
-      ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-      XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-      encode(xdrDataOutputStream);
-      return byteArrayOutputStream.toByteArray();
-    }
-
     public static NesterNestedStruct fromXdrBase64(String xdr) throws IOException {
       byte[] bytes = Base64Factory.getInstance().decode(xdr);
       return fromXdrByteArray(bytes);
@@ -220,20 +171,15 @@ public class Nester implements XdrElement {
     private Color discriminant;
     private Integer blah2;
 
-    public static void encode(XdrDataOutputStream stream, NesterNestedUnion encodedNesterNestedUnion) throws IOException {
-    //Xdrgen::AST::Identifier
-    //Color
-    stream.writeInt(encodedNesterNestedUnion.getDiscriminant().getValue());
-    switch (encodedNesterNestedUnion.getDiscriminant()) {
+    public void encode(XdrDataOutputStream stream) throws IOException {
+    stream.writeInt(discriminant.getValue());
+    switch (discriminant) {
     case RED:
     break;
     default:
-    stream.writeInt(encodedNesterNestedUnion.blah2);
+    stream.writeInt(blah2);
     break;
     }
-    }
-    public void encode(XdrDataOutputStream stream) throws IOException {
-      encode(stream, this);
     }
     public static NesterNestedUnion decode(XdrDataInputStream stream) throws IOException {
     NesterNestedUnion decodedNesterNestedUnion = new NesterNestedUnion();
@@ -248,19 +194,6 @@ public class Nester implements XdrElement {
     }
       return decodedNesterNestedUnion;
     }
-    @Override
-    public String toXdrBase64() throws IOException {
-      return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-    }
-
-    @Override
-    public byte[] toXdrByteArray() throws IOException {
-      ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-      XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-      encode(xdrDataOutputStream);
-      return byteArrayOutputStream.toByteArray();
-    }
-
     public static NesterNestedUnion fromXdrBase64(String xdr) throws IOException {
       byte[] bytes = Base64Factory.getInstance().decode(xdr);
       return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/test.x/OptHash1.java
+++ b/spec/output/generator_spec_java/test.x/OptHash1.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * OptHash1's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/test.x/OptHash1.java
+++ b/spec/output/generator_spec_java/test.x/OptHash1.java
@@ -24,18 +24,15 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class OptHash1 implements XdrElement {
   private Hash optHash1;
-  public static void encode(XdrDataOutputStream stream, OptHash1  encodedOptHash1) throws IOException {
-    if (encodedOptHash1.optHash1 != null) {
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    if (optHash1 != null) {
     stream.writeInt(1);
-    Hash.encode(stream, encodedOptHash1.optHash1);
+    optHash1.encode(stream);
     } else {
     stream.writeInt(0);
     }
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static OptHash1 decode(XdrDataInputStream stream) throws IOException {
     OptHash1 decodedOptHash1 = new OptHash1();
     int optHash1Present = stream.readInt();
@@ -43,19 +40,6 @@ public class OptHash1 implements XdrElement {
     decodedOptHash1.optHash1 = Hash.decode(stream);
     }
     return decodedOptHash1;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static OptHash1 fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/test.x/OptHash2.java
+++ b/spec/output/generator_spec_java/test.x/OptHash2.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * OptHash2's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/test.x/OptHash2.java
+++ b/spec/output/generator_spec_java/test.x/OptHash2.java
@@ -24,18 +24,15 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class OptHash2 implements XdrElement {
   private Hash optHash2;
-  public static void encode(XdrDataOutputStream stream, OptHash2  encodedOptHash2) throws IOException {
-    if (encodedOptHash2.optHash2 != null) {
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    if (optHash2 != null) {
     stream.writeInt(1);
-    Hash.encode(stream, encodedOptHash2.optHash2);
+    optHash2.encode(stream);
     } else {
     stream.writeInt(0);
     }
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static OptHash2 decode(XdrDataInputStream stream) throws IOException {
     OptHash2 decodedOptHash2 = new OptHash2();
     int optHash2Present = stream.readInt();
@@ -43,19 +40,6 @@ public class OptHash2 implements XdrElement {
     decodedOptHash2.optHash2 = Hash.decode(stream);
     }
     return decodedOptHash2;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static OptHash2 fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/test.x/Str.java
+++ b/spec/output/generator_spec_java/test.x/Str.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * Str's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/test.x/Str.java
+++ b/spec/output/generator_spec_java/test.x/Str.java
@@ -24,30 +24,14 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class Str implements XdrElement {
   private XdrString str;
-  public static void encode(XdrDataOutputStream stream, Str  encodedStr) throws IOException {
-    encodedStr.str.encode(stream);
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    str.encode(stream);
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static Str decode(XdrDataInputStream stream) throws IOException {
     Str decodedStr = new Str();
     decodedStr.str = XdrString.decode(stream, 64);
     return decodedStr;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static Str fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/test.x/Str2.java
+++ b/spec/output/generator_spec_java/test.x/Str2.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * Str2's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/test.x/Str2.java
+++ b/spec/output/generator_spec_java/test.x/Str2.java
@@ -24,30 +24,14 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class Str2 implements XdrElement {
   private XdrString str2;
-  public static void encode(XdrDataOutputStream stream, Str2  encodedStr2) throws IOException {
-    encodedStr2.str2.encode(stream);
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    str2.encode(stream);
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static Str2 decode(XdrDataInputStream stream) throws IOException {
     Str2 decodedStr2 = new Str2();
     decodedStr2.str2 = XdrString.decode(stream, Integer.MAX_VALUE);
     return decodedStr2;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static Str2 fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/test.x/Uint512.java
+++ b/spec/output/generator_spec_java/test.x/Uint512.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * Uint512's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/test.x/Uint512.java
+++ b/spec/output/generator_spec_java/test.x/Uint512.java
@@ -24,33 +24,17 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class Uint512 implements XdrElement {
   private byte[] uint512;
-  public static void encode(XdrDataOutputStream stream, Uint512  encodedUint512) throws IOException {
-    int uint512Size = encodedUint512.uint512.length;
-    stream.write(encodedUint512.getUint512(), 0, uint512Size);
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    int uint512Size = uint512.length;
+    stream.write(getUint512(), 0, uint512Size);
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static Uint512 decode(XdrDataInputStream stream) throws IOException {
     Uint512 decodedUint512 = new Uint512();
     int uint512Size = 64;
     decodedUint512.uint512 = new byte[uint512Size];
     stream.read(decodedUint512.uint512, 0, uint512Size);
     return decodedUint512;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static Uint512 fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/test.x/Uint513.java
+++ b/spec/output/generator_spec_java/test.x/Uint513.java
@@ -24,34 +24,18 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class Uint513 implements XdrElement {
   private byte[] uint513;
-  public static void encode(XdrDataOutputStream stream, Uint513  encodedUint513) throws IOException {
-    int uint513Size = encodedUint513.uint513.length;
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    int uint513Size = uint513.length;
     stream.writeInt(uint513Size);
-    stream.write(encodedUint513.getUint513(), 0, uint513Size);
+    stream.write(getUint513(), 0, uint513Size);
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static Uint513 decode(XdrDataInputStream stream) throws IOException {
     Uint513 decodedUint513 = new Uint513();
     int uint513Size = stream.readInt();
     decodedUint513.uint513 = new byte[uint513Size];
     stream.read(decodedUint513.uint513, 0, uint513Size);
     return decodedUint513;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static Uint513 fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/test.x/Uint513.java
+++ b/spec/output/generator_spec_java/test.x/Uint513.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * Uint513's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/test.x/Uint514.java
+++ b/spec/output/generator_spec_java/test.x/Uint514.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * Uint514's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/test.x/Uint514.java
+++ b/spec/output/generator_spec_java/test.x/Uint514.java
@@ -24,34 +24,18 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class Uint514 implements XdrElement {
   private byte[] uint514;
-  public static void encode(XdrDataOutputStream stream, Uint514  encodedUint514) throws IOException {
-    int uint514Size = encodedUint514.uint514.length;
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    int uint514Size = uint514.length;
     stream.writeInt(uint514Size);
-    stream.write(encodedUint514.getUint514(), 0, uint514Size);
+    stream.write(getUint514(), 0, uint514Size);
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static Uint514 decode(XdrDataInputStream stream) throws IOException {
     Uint514 decodedUint514 = new Uint514();
     int uint514Size = stream.readInt();
     decodedUint514.uint514 = new byte[uint514Size];
     stream.read(decodedUint514.uint514, 0, uint514Size);
     return decodedUint514;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static Uint514 fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/test.x/XdrElement.java
+++ b/spec/output/generator_spec_java/test.x/XdrElement.java
@@ -1,14 +1,21 @@
 package MyXDR;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import org.stellar.sdk.Base64Factory;
 
-/**
- * Common parent interface for all generated classes. 
- */
+/** Common parent interface for all generated classes. */
 interface XdrElement {
-    void encode(XdrDataOutputStream stream) throws IOException;
+  void encode(XdrDataOutputStream stream) throws IOException;
 
-    String toXdrBase64() throws IOException;
+  default String toXdrBase64() throws IOException {
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
+  }
 
-    byte[] toXdrByteArray() throws IOException;
+  default byte[] toXdrByteArray() throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
+    encode(xdrDataOutputStream);
+    return byteArrayOutputStream.toByteArray();
+  }
 }

--- a/spec/output/generator_spec_java/test.x/XdrString.java
+++ b/spec/output/generator_spec_java/test.x/XdrString.java
@@ -36,19 +36,6 @@ public class XdrString implements XdrElement {
     return new XdrString(bytes);
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes, maxSize);

--- a/spec/output/generator_spec_java/test.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/test.x/XdrUnsignedHyperInteger.java
@@ -56,19 +56,6 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     return paddedBytes;
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/test.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/test.x/XdrUnsignedInteger.java
@@ -44,19 +44,6 @@ public class XdrUnsignedInteger implements XdrElement {
     stream.writeInt(number.intValue());
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/union.x/Error.java
+++ b/spec/output/generator_spec_java/union.x/Error.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * Error's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/union.x/Error.java
+++ b/spec/output/generator_spec_java/union.x/Error.java
@@ -24,30 +24,14 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class Error implements XdrElement {
   private Integer Error;
-  public static void encode(XdrDataOutputStream stream, Error  encodedError) throws IOException {
-    stream.writeInt(encodedError.Error);
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    stream.writeInt(Error);
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static Error decode(XdrDataInputStream stream) throws IOException {
     Error decodedError = new Error();
     decodedError.Error = stream.readInt();
     return decodedError;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static Error fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/union.x/IntUnion.java
+++ b/spec/output/generator_spec_java/union.x/IntUnion.java
@@ -36,25 +36,20 @@ public class IntUnion implements XdrElement {
   private Error error;
   private Multi[] things;
 
-  public static void encode(XdrDataOutputStream stream, IntUnion encodedIntUnion) throws IOException {
-  //Xdrgen::AST::Typespecs::Int
-  //Integer
-  stream.writeInt(encodedIntUnion.getDiscriminant().intValue());
-  switch (encodedIntUnion.getDiscriminant()) {
+  public void encode(XdrDataOutputStream stream) throws IOException {
+  stream.writeInt(discriminant);
+  switch (discriminant) {
   case 0:
-  Error.encode(stream, encodedIntUnion.error);
+  error.encode(stream);
   break;
   case 1:
-  int thingsSize = encodedIntUnion.getThings().length;
+  int thingsSize = getThings().length;
   stream.writeInt(thingsSize);
   for (int i = 0; i < thingsSize; i++) {
-    Multi.encode(stream, encodedIntUnion.things[i]);
+    things[i].encode(stream);
   }
   break;
   }
-  }
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
   }
   public static IntUnion decode(XdrDataInputStream stream) throws IOException {
   IntUnion decodedIntUnion = new IntUnion();
@@ -74,19 +69,6 @@ public class IntUnion implements XdrElement {
   }
     return decodedIntUnion;
   }
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static IntUnion fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/union.x/IntUnion.java
+++ b/spec/output/generator_spec_java/union.x/IntUnion.java
@@ -12,7 +12,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import static MyXDR.Constants.*;
 
 /**
  * IntUnion's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/union.x/IntUnion2.java
+++ b/spec/output/generator_spec_java/union.x/IntUnion2.java
@@ -24,30 +24,14 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class IntUnion2 implements XdrElement {
   private IntUnion IntUnion2;
-  public static void encode(XdrDataOutputStream stream, IntUnion2  encodedIntUnion2) throws IOException {
-    IntUnion.encode(stream, encodedIntUnion2.IntUnion2);
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    IntUnion2.encode(stream);
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static IntUnion2 decode(XdrDataInputStream stream) throws IOException {
     IntUnion2 decodedIntUnion2 = new IntUnion2();
     decodedIntUnion2.IntUnion2 = IntUnion.decode(stream);
     return decodedIntUnion2;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static IntUnion2 fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/union.x/IntUnion2.java
+++ b/spec/output/generator_spec_java/union.x/IntUnion2.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * IntUnion2's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/union.x/Multi.java
+++ b/spec/output/generator_spec_java/union.x/Multi.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayOutputStream;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import static MyXDR.Constants.*;
 
 /**
  * Multi's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/union.x/Multi.java
+++ b/spec/output/generator_spec_java/union.x/Multi.java
@@ -24,30 +24,14 @@ import static MyXDR.Constants.*;
 @AllArgsConstructor
 public class Multi implements XdrElement {
   private Integer Multi;
-  public static void encode(XdrDataOutputStream stream, Multi  encodedMulti) throws IOException {
-    stream.writeInt(encodedMulti.Multi);
+  public void encode(XdrDataOutputStream stream) throws IOException {
+    stream.writeInt(Multi);
   }
 
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
-  }
   public static Multi decode(XdrDataInputStream stream) throws IOException {
     Multi decodedMulti = new Multi();
     decodedMulti.Multi = stream.readInt();
     return decodedMulti;
-  }
-
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
   }
 
   public static Multi fromXdrBase64(String xdr) throws IOException {

--- a/spec/output/generator_spec_java/union.x/MyUnion.java
+++ b/spec/output/generator_spec_java/union.x/MyUnion.java
@@ -37,25 +37,20 @@ public class MyUnion implements XdrElement {
   private Error error;
   private Multi[] things;
 
-  public static void encode(XdrDataOutputStream stream, MyUnion encodedMyUnion) throws IOException {
-  //Xdrgen::AST::Identifier
-  //UnionKey
-  stream.writeInt(encodedMyUnion.getDiscriminant().getValue());
-  switch (encodedMyUnion.getDiscriminant()) {
+  public void encode(XdrDataOutputStream stream) throws IOException {
+  stream.writeInt(discriminant.getValue());
+  switch (discriminant) {
   case ERROR:
-  Error.encode(stream, encodedMyUnion.error);
+  error.encode(stream);
   break;
   case MULTI:
-  int thingsSize = encodedMyUnion.getThings().length;
+  int thingsSize = getThings().length;
   stream.writeInt(thingsSize);
   for (int i = 0; i < thingsSize; i++) {
-    Multi.encode(stream, encodedMyUnion.things[i]);
+    things[i].encode(stream);
   }
   break;
   }
-  }
-  public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
   }
   public static MyUnion decode(XdrDataInputStream stream) throws IOException {
   MyUnion decodedMyUnion = new MyUnion();
@@ -75,19 +70,6 @@ public class MyUnion implements XdrElement {
   }
     return decodedMyUnion;
   }
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static MyUnion fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/union.x/MyUnion.java
+++ b/spec/output/generator_spec_java/union.x/MyUnion.java
@@ -12,7 +12,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import static MyXDR.Constants.*;
 
 /**
  * MyUnion's original definition in the XDR file is:

--- a/spec/output/generator_spec_java/union.x/UnionKey.java
+++ b/spec/output/generator_spec_java/union.x/UnionKey.java
@@ -42,26 +42,9 @@ public enum UnionKey implements XdrElement {
     }
   }
 
-  public static void encode(XdrDataOutputStream stream, UnionKey value) throws IOException {
-    stream.writeInt(value.getValue());
-  }
-
   public void encode(XdrDataOutputStream stream) throws IOException {
-    encode(stream, this);
+    stream.writeInt(value);
   }
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static UnionKey fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/union.x/XdrElement.java
+++ b/spec/output/generator_spec_java/union.x/XdrElement.java
@@ -1,14 +1,21 @@
 package MyXDR;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import org.stellar.sdk.Base64Factory;
 
-/**
- * Common parent interface for all generated classes. 
- */
+/** Common parent interface for all generated classes. */
 interface XdrElement {
-    void encode(XdrDataOutputStream stream) throws IOException;
+  void encode(XdrDataOutputStream stream) throws IOException;
 
-    String toXdrBase64() throws IOException;
+  default String toXdrBase64() throws IOException {
+    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
+  }
 
-    byte[] toXdrByteArray() throws IOException;
+  default byte[] toXdrByteArray() throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
+    encode(xdrDataOutputStream);
+    return byteArrayOutputStream.toByteArray();
+  }
 }

--- a/spec/output/generator_spec_java/union.x/XdrString.java
+++ b/spec/output/generator_spec_java/union.x/XdrString.java
@@ -36,19 +36,6 @@ public class XdrString implements XdrElement {
     return new XdrString(bytes);
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrString fromXdrBase64(String xdr, int maxSize) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes, maxSize);

--- a/spec/output/generator_spec_java/union.x/XdrUnsignedHyperInteger.java
+++ b/spec/output/generator_spec_java/union.x/XdrUnsignedHyperInteger.java
@@ -56,19 +56,6 @@ public class XdrUnsignedHyperInteger implements XdrElement {
     return paddedBytes;
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrUnsignedHyperInteger fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);

--- a/spec/output/generator_spec_java/union.x/XdrUnsignedInteger.java
+++ b/spec/output/generator_spec_java/union.x/XdrUnsignedInteger.java
@@ -44,19 +44,6 @@ public class XdrUnsignedInteger implements XdrElement {
     stream.writeInt(number.intValue());
   }
 
-  @Override
-  public String toXdrBase64() throws IOException {
-    return Base64Factory.getInstance().encodeToString(toXdrByteArray());
-  }
-
-  @Override
-  public byte[] toXdrByteArray() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    XdrDataOutputStream xdrDataOutputStream = new XdrDataOutputStream(byteArrayOutputStream);
-    encode(xdrDataOutputStream);
-    return byteArrayOutputStream.toByteArray();
-  }
-
   public static XdrUnsignedInteger fromXdrBase64(String xdr) throws IOException {
     byte[] bytes = Base64Factory.getInstance().decode(xdr);
     return fromXdrByteArray(bytes);


### PR DESCRIPTION
- Move toXdrByteArray and toXdrBase64 into the interface as default methods.
- Remove the static encode method.
- No longer import all constants.

https://github.com/lightsail-network/java-stellar-sdk/pull/597