### PR TITLE
chore: pin 'concurrent-ruby' to a working version.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     xdrgen (0.1.3)
       activesupport (~> 6)
+      concurrent-ruby (<= 1.3.4)
       memoist (~> 0.11.0)
       slop (~> 3.4)
       treetop (~> 1.5.3)

--- a/xdrgen.gemspec
+++ b/xdrgen.gemspec
@@ -23,7 +23,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", "~> 6"
   spec.add_dependency "slop", "~> 3.4"
   spec.add_dependency "memoist", "~> 0.11.0"
-
+  # https://stackoverflow.com/questions/79360526/uninitialized-constant-activesupportloggerthreadsafelevellogger-nameerror
+  spec.add_dependency "concurrent-ruby", "<= 1.3.4"
+  
   spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.1"


### PR DESCRIPTION
See https://stackoverflow.com/questions/79360526/uninitialized-constant-activesupportloggerthreadsafelevellogger-nameerror

Running xdrgen will result in the following error, and this PR will fix the issue.
```
/usr/local/rvm/gems/default/gems/activesupport-6.1.6.1/lib/active_support/logger_thread_safe_level.rb:16:in `<module:LoggerThreadSafeLevel>': uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger (NameError)

    Logger::Severity.constants.each do |severity|
          ^^^^^^^^^^
        from /usr/local/rvm/gems/default/gems/activesupport-6.1.6.1/lib/active_support/logger_thread_safe_level.rb:9:in `<module:ActiveSupport>'
        from /usr/local/rvm/gems/default/gems/activesupport-6.1.6.1/lib/active_support/logger_thread_safe_level.rb:8:in `<top (required)>'
        from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
        from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
        from /usr/local/rvm/gems/default/gems/activesupport-6.1.6.1/lib/active_support/logger_silence.rb:5:in `<top (required)>'
        from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
        from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
        from /usr/local/rvm/gems/default/gems/activesupport-6.1.6.1/lib/active_support/logger.rb:3:in `<top (required)>'
        from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
        from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
        from /usr/local/rvm/gems/default/gems/activesupport-6.1.6.1/lib/active_support.rb:29:in `<top (required)>'
        from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
        from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
        from /usr/local/rvm/gems/default/gems/activesupport-6.1.6.1/lib/active_support/all.rb:3:in `<top (required)>'
        from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
        from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
        from /usr/local/rvm/gems/default/gems/xdrgen-0.1.3/lib/xdrgen.rb:2:in `<top (required)>'
        from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
        from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
        from /usr/local/rvm/gems/default/gems/xdrgen-0.1.3/bin/xdrgen:3:in `<top (required)>'
        from /usr/local/rvm/gems/default/bin/xdrgen:25:in `load'
        from /usr/local/rvm/gems/default/bin/xdrgen:25:in `<main>'
```