### PR TITLE
Auto skip whitespace in base64 decode of XDR

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -185,7 +185,13 @@ module Xdrgen
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -204,7 +210,13 @@ module Xdrgen
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -228,7 +240,10 @@ module Xdrgen
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+                let dec = base64::read::DecoderReader::new(
+                    SkipWhitespace::new(&mut r.inner),
+                    &base64::engine::general_purpose::STANDARD,
+                );
                 match v {
                     #{types.map { |t| "TypeVariant::#{t} => Box::new(ReadXdrIter::<_, #{t}>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::#{t}(Box::new(t)))))," }.join("\n")}
                 }
@@ -244,7 +259,13 @@ module Xdrgen
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
                 let mut b64_reader = Cursor::new(b64);
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(b64_reader),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    limits,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -258,10 +258,9 @@ module Xdrgen
 
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-                let mut b64_reader = Cursor::new(b64);
                 let mut dec = Limited::new(
                     base64::read::DecoderReader::new(
-                        SkipWhitespace::new(b64_reader),
+                        SkipWhitespace::new(Cursor::new(b64)),
                         &base64::engine::general_purpose::STANDARD,
                     ),
                     limits,

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -405,11 +405,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(&mut r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -453,11 +452,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(&mut r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -546,7 +544,7 @@ where
     ) -> ReadXdrIter<base64::read::DecoderReader<impl Read>, Self> {
         let dec = base64::read::DecoderReader::new(
             SkipWhitespace::new(&mut r.inner),
-            base64::STANDARD,
+            base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -569,11 +567,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -597,7 +594,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -545,7 +545,7 @@ where
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<impl Read>, Self> {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(&mut r.inner),
+            SkipWhitespace::new(&mut r.inner),
             base64::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -545,7 +545,7 @@ where
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<impl Read>, Self> {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
+            &mut SkipWhitespace::new(&mut r.inner),
             base64::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -2171,8 +2171,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -543,7 +543,7 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<base64::read::DecoderReader<impl Read>, Self> {
         let dec = base64::read::DecoderReader::new(
             &mut SkipWhitespace::new(r.inner),
             base64::STANDARD,

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -541,7 +541,13 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
             SkipWhitespace::new(&mut r.inner),
             &base64::engine::general_purpose::STANDARD,

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -405,9 +405,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -452,9 +453,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -567,9 +569,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -541,7 +541,7 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<impl Read>, Self> {
+    ) -> ReadXdrIter<base64::read::DecoderReader, Self> {
         let dec = base64::read::DecoderReader::new(
             SkipWhitespace::new(&mut r.inner),
             &base64::engine::general_purpose::STANDARD,

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -408,7 +408,7 @@ where
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
                 SkipWhitespace::new(&mut r.inner),
-                base64::engine::general_purpose::STANDARD,
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -455,7 +455,7 @@ where
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
                 SkipWhitespace::new(&mut r.inner),
-                base64::engine::general_purpose::STANDARD,
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -544,7 +544,7 @@ where
     ) -> ReadXdrIter<base64::read::DecoderReader<impl Read>, Self> {
         let dec = base64::read::DecoderReader::new(
             SkipWhitespace::new(&mut r.inner),
-            base64::engine::general_purpose::STANDARD,
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -570,7 +570,7 @@ where
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
                 SkipWhitespace::new(b64_reader),
-                base64::engine::general_purpose::STANDARD,
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -594,7 +594,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::engine::general_purpose::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -571,7 +571,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -544,7 +544,7 @@ where
     ) -> ReadXdrIter<
         base64::read::DecoderReader<
             base64::engine::general_purpose::GeneralPurpose,
-            SkipWhitespace<R>,
+            SkipWhitespace<&mut R>,
         >,
         Self
     > {

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -405,7 +405,7 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
+        let mut skip_whitespace = SkipWhitespace::new(&mut r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
                 &mut skip_whitespace,
@@ -453,7 +453,7 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
+        let mut skip_whitespace = SkipWhitespace::new(&mut r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
                 &mut skip_whitespace,
@@ -568,7 +568,7 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
+        let b64_reader = Cursor::new(b64);
         let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -415,11 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -463,11 +462,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -553,10 +551,16 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
-            base64::STANDARD,
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -578,12 +582,11 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
+        let b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -607,7 +610,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;
@@ -3068,7 +3071,13 @@ impl Type {
 
     #[cfg(feature = "base64")]
     pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+        let mut dec = Limited::new(
+            base64::read::DecoderReader::new(
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
+            ),
+            r.limits.clone(),
+        );
         let t = Self::read_xdr(v, &mut dec)?;
         Ok(t)
     }
@@ -3087,7 +3096,13 @@ impl Type {
 
     #[cfg(feature = "base64")]
     pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+        let mut dec = Limited::new(
+            base64::read::DecoderReader::new(
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
+            ),
+            r.limits.clone(),
+        );
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
     }
@@ -3111,7 +3126,10 @@ impl Type {
     #[cfg(feature = "base64")]
     #[allow(clippy::too_many_lines)]
     pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
+        );
         match v {
             TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
@@ -3126,8 +3144,13 @@ impl Type {
 
     #[cfg(feature = "base64")]
     pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+        let mut dec = Limited::new(
+            base64::read::DecoderReader::new(
+                SkipWhitespace::new(Cursor::new(b64)),
+                &base64::engine::general_purpose::STANDARD,
+            ),
+            limits,
+        );
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
     }

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -415,11 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -463,11 +462,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -553,10 +551,16 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
-            base64::STANDARD,
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -578,12 +582,11 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
+        let b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -607,7 +610,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;
@@ -3004,7 +3007,13 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -3023,7 +3032,13 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -3049,7 +3064,10 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mu
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+                let dec = base64::read::DecoderReader::new(
+                    SkipWhitespace::new(&mut r.inner),
+                    &base64::engine::general_purpose::STANDARD,
+                );
                 match v {
                     TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
 TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
@@ -3065,8 +3083,13 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.lim
 
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-                let mut b64_reader = Cursor::new(b64);
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(Cursor::new(b64)),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    limits,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -415,11 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -463,11 +462,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -553,10 +551,16 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
-            base64::STANDARD,
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -578,12 +582,11 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
+        let b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -607,7 +610,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;
@@ -3331,7 +3334,13 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -3350,7 +3359,13 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -3382,7 +3397,10 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(&mu
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+                let dec = base64::read::DecoderReader::new(
+                    SkipWhitespace::new(&mut r.inner),
+                    &base64::engine::general_purpose::STANDARD,
+                );
                 match v {
                     TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
 TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
@@ -3401,8 +3419,13 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.lim
 
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-                let mut b64_reader = Cursor::new(b64);
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(Cursor::new(b64)),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    limits,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -415,11 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -463,11 +462,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -553,10 +551,16 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
-            base64::STANDARD,
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -578,12 +582,11 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
+        let b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -607,7 +610,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;
@@ -3034,7 +3037,13 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -3053,7 +3062,13 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -3079,7 +3094,10 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mu
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+                let dec = base64::read::DecoderReader::new(
+                    SkipWhitespace::new(&mut r.inner),
+                    &base64::engine::general_purpose::STANDARD,
+                );
                 match v {
                     TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
 TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
@@ -3095,8 +3113,13 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.lim
 
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-                let mut b64_reader = Cursor::new(b64);
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(Cursor::new(b64)),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    limits,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -415,11 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -463,11 +462,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -553,10 +551,16 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
-            base64::STANDARD,
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -578,12 +582,11 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
+        let b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -607,7 +610,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;
@@ -3042,7 +3045,13 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -3061,7 +3070,13 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -3087,7 +3102,10 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+                let dec = base64::read::DecoderReader::new(
+                    SkipWhitespace::new(&mut r.inner),
+                    &base64::engine::general_purpose::STANDARD,
+                );
                 match v {
                     TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
 TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
@@ -3103,8 +3121,13 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits.
 
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-                let mut b64_reader = Cursor::new(b64);
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(Cursor::new(b64)),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    limits,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -415,11 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -463,11 +462,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -553,10 +551,16 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
-            base64::STANDARD,
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -578,12 +582,11 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
+        let b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -607,7 +610,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;
@@ -4888,7 +4891,13 @@ TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNested
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -4907,7 +4916,13 @@ TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNested
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -4975,7 +4990,10 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, Frame<NesterNestedUn
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+                let dec = base64::read::DecoderReader::new(
+                    SkipWhitespace::new(&mut r.inner),
+                    &base64::engine::general_purpose::STANDARD,
+                );
                 match v {
                     TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
 TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Uint513>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Uint513(Box::new(t))))),
@@ -5012,8 +5030,13 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::
 
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-                let mut b64_reader = Cursor::new(b64);
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(Cursor::new(b64)),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    limits,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -415,11 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -463,11 +462,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -553,10 +551,16 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
-            base64::STANDARD,
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -578,12 +582,11 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
+        let b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -607,7 +610,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;
@@ -3414,7 +3417,13 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -3433,7 +3442,13 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -3467,7 +3482,10 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, Frame<IntUnion2>>::new(&mut 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+                let dec = base64::read::DecoderReader::new(
+                    SkipWhitespace::new(&mut r.inner),
+                    &base64::engine::general_purpose::STANDARD,
+                );
                 match v {
                     TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::SError(Box::new(t))))),
 TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
@@ -3487,8 +3505,13 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.limit
 
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-                let mut b64_reader = Cursor::new(b64);
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(Cursor::new(b64)),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    limits,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
@@ -415,11 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -463,11 +462,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -553,10 +551,16 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
-            base64::STANDARD,
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -578,12 +582,11 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
+        let b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -607,7 +610,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;
@@ -3068,7 +3071,13 @@ impl Type {
 
     #[cfg(feature = "base64")]
     pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+        let mut dec = Limited::new(
+            base64::read::DecoderReader::new(
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
+            ),
+            r.limits.clone(),
+        );
         let t = Self::read_xdr(v, &mut dec)?;
         Ok(t)
     }
@@ -3087,7 +3096,13 @@ impl Type {
 
     #[cfg(feature = "base64")]
     pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+        let mut dec = Limited::new(
+            base64::read::DecoderReader::new(
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
+            ),
+            r.limits.clone(),
+        );
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
     }
@@ -3111,7 +3126,10 @@ impl Type {
     #[cfg(feature = "base64")]
     #[allow(clippy::too_many_lines)]
     pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
+        );
         match v {
             TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
@@ -3126,8 +3144,13 @@ impl Type {
 
     #[cfg(feature = "base64")]
     pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+        let mut dec = Limited::new(
+            base64::read::DecoderReader::new(
+                SkipWhitespace::new(Cursor::new(b64)),
+                &base64::engine::general_purpose::STANDARD,
+            ),
+            limits,
+        );
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
     }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
@@ -415,11 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -463,11 +462,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -553,10 +551,16 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
-            base64::STANDARD,
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -578,12 +582,11 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
+        let b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -607,7 +610,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;
@@ -3004,7 +3007,13 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -3023,7 +3032,13 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -3049,7 +3064,10 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mu
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+                let dec = base64::read::DecoderReader::new(
+                    SkipWhitespace::new(&mut r.inner),
+                    &base64::engine::general_purpose::STANDARD,
+                );
                 match v {
                     TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
 TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
@@ -3065,8 +3083,13 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.lim
 
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-                let mut b64_reader = Cursor::new(b64);
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(Cursor::new(b64)),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    limits,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
@@ -415,11 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -463,11 +462,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -553,10 +551,16 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
-            base64::STANDARD,
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -578,12 +582,11 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
+        let b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -607,7 +610,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;
@@ -3508,7 +3511,13 @@ TypeVariant::Color3 => r.with_limited_depth(|r| Ok(Self::Color3(Box::new(Color3:
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -3527,7 +3536,13 @@ TypeVariant::Color3 => r.with_limited_depth(|r| Ok(Self::Color3(Box::new(Color3:
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -3557,7 +3572,10 @@ TypeVariant::Color3 => Box::new(ReadXdrIter::<_, Frame<Color3>>::new(&mut r.inne
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+                let dec = base64::read::DecoderReader::new(
+                    SkipWhitespace::new(&mut r.inner),
+                    &base64::engine::general_purpose::STANDARD,
+                );
                 match v {
                     TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
 TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
@@ -3575,8 +3593,13 @@ TypeVariant::Color3 => Box::new(ReadXdrIter::<_, Color3>::new(dec, r.limits.clon
 
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-                let mut b64_reader = Cursor::new(b64);
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(Cursor::new(b64)),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    limits,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -415,11 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -463,11 +462,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -553,10 +551,16 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
-            base64::STANDARD,
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -578,12 +582,11 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
+        let b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -607,7 +610,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;
@@ -3329,7 +3332,13 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -3348,7 +3357,13 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -3380,7 +3395,10 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(&mu
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+                let dec = base64::read::DecoderReader::new(
+                    SkipWhitespace::new(&mut r.inner),
+                    &base64::engine::general_purpose::STANDARD,
+                );
                 match v {
                     TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
 TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
@@ -3399,8 +3417,13 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.lim
 
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-                let mut b64_reader = Cursor::new(b64);
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(Cursor::new(b64)),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    limits,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -415,11 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -463,11 +462,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -553,10 +551,16 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
-            base64::STANDARD,
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -578,12 +582,11 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
+        let b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -607,7 +610,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;
@@ -3033,7 +3036,13 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -3052,7 +3061,13 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -3078,7 +3093,10 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mu
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+                let dec = base64::read::DecoderReader::new(
+                    SkipWhitespace::new(&mut r.inner),
+                    &base64::engine::general_purpose::STANDARD,
+                );
                 match v {
                     TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
 TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
@@ -3094,8 +3112,13 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.lim
 
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-                let mut b64_reader = Cursor::new(b64);
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(Cursor::new(b64)),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    limits,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -415,11 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -463,11 +462,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -553,10 +551,16 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
-            base64::STANDARD,
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -578,12 +582,11 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
+        let b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -607,7 +610,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;
@@ -3041,7 +3044,13 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -3060,7 +3069,13 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -3086,7 +3101,10 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+                let dec = base64::read::DecoderReader::new(
+                    SkipWhitespace::new(&mut r.inner),
+                    &base64::engine::general_purpose::STANDARD,
+                );
                 match v {
                     TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
 TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
@@ -3102,8 +3120,13 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits.
 
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-                let mut b64_reader = Cursor::new(b64);
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(Cursor::new(b64)),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    limits,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -415,11 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -463,11 +462,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -553,10 +551,16 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
-            base64::STANDARD,
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -578,12 +582,11 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
+        let b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -607,7 +610,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;
@@ -4886,7 +4889,13 @@ TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNested
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -4905,7 +4914,13 @@ TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNested
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -4973,7 +4988,10 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, Frame<NesterNestedUn
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+                let dec = base64::read::DecoderReader::new(
+                    SkipWhitespace::new(&mut r.inner),
+                    &base64::engine::general_purpose::STANDARD,
+                );
                 match v {
                     TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
 TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Uint513>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Uint513(Box::new(t))))),
@@ -5010,8 +5028,13 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::
 
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-                let mut b64_reader = Cursor::new(b64);
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(Cursor::new(b64)),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    limits,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -415,11 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -463,11 +462,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -553,10 +551,16 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
-            base64::STANDARD,
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -578,12 +582,11 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
+        let b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -607,7 +610,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;
@@ -3068,7 +3071,13 @@ impl Type {
 
     #[cfg(feature = "base64")]
     pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+        let mut dec = Limited::new(
+            base64::read::DecoderReader::new(
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
+            ),
+            r.limits.clone(),
+        );
         let t = Self::read_xdr(v, &mut dec)?;
         Ok(t)
     }
@@ -3087,7 +3096,13 @@ impl Type {
 
     #[cfg(feature = "base64")]
     pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+        let mut dec = Limited::new(
+            base64::read::DecoderReader::new(
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
+            ),
+            r.limits.clone(),
+        );
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
     }
@@ -3111,7 +3126,10 @@ impl Type {
     #[cfg(feature = "base64")]
     #[allow(clippy::too_many_lines)]
     pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
+        );
         match v {
             TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
@@ -3126,8 +3144,13 @@ impl Type {
 
     #[cfg(feature = "base64")]
     pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+        let mut dec = Limited::new(
+            base64::read::DecoderReader::new(
+                SkipWhitespace::new(Cursor::new(b64)),
+                &base64::engine::general_purpose::STANDARD,
+            ),
+            limits,
+        );
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
     }

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -415,11 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -463,11 +462,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -553,10 +551,16 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
-            base64::STANDARD,
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -578,12 +582,11 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
+        let b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -607,7 +610,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;
@@ -3004,7 +3007,13 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -3023,7 +3032,13 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -3049,7 +3064,10 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mu
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+                let dec = base64::read::DecoderReader::new(
+                    SkipWhitespace::new(&mut r.inner),
+                    &base64::engine::general_purpose::STANDARD,
+                );
                 match v {
                     TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
 TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
@@ -3065,8 +3083,13 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.lim
 
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-                let mut b64_reader = Cursor::new(b64);
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(Cursor::new(b64)),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    limits,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -415,11 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -463,11 +462,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -553,10 +551,16 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
-            base64::STANDARD,
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -578,12 +582,11 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
+        let b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -607,7 +610,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;
@@ -3331,7 +3334,13 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -3350,7 +3359,13 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -3382,7 +3397,10 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(&mu
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+                let dec = base64::read::DecoderReader::new(
+                    SkipWhitespace::new(&mut r.inner),
+                    &base64::engine::general_purpose::STANDARD,
+                );
                 match v {
                     TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
 TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
@@ -3401,8 +3419,13 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.lim
 
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-                let mut b64_reader = Cursor::new(b64);
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(Cursor::new(b64)),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    limits,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -415,11 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -463,11 +462,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -553,10 +551,16 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
-            base64::STANDARD,
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -578,12 +582,11 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
+        let b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -607,7 +610,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;
@@ -3034,7 +3037,13 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -3053,7 +3062,13 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -3079,7 +3094,10 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mu
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+                let dec = base64::read::DecoderReader::new(
+                    SkipWhitespace::new(&mut r.inner),
+                    &base64::engine::general_purpose::STANDARD,
+                );
                 match v {
                     TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
 TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
@@ -3095,8 +3113,13 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.lim
 
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-                let mut b64_reader = Cursor::new(b64);
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(Cursor::new(b64)),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    limits,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -415,11 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -463,11 +462,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -553,10 +551,16 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
-            base64::STANDARD,
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -578,12 +582,11 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
+        let b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -607,7 +610,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;
@@ -3042,7 +3045,13 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -3061,7 +3070,13 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -3087,7 +3102,10 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+                let dec = base64::read::DecoderReader::new(
+                    SkipWhitespace::new(&mut r.inner),
+                    &base64::engine::general_purpose::STANDARD,
+                );
                 match v {
                     TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
 TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
@@ -3103,8 +3121,13 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits.
 
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-                let mut b64_reader = Cursor::new(b64);
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(Cursor::new(b64)),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    limits,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -415,11 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -463,11 +462,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -553,10 +551,16 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
-            base64::STANDARD,
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -578,12 +582,11 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
+        let b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -607,7 +610,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;
@@ -4888,7 +4891,13 @@ TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNested
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -4907,7 +4916,13 @@ TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNested
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -4975,7 +4990,10 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, Frame<NesterNestedUn
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+                let dec = base64::read::DecoderReader::new(
+                    SkipWhitespace::new(&mut r.inner),
+                    &base64::engine::general_purpose::STANDARD,
+                );
                 match v {
                     TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
 TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Uint513>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Uint513(Box::new(t))))),
@@ -5012,8 +5030,13 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::
 
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-                let mut b64_reader = Cursor::new(b64);
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(Cursor::new(b64)),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    limits,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -581,7 +581,7 @@ where
             base64::read::DecoderReader::new(
                 &mut SkipWhitespace::new(b64_reader),
                 base64::STANDARD,
-            )
+            ),
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -415,9 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -462,9 +463,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(r.inner),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             r.limits.clone(),
@@ -577,9 +579,10 @@ where
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
+        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut SkipWhitespace::new(b64_reader),
+                &mut skip_whitespace,
                 base64::STANDARD,
             ),
             limits,

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -2181,8 +2181,6 @@ where
     }
 }
 
-use std::io::Read;
-
 /// Forwards read operations to the wrapped object, skipping over any
 /// whitespace.
 #[cfg(feature = "std")]

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -415,11 +415,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -463,11 +462,10 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
-        let mut skip_whitespace = SkipWhitespace::new(r.inner);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(&mut r.inner),
+                &base64::engine::general_purpose::STANDARD,
             ),
             r.limits.clone(),
         );
@@ -553,10 +551,16 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
-    ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
+    ) -> ReadXdrIter<
+        base64::read::DecoderReader<
+            base64::engine::general_purpose::GeneralPurpose,
+            SkipWhitespace<&mut R>,
+        >,
+        Self
+    > {
         let dec = base64::read::DecoderReader::new(
-            &mut SkipWhitespace::new(r.inner),
-            base64::STANDARD,
+            SkipWhitespace::new(&mut r.inner),
+            &base64::engine::general_purpose::STANDARD,
         );
         ReadXdrIter::new(dec, r.limits.clone())
     }
@@ -578,12 +582,11 @@ where
     /// deserialization.
     #[cfg(feature = "base64")]
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-        let mut b64_reader = Cursor::new(b64);
-        let mut skip_whitespace = SkipWhitespace::new(b64_reader);
+        let b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(
-                &mut skip_whitespace,
-                base64::STANDARD,
+                SkipWhitespace::new(b64_reader),
+                &base64::engine::general_purpose::STANDARD,
             ),
             limits,
         );
@@ -607,7 +610,7 @@ pub trait WriteXdr {
     #[cfg(feature = "base64")]
     fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
         let mut enc = Limited::new(
-            base64::write::EncoderStringWriter::new(base64::STANDARD),
+            base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD),
             limits,
         );
         self.write_xdr(&mut enc)?;
@@ -3414,7 +3417,13 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
@@ -3433,7 +3442,13 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
 
             #[cfg(feature = "base64")]
             pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(&mut r.inner),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    r.limits.clone(),
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }
@@ -3467,7 +3482,10 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, Frame<IntUnion2>>::new(&mut 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
             pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
-                let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+                let dec = base64::read::DecoderReader::new(
+                    SkipWhitespace::new(&mut r.inner),
+                    &base64::engine::general_purpose::STANDARD,
+                );
                 match v {
                     TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::SError(Box::new(t))))),
 TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
@@ -3487,8 +3505,13 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.limit
 
             #[cfg(feature = "base64")]
             pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
-                let mut b64_reader = Cursor::new(b64);
-                let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
+                let mut dec = Limited::new(
+                    base64::read::DecoderReader::new(
+                        SkipWhitespace::new(Cursor::new(b64)),
+                        &base64::engine::general_purpose::STANDARD,
+                    ),
+                    limits,
+                );
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
             }

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -416,7 +416,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr(&mut dec)?;
@@ -460,7 +463,10 @@ where
     #[cfg(feature = "base64")]
     fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(r.inner),
+                base64::STANDARD,
+            ),
             r.limits.clone(),
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -546,7 +552,10 @@ where
     fn read_xdr_base64_iter<R: Read>(
         r: &mut Limited<R>,
     ) -> ReadXdrIter<base64::read::DecoderReader<R>, Self> {
-        let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
+        let dec = base64::read::DecoderReader::new(
+            &mut SkipWhitespace::new(r.inner),
+            base64::STANDARD,
+        );
         ReadXdrIter::new(dec, r.limits.clone())
     }
 
@@ -569,7 +578,10 @@ where
     fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
-            base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
+            base64::read::DecoderReader::new(
+                &mut SkipWhitespace::new(b64_reader),
+                base64::STANDARD,
+            )
             limits,
         );
         let t = Self::read_xdr_to_end(&mut dec)?;
@@ -2165,6 +2177,80 @@ where
             // TODO: Support reading those additional frames for the same
             // record.
             Err(Error::Unsupported)
+        }
+    }
+}
+
+use std::io::Read;
+
+/// Forwards read operations to the wrapped object, skipping over any
+/// whitespace.
+#[cfg(feature = "std")]
+pub struct SkipWhitespace<R: Read> {
+    pub inner: R,
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> SkipWhitespace<R> {
+    pub fn new(inner: R) -> Self {
+        SkipWhitespace { inner }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<R: Read> Read for SkipWhitespace<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        let mut written = 0;
+        for read in 0..n {
+            if !buf[read].is_ascii_whitespace() {
+                buf[written] = buf[read];
+                written += 1;
+            }
+        }
+
+        Ok(written)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test_skip_whitespace {
+    use super::*;
+
+    #[test]
+    fn test() {
+        struct Test {
+            input: &'static [u8],
+            output: &'static [u8],
+        }
+        let tests = [
+            Test {
+                input: b"",
+                output: b"",
+            },
+            Test {
+                input: b" \n\t\r",
+                output: b"",
+            },
+            Test {
+                input: b"a c",
+                output: b"ac",
+            },
+            Test {
+                input: b"ab cd",
+                output: b"abcd",
+            },
+            Test {
+                input: b" ab \n cd ",
+                output: b"abcd",
+            },
+        ];
+        for (i, t) in tests.iter().enumerate() {
+            let mut skip = SkipWhitespace::new(t.input);
+            let mut output = Vec::new();
+            skip.read_to_end(&mut output).unwrap();
+            assert_eq!(output, t.output, "#{i}");
         }
     }
 }


### PR DESCRIPTION
### What
Modify XDR base64 to skip whitespace when decoding.

### Why
The stellar-xdr CLI already skips whitespace on all reads, but other applications also using this crate are copy-pasting the same logic.

There's an argument that skipping whitespace is very much a concern for the presentation layer or the application domain. However, the same could be said for base64 which is not actually part of the XDR standard and just happens to be a common way that systems and humans in the Stellar ecosystem pass around XDR. Yet, the stellar-xdr Rust crate includes base64 functionality as a first-class feature. And so, I think it's reasonable for it's base64 functionality to by default and exclusively skip whitespace.

### Considerations

We should consider if it's ever unsafe to skip whitespace when decoding base64. Whitespace characters are not included in the standard base64 alphabet, which is the alphabet used by the stellar-xdr Rust crate. It may be possible that an application hashes the base64 representation and expects that every base64 XDR hashed that parses successfully would map uniquely to only one XDR binary. However this assumption is already not true since base64 can contain optional trailing padding characters.