### PR TITLE
Fix xdrgen build breakage.

### DIFF
--- a/lib/xdrgen.rb
+++ b/lib/xdrgen.rb
@@ -1,4 +1,5 @@
 require "xdrgen/version"
+require "logger"
 require "active_support/all"
 require 'memoist'
 


### PR DESCRIPTION
There was an issue introduced in the new version of `concurrent-ruby` that breaks `active-support`. It seems to be easily resolved by just requiring logger before the affected library.