### PR TITLE
Add Make Job to GitHub Workflow

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,12 +9,13 @@ jobs:
 
   complete:
     if: always()
-    needs: [test]
+    needs: [test, make]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
       run: exit 1
 
+  # Test that the tests pass across different versions of Ruby.
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -32,5 +33,17 @@ jobs:
       run: rm -fr spec/output
     - name: Run Rspec tests
       run: bundle exec rspec
+    - name: Check test outputs contain no diffs
+      run: git add spec/output && git status && git diff --staged --exit-code -- spec/output || (echo "Test outputs contain changes. Run 'make' locally and check that the changes are desired. If they're desired, commit them as part of the change." && exit 1)
+
+  # Test that the makefile for use locally works.
+  make:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Remove test outputs for tests to generate
+      run: rm -fr spec/output
+    - name: Run make
+      run: make
     - name: Check test outputs contain no diffs
       run: git add spec/output && git status && git diff --staged --exit-code -- spec/output || (echo "Test outputs contain changes. Run 'make' locally and check that the changes are desired. If they're desired, commit them as part of the change." && exit 1)

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0']
+        ruby-version: ['2.7', '3.0', '3.3']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      uses: ruby/setup-ruby@8388f20e6a9c43cd241131b678469a9f89579f37
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 test:
-	docker run -it --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
+	docker run -it --rm -v $$PWD:/wd -w /wd ruby:3.3 /bin/bash -c '\
 		bundle install && \
 		bundle exec rspec \
 	'
 
 console:
-	docker run -it --rm -v $$PWD:/wd -w /wd ruby /bin/bash -c '\
+	docker run -it --rm -v $$PWD:/wd -w /wd ruby:3.3 /bin/bash -c '\
 		bundle install && \
 		bash \
 	'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	docker run -it --rm -v $$PWD:/wd -w /wd ruby:3.3 /bin/bash -c '\
+	docker run --rm -v $$PWD:/wd -w /wd ruby:3.3 /bin/bash -c '\
 		bundle install && \
 		bundle exec rspec \
 	'


### PR DESCRIPTION
### What
Adds a new 'make' job to the GitHub workflow to test the local Makefile.

Pin the make job to ruby 3.3.

### Why
Ensures that the Makefile works correctly and generates expected test outputs during continuous integration. I noticed in @overcat's PR below that the tests pass in CI, but the Makefile doesn't locally.

- https://github.com/stellar/xdrgen/pull/206

As @overcat pointed out in that other PR, the Makefile doesn't pin to a version of ruby and xdrgen currently doesn't build with ruby 3.4.