### PR TITLE
Rust: Add iter_mut method to VecM struct

### DIFF
--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -927,6 +927,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -927,12 +927,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -933,6 +933,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -937,6 +937,10 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
+      self.0.iter_mut()
+    }
 }
 
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -943,6 +943,14 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     }
 }
 
+impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T: Clone, const MAX: u32> VecM<T, MAX> {
     #[must_use]
     #[cfg(feature = "alloc")]

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -937,12 +937,16 @@ impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn as_vec(&self) -> &Vec<T> {
         self.as_ref()
     }
+}
 
+#[cfg(feature = "alloc")]
+impl<T, const MAX: u32> VecM<T, MAX> {
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> {
-      self.0.iter_mut()
+        self.0.iter_mut()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, T, const MAX: u32> core::iter::IntoIterator for &'a mut VecM<T, MAX> {
     type Item = &'a mut T;
     type IntoIter = core::slice::IterMut<'a, T>;


### PR DESCRIPTION
### What
Add iter_mut method to VecM struct in the Rust generated code.

### Why
Enables direct modification of elements within a VecM without needing to replace the entire collection.

Close #209