### PR TITLE
Rust: Add fn for deserializing multiple types in json from a stream

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -250,10 +250,24 @@ module Xdrgen
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     #{types.map { |t| "TypeVariant::#{t} => Ok(Self::#{t}(Box::new(serde_json::from_reader(r)?)))," }.join("\n")}
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    #{types.map { |t| "TypeVariant::#{t} => Ok(Self::#{t}(Box::new(serde::de::Deserialize::deserialize(r)?)))," }.join("\n")}
                 }
             }
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -3030,10 +3030,24 @@ impl Type {
     }
 
     #[cfg(all(feature = "std", feature = "serde_json"))]
-    #[allow(clippy::too_many_lines)]
+    #[deprecated(note = "use from_json")]
     pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+        Self::from_json(v, r)
+    }
+
+    #[cfg(all(feature = "std", feature = "serde_json"))]
+    #[allow(clippy::too_many_lines)]
+    pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
         match v {
             TypeVariant::AccountFlags => Ok(Self::AccountFlags(Box::new(serde_json::from_reader(r)?))),
+        }
+    }
+
+    #[cfg(all(feature = "std", feature = "serde_json"))]
+    #[allow(clippy::too_many_lines)]
+    pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+        match v {
+            TypeVariant::AccountFlags => Ok(Self::AccountFlags(Box::new(serde::de::Deserialize::deserialize(r)?))),
         }
     }
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -2969,11 +2969,26 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.lim
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     TypeVariant::TestArray => Ok(Self::TestArray(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::TestArray2 => Ok(Self::TestArray2(Box::new(serde_json::from_reader(r)?))),
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    TypeVariant::TestArray => Ok(Self::TestArray(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::TestArray2 => Ok(Self::TestArray2(Box::new(serde::de::Deserialize::deserialize(r)?))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -3480,13 +3480,30 @@ TypeVariant::Color3 => Box::new(ReadXdrIter::<_, Color3>::new(dec, r.limits.clon
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     TypeVariant::MessageType => Ok(Self::MessageType(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Color => Ok(Self::Color(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Color2 => Ok(Self::Color2(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Color3 => Ok(Self::Color3(Box::new(serde_json::from_reader(r)?))),
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    TypeVariant::MessageType => Ok(Self::MessageType(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Color => Ok(Self::Color(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Color2 => Ok(Self::Color2(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Color3 => Ok(Self::Color3(Box::new(serde::de::Deserialize::deserialize(r)?))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -3305,14 +3305,32 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.lim
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     TypeVariant::UnionKey => Ok(Self::UnionKey(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Foo => Ok(Self::Foo(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::MyUnion => Ok(Self::MyUnion(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::MyUnionOne => Ok(Self::MyUnionOne(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::MyUnionTwo => Ok(Self::MyUnionTwo(Box::new(serde_json::from_reader(r)?))),
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    TypeVariant::UnionKey => Ok(Self::UnionKey(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Foo => Ok(Self::Foo(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::MyUnion => Ok(Self::MyUnion(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::MyUnionOne => Ok(Self::MyUnionOne(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::MyUnionTwo => Ok(Self::MyUnionTwo(Box::new(serde::de::Deserialize::deserialize(r)?))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -2999,11 +2999,26 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.lim
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     TypeVariant::Arr => Ok(Self::Arr(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::HasOptions => Ok(Self::HasOptions(Box::new(serde_json::from_reader(r)?))),
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    TypeVariant::Arr => Ok(Self::Arr(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::HasOptions => Ok(Self::HasOptions(Box::new(serde::de::Deserialize::deserialize(r)?))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -3007,11 +3007,26 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits.
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     TypeVariant::Int64 => Ok(Self::Int64(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::MyStruct => Ok(Self::MyStruct(Box::new(serde_json::from_reader(r)?))),
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    TypeVariant::Int64 => Ok(Self::Int64(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::MyStruct => Ok(Self::MyStruct(Box::new(serde::de::Deserialize::deserialize(r)?))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -4916,8 +4916,14 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     TypeVariant::Uint512 => Ok(Self::Uint512(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Uint513 => Ok(Self::Uint513(Box::new(serde_json::from_reader(r)?))),
@@ -4942,6 +4948,36 @@ TypeVariant::Nester => Ok(Self::Nester(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::NesterNestedEnum => Ok(Self::NesterNestedEnum(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::NesterNestedStruct => Ok(Self::NesterNestedStruct(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::NesterNestedUnion => Ok(Self::NesterNestedUnion(Box::new(serde_json::from_reader(r)?))),
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    TypeVariant::Uint512 => Ok(Self::Uint512(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Uint513 => Ok(Self::Uint513(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Uint514 => Ok(Self::Uint514(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Str => Ok(Self::Str(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Str2 => Ok(Self::Str2(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Hash => Ok(Self::Hash(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Hashes1 => Ok(Self::Hashes1(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Hashes2 => Ok(Self::Hashes2(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Hashes3 => Ok(Self::Hashes3(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::OptHash1 => Ok(Self::OptHash1(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::OptHash2 => Ok(Self::OptHash2(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Int1 => Ok(Self::Int1(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Int2 => Ok(Self::Int2(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Int3 => Ok(Self::Int3(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Int4 => Ok(Self::Int4(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::MyStruct => Ok(Self::MyStruct(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::LotsOfMyStructs => Ok(Self::LotsOfMyStructs(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::HasStuff => Ok(Self::HasStuff(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Color => Ok(Self::Color(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Nester => Ok(Self::Nester(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::NesterNestedEnum => Ok(Self::NesterNestedEnum(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::NesterNestedStruct => Ok(Self::NesterNestedStruct(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::NesterNestedUnion => Ok(Self::NesterNestedUnion(Box::new(serde::de::Deserialize::deserialize(r)?))),
                 }
             }
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -3391,8 +3391,14 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.limit
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     TypeVariant::SError => Ok(Self::SError(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Multi => Ok(Self::Multi(Box::new(serde_json::from_reader(r)?))),
@@ -3400,6 +3406,19 @@ TypeVariant::UnionKey => Ok(Self::UnionKey(Box::new(serde_json::from_reader(r)?)
 TypeVariant::MyUnion => Ok(Self::MyUnion(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::IntUnion => Ok(Self::IntUnion(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::IntUnion2 => Ok(Self::IntUnion2(Box::new(serde_json::from_reader(r)?))),
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    TypeVariant::SError => Ok(Self::SError(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Multi => Ok(Self::Multi(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::UnionKey => Ok(Self::UnionKey(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::MyUnion => Ok(Self::MyUnion(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::IntUnion => Ok(Self::IntUnion(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::IntUnion2 => Ok(Self::IntUnion2(Box::new(serde::de::Deserialize::deserialize(r)?))),
                 }
             }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
@@ -3030,10 +3030,24 @@ impl Type {
     }
 
     #[cfg(all(feature = "std", feature = "serde_json"))]
-    #[allow(clippy::too_many_lines)]
+    #[deprecated(note = "use from_json")]
     pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+        Self::from_json(v, r)
+    }
+
+    #[cfg(all(feature = "std", feature = "serde_json"))]
+    #[allow(clippy::too_many_lines)]
+    pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
         match v {
             TypeVariant::AccountFlags => Ok(Self::AccountFlags(Box::new(serde_json::from_reader(r)?))),
+        }
+    }
+
+    #[cfg(all(feature = "std", feature = "serde_json"))]
+    #[allow(clippy::too_many_lines)]
+    pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+        match v {
+            TypeVariant::AccountFlags => Ok(Self::AccountFlags(Box::new(serde::de::Deserialize::deserialize(r)?))),
         }
     }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
@@ -2969,11 +2969,26 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.lim
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     TypeVariant::TestArray => Ok(Self::TestArray(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::TestArray2 => Ok(Self::TestArray2(Box::new(serde_json::from_reader(r)?))),
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    TypeVariant::TestArray => Ok(Self::TestArray(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::TestArray2 => Ok(Self::TestArray2(Box::new(serde::de::Deserialize::deserialize(r)?))),
                 }
             }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
@@ -3479,13 +3479,30 @@ TypeVariant::Color3 => Box::new(ReadXdrIter::<_, Color3>::new(dec, r.limits.clon
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     TypeVariant::MessageType => Ok(Self::MessageType(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Color => Ok(Self::Color(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Color2 => Ok(Self::Color2(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Color3 => Ok(Self::Color3(Box::new(serde_json::from_reader(r)?))),
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    TypeVariant::MessageType => Ok(Self::MessageType(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Color => Ok(Self::Color(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Color2 => Ok(Self::Color2(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Color3 => Ok(Self::Color3(Box::new(serde::de::Deserialize::deserialize(r)?))),
                 }
             }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -3303,14 +3303,32 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.lim
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     TypeVariant::UnionKey => Ok(Self::UnionKey(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Foo => Ok(Self::Foo(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::MyUnion => Ok(Self::MyUnion(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::MyUnionOne => Ok(Self::MyUnionOne(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::MyUnionTwo => Ok(Self::MyUnionTwo(Box::new(serde_json::from_reader(r)?))),
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    TypeVariant::UnionKey => Ok(Self::UnionKey(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Foo => Ok(Self::Foo(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::MyUnion => Ok(Self::MyUnion(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::MyUnionOne => Ok(Self::MyUnionOne(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::MyUnionTwo => Ok(Self::MyUnionTwo(Box::new(serde::de::Deserialize::deserialize(r)?))),
                 }
             }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -2998,11 +2998,26 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.lim
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     TypeVariant::Arr => Ok(Self::Arr(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::HasOptions => Ok(Self::HasOptions(Box::new(serde_json::from_reader(r)?))),
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    TypeVariant::Arr => Ok(Self::Arr(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::HasOptions => Ok(Self::HasOptions(Box::new(serde::de::Deserialize::deserialize(r)?))),
                 }
             }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -3006,11 +3006,26 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits.
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     TypeVariant::Int64 => Ok(Self::Int64(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::MyStruct => Ok(Self::MyStruct(Box::new(serde_json::from_reader(r)?))),
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    TypeVariant::Int64 => Ok(Self::Int64(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::MyStruct => Ok(Self::MyStruct(Box::new(serde::de::Deserialize::deserialize(r)?))),
                 }
             }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -4914,8 +4914,14 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     TypeVariant::Uint512 => Ok(Self::Uint512(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Uint513 => Ok(Self::Uint513(Box::new(serde_json::from_reader(r)?))),
@@ -4940,6 +4946,36 @@ TypeVariant::Nester => Ok(Self::Nester(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::NesterNestedEnum => Ok(Self::NesterNestedEnum(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::NesterNestedStruct => Ok(Self::NesterNestedStruct(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::NesterNestedUnion => Ok(Self::NesterNestedUnion(Box::new(serde_json::from_reader(r)?))),
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    TypeVariant::Uint512 => Ok(Self::Uint512(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Uint513 => Ok(Self::Uint513(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Uint514 => Ok(Self::Uint514(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Str => Ok(Self::Str(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Str2 => Ok(Self::Str2(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Hash => Ok(Self::Hash(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Hashes1 => Ok(Self::Hashes1(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Hashes2 => Ok(Self::Hashes2(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Hashes3 => Ok(Self::Hashes3(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::OptHash1 => Ok(Self::OptHash1(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::OptHash2 => Ok(Self::OptHash2(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Int1 => Ok(Self::Int1(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Int2 => Ok(Self::Int2(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Int3 => Ok(Self::Int3(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Int4 => Ok(Self::Int4(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::MyStruct => Ok(Self::MyStruct(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::LotsOfMyStructs => Ok(Self::LotsOfMyStructs(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::HasStuff => Ok(Self::HasStuff(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Color => Ok(Self::Color(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Nester => Ok(Self::Nester(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::NesterNestedEnum => Ok(Self::NesterNestedEnum(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::NesterNestedStruct => Ok(Self::NesterNestedStruct(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::NesterNestedUnion => Ok(Self::NesterNestedUnion(Box::new(serde::de::Deserialize::deserialize(r)?))),
                 }
             }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -3389,8 +3389,14 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.limit
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     TypeVariant::SError => Ok(Self::SError(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Multi => Ok(Self::Multi(Box::new(serde_json::from_reader(r)?))),
@@ -3398,6 +3404,19 @@ TypeVariant::UnionKey => Ok(Self::UnionKey(Box::new(serde_json::from_reader(r)?)
 TypeVariant::MyUnion => Ok(Self::MyUnion(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::IntUnion => Ok(Self::IntUnion(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::IntUnion2 => Ok(Self::IntUnion2(Box::new(serde_json::from_reader(r)?))),
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    TypeVariant::SError => Ok(Self::SError(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Multi => Ok(Self::Multi(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::UnionKey => Ok(Self::UnionKey(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::MyUnion => Ok(Self::MyUnion(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::IntUnion => Ok(Self::IntUnion(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::IntUnion2 => Ok(Self::IntUnion2(Box::new(serde::de::Deserialize::deserialize(r)?))),
                 }
             }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -3030,10 +3030,24 @@ impl Type {
     }
 
     #[cfg(all(feature = "std", feature = "serde_json"))]
-    #[allow(clippy::too_many_lines)]
+    #[deprecated(note = "use from_json")]
     pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+        Self::from_json(v, r)
+    }
+
+    #[cfg(all(feature = "std", feature = "serde_json"))]
+    #[allow(clippy::too_many_lines)]
+    pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
         match v {
             TypeVariant::AccountFlags => Ok(Self::AccountFlags(Box::new(serde_json::from_reader(r)?))),
+        }
+    }
+
+    #[cfg(all(feature = "std", feature = "serde_json"))]
+    #[allow(clippy::too_many_lines)]
+    pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+        match v {
+            TypeVariant::AccountFlags => Ok(Self::AccountFlags(Box::new(serde::de::Deserialize::deserialize(r)?))),
         }
     }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -2969,11 +2969,26 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.lim
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     TypeVariant::TestArray => Ok(Self::TestArray(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::TestArray2 => Ok(Self::TestArray2(Box::new(serde_json::from_reader(r)?))),
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    TypeVariant::TestArray => Ok(Self::TestArray(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::TestArray2 => Ok(Self::TestArray2(Box::new(serde::de::Deserialize::deserialize(r)?))),
                 }
             }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -3480,13 +3480,30 @@ TypeVariant::Color3 => Box::new(ReadXdrIter::<_, Color3>::new(dec, r.limits.clon
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     TypeVariant::MessageType => Ok(Self::MessageType(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Color => Ok(Self::Color(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Color2 => Ok(Self::Color2(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Color3 => Ok(Self::Color3(Box::new(serde_json::from_reader(r)?))),
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    TypeVariant::MessageType => Ok(Self::MessageType(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Color => Ok(Self::Color(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Color2 => Ok(Self::Color2(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Color3 => Ok(Self::Color3(Box::new(serde::de::Deserialize::deserialize(r)?))),
                 }
             }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -3305,14 +3305,32 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.lim
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     TypeVariant::UnionKey => Ok(Self::UnionKey(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Foo => Ok(Self::Foo(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::MyUnion => Ok(Self::MyUnion(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::MyUnionOne => Ok(Self::MyUnionOne(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::MyUnionTwo => Ok(Self::MyUnionTwo(Box::new(serde_json::from_reader(r)?))),
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    TypeVariant::UnionKey => Ok(Self::UnionKey(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Foo => Ok(Self::Foo(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::MyUnion => Ok(Self::MyUnion(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::MyUnionOne => Ok(Self::MyUnionOne(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::MyUnionTwo => Ok(Self::MyUnionTwo(Box::new(serde::de::Deserialize::deserialize(r)?))),
                 }
             }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -2999,11 +2999,26 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.lim
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     TypeVariant::Arr => Ok(Self::Arr(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::HasOptions => Ok(Self::HasOptions(Box::new(serde_json::from_reader(r)?))),
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    TypeVariant::Arr => Ok(Self::Arr(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::HasOptions => Ok(Self::HasOptions(Box::new(serde::de::Deserialize::deserialize(r)?))),
                 }
             }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -3007,11 +3007,26 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits.
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     TypeVariant::Int64 => Ok(Self::Int64(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::MyStruct => Ok(Self::MyStruct(Box::new(serde_json::from_reader(r)?))),
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    TypeVariant::Int64 => Ok(Self::Int64(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::MyStruct => Ok(Self::MyStruct(Box::new(serde::de::Deserialize::deserialize(r)?))),
                 }
             }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -4916,8 +4916,14 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     TypeVariant::Uint512 => Ok(Self::Uint512(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Uint513 => Ok(Self::Uint513(Box::new(serde_json::from_reader(r)?))),
@@ -4942,6 +4948,36 @@ TypeVariant::Nester => Ok(Self::Nester(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::NesterNestedEnum => Ok(Self::NesterNestedEnum(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::NesterNestedStruct => Ok(Self::NesterNestedStruct(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::NesterNestedUnion => Ok(Self::NesterNestedUnion(Box::new(serde_json::from_reader(r)?))),
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    TypeVariant::Uint512 => Ok(Self::Uint512(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Uint513 => Ok(Self::Uint513(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Uint514 => Ok(Self::Uint514(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Str => Ok(Self::Str(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Str2 => Ok(Self::Str2(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Hash => Ok(Self::Hash(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Hashes1 => Ok(Self::Hashes1(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Hashes2 => Ok(Self::Hashes2(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Hashes3 => Ok(Self::Hashes3(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::OptHash1 => Ok(Self::OptHash1(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::OptHash2 => Ok(Self::OptHash2(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Int1 => Ok(Self::Int1(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Int2 => Ok(Self::Int2(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Int3 => Ok(Self::Int3(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Int4 => Ok(Self::Int4(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::MyStruct => Ok(Self::MyStruct(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::LotsOfMyStructs => Ok(Self::LotsOfMyStructs(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::HasStuff => Ok(Self::HasStuff(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Color => Ok(Self::Color(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Nester => Ok(Self::Nester(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::NesterNestedEnum => Ok(Self::NesterNestedEnum(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::NesterNestedStruct => Ok(Self::NesterNestedStruct(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::NesterNestedUnion => Ok(Self::NesterNestedUnion(Box::new(serde::de::Deserialize::deserialize(r)?))),
                 }
             }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -3391,8 +3391,14 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.limit
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
-            #[allow(clippy::too_many_lines)]
+            #[deprecated(note = "use from_json")]
             pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+                Self::from_json(v, r)
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
                 match v {
                     TypeVariant::SError => Ok(Self::SError(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Multi => Ok(Self::Multi(Box::new(serde_json::from_reader(r)?))),
@@ -3400,6 +3406,19 @@ TypeVariant::UnionKey => Ok(Self::UnionKey(Box::new(serde_json::from_reader(r)?)
 TypeVariant::MyUnion => Ok(Self::MyUnion(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::IntUnion => Ok(Self::IntUnion(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::IntUnion2 => Ok(Self::IntUnion2(Box::new(serde_json::from_reader(r)?))),
+                }
+            }
+
+            #[cfg(all(feature = "std", feature = "serde_json"))]
+            #[allow(clippy::too_many_lines)]
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+                match v {
+                    TypeVariant::SError => Ok(Self::SError(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::Multi => Ok(Self::Multi(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::UnionKey => Ok(Self::UnionKey(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::MyUnion => Ok(Self::MyUnion(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::IntUnion => Ok(Self::IntUnion(Box::new(serde::de::Deserialize::deserialize(r)?))),
+TypeVariant::IntUnion2 => Ok(Self::IntUnion2(Box::new(serde::de::Deserialize::deserialize(r)?))),
                 }
             }
 


### PR DESCRIPTION
### What
Add deserialize_json fn to the Type object for deserializing multiple types in json from a stream when the type variant is known at runtime not compile time. Also rename read_json to from_json in a backwards compatible way.

### Why
In the CLI we need to be able to decode JSON for arbitrary types at runtime in much the same way we can decode XDR for arbitrary types so the commands have symmetry.

We support decoding XDR to JSON for streams, but not in reverse.

There's a function today `read_json` that can decode a JSON object into an arbitrary Type variant, but because of the interface the function used it only does so for a single JSON object and expects an EOF to occur.

For streams we need to use the more complex serde interface to deserialize multiple objects from the stream.

The read_json fn is renamed to from_json to be more similar to the serde_json's own naming schemes for these two functions. It's much easier to see the correlation that the from method in our crate calls a from method on the serde_json crate which has certain meaning, vs the deserialize call which has certain meaning in that crate too.