### PR TITLE
Rust: Serialize 64-bit integers as strings in xdr-json

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -1029,7 +1029,7 @@ module Xdrgen
         base_ref = base_reference(type)
         if ['i64','u64'].include?(base_ref)
           ref = reference(parent, type, 'DisplayFromStr')
-          "#[serde_as(as = \"#{ref}\")]"
+          "#[cfg_attr(all(feature = \"serde\", feature = \"alloc\"), serde_as(as = \"#{ref}\"))]"
         else
           nil
         end

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -1025,7 +1025,7 @@ module Xdrgen
       def field_attrs(parent, type)
         base_ref = base_reference(type)
         if ['i64','u64'].include?(base_ref)
-          ref = reference(parent, type, 'serde_with::DisplayFromStr')
+          ref = reference(parent, type, 'DisplayFromStr')
           "#[serde_as(as = \"#{ref}\")]"
         else
           nil
@@ -1057,9 +1057,9 @@ module Xdrgen
           "[#{base_ref}; #{size}]"
         when :var_array
           if !type.decl.resolved_size.nil?
-            "VecM::<#{base_ref}, #{type.decl.resolved_size}>"
+            "VecM<#{base_ref}, #{type.decl.resolved_size}>"
           else
-            "VecM::<#{base_ref}>"
+            "VecM<#{base_ref}>"
           end
         else
           raise "Unknown sub_type: #{type.sub_type}"

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -388,6 +388,7 @@ module Xdrgen
 
       def render_struct(out, struct)
         out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]"
+        out.puts %{#[cfg_eval::cfg_eval]}
         out.puts %{#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]}
         if @options[:rust_types_custom_str_impl].include?(name struct)
           out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]}
@@ -569,6 +570,7 @@ module Xdrgen
         discriminant_type = reference(nil, union.discriminant.type)
         discriminant_type_builtin = is_builtin_type(union.discriminant.type) || (is_builtin_type(union.discriminant.type.resolved_type.type) if union.discriminant.type.respond_to?(:resolved_type) && AST::Definitions::Typedef === union.discriminant.type.resolved_type)
         out.puts "// union with discriminant #{discriminant_type}"
+        out.puts %{#[cfg_eval::cfg_eval]}
         out.puts "#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]"
         out.puts %{#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]}
         if @options[:rust_types_custom_str_impl].include?(name union)
@@ -712,6 +714,7 @@ module Xdrgen
         if is_builtin_type(typedef.type)
           out.puts "pub type #{name typedef} = #{reference(typedef, typedef.type)};"
         else
+          out.puts %{#[cfg_eval::cfg_eval]}
           out.puts "#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]"
           out.puts %{#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]}
           out.puts "#[derive(Default)]" if is_var_array_type(typedef.type)

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -400,7 +400,8 @@ module Xdrgen
         out.puts "pub struct #{name struct} {"
         out.indent do
           struct.members.each do |m|
-            out.puts_if(field_attrs(m.declaration.type)) unless @options[:rust_types_custom_str_impl].include?(name struct)
+            puts "struct #{name struct} has #{m.declaration.type} #{reference(struct, m.declaration.type)}"
+            out.puts_if(field_attrs(m.declaration.type)) if !@options[:rust_types_custom_str_impl].include?(name struct)
             out.puts "pub #{field_name m}: #{reference(struct, m.declaration.type)},"
           end
         end
@@ -589,7 +590,7 @@ module Xdrgen
               out.puts "#{case_name}#{"(())" unless arm.void?},"
             else
               out.puts "#{case_name}("
-              out.puts_if(field_attrs(arm.type)) unless @options[:rust_types_custom_str_impl].include?(name union)
+              out.puts_if(field_attrs(arm.type)) if !@options[:rust_types_custom_str_impl].include?(name union)
               out.puts "  #{reference(union, arm.type)}"
               out.puts "),"
             end
@@ -727,7 +728,7 @@ module Xdrgen
             out.puts "#[derive(Debug)]"
           end
           out.puts "pub struct #{name typedef}("
-          out.puts_if(field_attrs(typedef.type)) unless @options[:rust_types_custom_str_impl].include?(name typedef)
+          out.puts_if(field_attrs(typedef.type)) if !@options[:rust_types_custom_str_impl].include?(name typedef)
           out.puts "  pub #{reference(typedef, typedef.type)}"
           out.puts ");"
           out.puts ""
@@ -972,9 +973,11 @@ module Xdrgen
       end
 
       def field_attrs(type)
-        case type
-        when AST::Typespecs::Hyper
-        when AST::Typespecs::UnsignedHyper
+        base_ref = base_reference(type)
+        case base_ref
+        when 'i64'
+          '#[serde_as(as = "serde_with::DisplayFromStr")]'
+        when 'u64'
           '#[serde_as(as = "serde_with::DisplayFromStr")]'
         end
       end

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -973,6 +973,7 @@ module Xdrgen
 
       def field_attrs(type)
         case type
+        when AST::Typespecs::Hyper
         when AST::Typespecs::UnsignedHyper
           '#[serde_as(as = "serde_with::DisplayFromStr")]'
         end

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -1026,7 +1026,7 @@ module Xdrgen
         base_ref = base_reference(type)
         if ['i64','u64'].include?(base_ref)
           ref = reference(parent, type, 'serde_with::DisplayFromStr')
-          "#[serde_as(as = \"${ref}\")]"
+          "#[serde_as(as = \"#{ref}\")]"
         else
           nil
         end

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -1023,14 +1023,13 @@ module Xdrgen
       end
 
       def field_attrs(parent, type)
-        nil
-        #base_ref = base_reference(type)
-        #if ['i64','u64'].include?(base_ref)
-        #  ref = reference(parent, type, 'serde_with::DisplayFromStr')
-        #  "#[serde_as(as = \"#{ref}\")]"
-        #else
-        #  nil
-        #end
+        base_ref = base_reference(type)
+        if ['i64','u64'].include?(base_ref)
+          ref = reference(parent, type, 'serde_with::DisplayFromStr')
+          "#[serde_as(as = \"#{ref}\")]"
+        else
+          nil
+        end
       end
 
       def reference(parent, type, base_ref = nil)

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -400,7 +400,6 @@ module Xdrgen
         out.puts "pub struct #{name struct} {"
         out.indent do
           struct.members.each do |m|
-            puts "struct #{name struct} has #{m.declaration.type} #{reference(struct, m.declaration.type)}"
             out.puts_if(field_attrs(m.declaration.type)) if !@options[:rust_types_custom_str_impl].include?(name struct)
             out.puts "pub #{field_name m}: #{reference(struct, m.declaration.type)},"
           end
@@ -575,7 +574,7 @@ module Xdrgen
         if @options[:rust_types_custom_str_impl].include?(name union)
           out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]}
         else
-          out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]}
+          out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]}
         end
         if !@options[:rust_types_custom_jsonschema_impl].include?(name union)
           out.puts %{#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]}
@@ -719,7 +718,7 @@ module Xdrgen
           if is_fixed_array_opaque(typedef.type) || @options[:rust_types_custom_str_impl].include?(name typedef)
             out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]}
           else
-            out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]}
+            out.puts %{#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]}
           end
           if !is_fixed_array_opaque(typedef.type) && !@options[:rust_types_custom_jsonschema_impl].include?(name typedef)
             out.puts %{#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]}

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -1023,13 +1023,14 @@ module Xdrgen
       end
 
       def field_attrs(parent, type)
-        base_ref = base_reference(type)
-        if ['i64','u64'].include?(base_ref)
-          ref = reference(parent, type, 'serde_with::DisplayFromStr')
-          "#[serde_as(as = \"#{ref}\")]"
-        else
-          nil
-        end
+        nil
+        #base_ref = base_reference(type)
+        #if ['i64','u64'].include?(base_ref)
+        #  ref = reference(parent, type, 'serde_with::DisplayFromStr')
+        #  "#[serde_as(as = \"#{ref}\")]"
+        #else
+        #  nil
+        #end
       end
 
       def reference(parent, type, base_ref = nil)

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -1028,7 +1028,7 @@ module Xdrgen
       def field_attrs(parent, type)
         base_ref = base_reference(type)
         if ['i64','u64'].include?(base_ref)
-          ref = reference(parent, type, 'DisplayFromStr')
+          ref = reference(parent, type, 'NumberOrString')
           "#[cfg_attr(all(feature = \"serde\", feature = \"alloc\"), serde_as(as = \"#{ref}\"))]"
         else
           nil

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -400,7 +400,7 @@ module Xdrgen
         out.puts "pub struct #{name struct} {"
         out.indent do
           struct.members.each do |m|
-            out.print(field_attrs(m.declaration.type)) unless @options[:rust_types_custom_str_impl].include?(name struct)
+            out.puts_if(field_attrs(m.declaration.type)) unless @options[:rust_types_custom_str_impl].include?(name struct)
             out.puts "pub #{field_name m}: #{reference(struct, m.declaration.type)},"
           end
         end
@@ -589,7 +589,7 @@ module Xdrgen
               out.puts "#{case_name}#{"(())" unless arm.void?},"
             else
               out.puts "#{case_name}("
-              out.print(field_attrs(arm.type)) unless @options[:rust_types_custom_str_impl].include?(name union)
+              out.puts_if(field_attrs(arm.type)) unless @options[:rust_types_custom_str_impl].include?(name union)
               out.puts "  #{reference(union, arm.type)}"
               out.puts "),"
             end
@@ -727,7 +727,7 @@ module Xdrgen
             out.puts "#[derive(Debug)]"
           end
           out.puts "pub struct #{name typedef}("
-          out.print(field_attrs(typedef.type)) unless @options[:rust_types_custom_str_impl].include?(name typedef)
+          out.puts_if(field_attrs(typedef.type)) unless @options[:rust_types_custom_str_impl].include?(name typedef)
           out.puts "  pub #{reference(typedef, typedef.type)}"
           out.puts ");"
           out.puts ""

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -400,7 +400,7 @@ module Xdrgen
         out.puts "pub struct #{name struct} {"
         out.indent do
           struct.members.each do |m|
-            out.puts("#{field_attrs(m.declaration.type)}") unless @options[:rust_types_custom_str_impl].include?(name struct)
+            out.print(field_attrs(m.declaration.type)) unless @options[:rust_types_custom_str_impl].include?(name struct)
             out.puts "pub #{field_name m}: #{reference(struct, m.declaration.type)},"
           end
         end
@@ -589,7 +589,7 @@ module Xdrgen
               out.puts "#{case_name}#{"(())" unless arm.void?},"
             else
               out.puts "#{case_name}("
-              out.puts("  #{field_attrs(arm.type)}") unless @options[:rust_types_custom_str_impl].include?(name union)
+              out.print(field_attrs(arm.type)) unless @options[:rust_types_custom_str_impl].include?(name union)
               out.puts "  #{reference(union, arm.type)}"
               out.puts "),"
             end
@@ -727,7 +727,7 @@ module Xdrgen
             out.puts "#[derive(Debug)]"
           end
           out.puts "pub struct #{name typedef}("
-          out.puts("  #{field_attrs(typedef.type)}") unless @options[:rust_types_custom_str_impl].include?(name typedef)
+          out.print(field_attrs(typedef.type)) unless @options[:rust_types_custom_str_impl].include?(name typedef)
           out.puts "  pub #{reference(typedef, typedef.type)}"
           out.puts ");"
           out.puts ""

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -958,7 +958,7 @@ where
     where
         D: serde::Deserializer<'de>,
     {
-        let vec: Vec<T> = <Vec<U> as serde_with::DeserializeAs>::deserialize_as(deserializer)?;
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
         Ok(vec.try_into().unwrap())
     }
 }

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -3009,7 +3009,7 @@ mod test {
     }
 }
 
-#[cfg(all(test, not(feature = "alloc")))]
+#[cfg(all(test, feature = "serde"))]
 mod tests {
     use super::*;
     use serde::{Deserialize, Serialize};

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -28,7 +28,7 @@ use alloc::{
     vec::Vec,
 };
 #[cfg(feature = "std")]
-use std::string::FromUtf8Error};
+use std::string::FromUtf8Error;
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -2343,6 +2343,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
+        use serde::Serialize;
         source.to_string().serialize(serializer)
     }
 }
@@ -2352,6 +2353,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
+        use serde::Serialize;
         source.to_string().serialize(serializer)
     }
 }
@@ -2365,7 +2367,7 @@ impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
         <String as schemars::JsonSchema>::schema_id()
     }
 
-    fn json_schema(gen: &mut schemars::SchemaGenerator) -> schemars::schema::Schema {
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
         <String as schemars::JsonSchema>::json_schema(gen)
     }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -963,7 +963,7 @@ where
         struct SeqVisitor<T, U, const MAX: u32>(PhantomData<(T, U, MAX)>);
         impl<'de, T, U, const MAX: u32> serde::de::Visitor<'de> for SeqVisitor<T, U, MAX>
         where
-            U: DeserializeAs<'de, T>,
+            U: serde_with::DeserializeAs<'de, T>,
         {
             type Value = VecM<T, MAX>;
 
@@ -975,13 +975,15 @@ where
             where
                 A: serde::de::SeqAccess<'de>,
             {
-                #[allow(clippy::redundant_closure_call)]
                 let mut values = Vec::new();
 
                 while let Some(value) = seq
                     .next_element()?
                     .map(|v: DeserializeAsWrap<T, U>| v.into_inner())
                 {
+                    if (values.len() + 1) > MAX {
+                        panic!("over size");
+                    }
                     values.append(value);
                 }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -954,11 +954,12 @@ impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for
 where
     U: serde_with::DeserializeAs<'de, T>,
 {
-    fn deserialize_as<D>(_deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        todo!()
+        let vec: Vec<T> = <Vec<U> as serde_with::DeserializeAs>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().unwrap())
     }
 }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -981,7 +981,7 @@ where
                     .next_element()?
                     .map(|v: DeserializeAsWrap<T, U>| v.into_inner())
                 {
-                    if (values.len() + 1) > MAX {
+                    if (values.len() + 1) > MAX as usize {
                         panic!("over size");
                     }
                     values.append(value);

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -961,7 +961,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        vec.try_into().map_err(serde::de::Error::custom)?
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -2231,63 +2231,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2297,63 +2251,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3113,7 +3021,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3141,7 +3049,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3195,7 +3103,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3207,7 +3115,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3244,7 +3152,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3255,71 +3163,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3327,34 +3245,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3364,7 +3299,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3385,7 +3320,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3441,13 +3376,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3476,80 +3407,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3573,7 +3521,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3587,7 +3535,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3603,7 +3550,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3616,21 +3563,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3642,10 +3598,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3665,21 +3620,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3687,7 +3651,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3719,7 +3683,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3734,8 +3700,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3747,7 +3712,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3763,7 +3730,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3780,15 +3749,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3809,14 +3774,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3833,7 +3804,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3842,7 +3813,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -961,7 +961,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2298,7 +2298,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3242,15 +3242,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3470,8 +3470,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -960,7 +960,7 @@ where
     {
         // let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
         // Ok(vec.try_into().unwrap())
-        struct SeqVisitor<T, U, const MAX: u32>(PhantomData<(T, U, MAX)>);
+        struct SeqVisitor<T, U, const MAX: u32>(PhantomData<(T, U)>);
         impl<'de, T, U, const MAX: u32> serde::de::Visitor<'de> for SeqVisitor<T, U, MAX>
         where
             U: serde_with::DeserializeAs<'de, T>,

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -3008,3 +3008,836 @@ mod test {
         assert_eq!(v.to_option(), Some(1));
     }
 }
+
+#[cfg(all(test, not(feature = "alloc")))]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+}

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -2240,27 +2240,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
+                v.into()
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
+                v.into()
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
+                v.into()
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
+                v.into()
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
+                v.into()
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
+                v.into()
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2268,6 +2268,14 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
                 v.try_into().map_err(serde::de::Error::custom)
             }
 
@@ -2302,7 +2310,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
+                v.into()
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2310,7 +2318,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
+                v.into()
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2318,7 +2326,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
+                v.into()
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2327,6 +2335,14 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -863,7 +863,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -22,7 +22,7 @@ use noalloc::{boxed::Box, vec::Vec};
 extern crate alloc;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::{
-    borrow::ToOwned,
+    borrow::{ToOwned, Cow},
     boxed::Box,
     string::{FromUtf8Error, String},
     vec::Vec,
@@ -923,7 +923,7 @@ where
         <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
     }
 
-    fn schema_id() -> alloc::borrow::Cow<'static, str> {
+    fn schema_id() -> Cow<'static, str> {
         <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
     }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -915,7 +915,7 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
 }
 
 #[cfg(feature = "schemars")]
-impl<T, TA, const MAX: u32> serde_with::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
 where
     TA: serde_with::JsonSchemaAs<T>,
 {
@@ -923,7 +923,7 @@ where
         <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
     }
 
-    fn schema_id() -> Cow<'static, str> {
+    fn schema_id() -> alloc::borrow::Cow<'static, str> {
         <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
     }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -954,7 +954,7 @@ impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for
 where
     U: serde_with::DeserializeAs<'de, T>,
 {
-    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    fn deserialize_as<D>(_deserializer: D) -> Result<VecM<T, MAX>, D::Error>
     where
         D: serde::Deserializer<'de>,
     {

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -920,19 +920,19 @@ where
     TA: serde_with::JsonSchemaAs<T>,
 {
     fn schema_name() -> String {
-        <VecM<serde_with::Schema<T, TA>, MAX> as JsonSchema>::schema_name()
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
     }
 
     fn schema_id() -> Cow<'static, str> {
-        <VecM<serde_with::Schema<T, TA>, MAX> as JsonSchema>::schema_id()
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
     }
 
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
-        <VecM<serde_with::Schema<T, TA>, MAX> as JsonSchema>::json_schema(gen)
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
     }
 
     fn is_referenceable() -> bool {
-        <VecM<serde_with::Schema<T, TA>, MAX> as JsonSchema>::is_referenceable()
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
     }
 }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -22,13 +22,13 @@ use noalloc::{boxed::Box, vec::Vec};
 extern crate alloc;
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::{
-    borrow::{ToOwned, Cow},
+    borrow::ToOwned,
     boxed::Box,
     string::{FromUtf8Error, String},
     vec::Vec,
 };
 #[cfg(feature = "std")]
-use std::{string::FromUtf8Error, borrow::Cow};
+use std::string::FromUtf8Error};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -2240,27 +2240,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.into()
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.into()
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.into()
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.into()
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.into()
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.into()
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2310,7 +2310,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.into()
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2318,7 +2318,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.into()
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2326,7 +2326,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.into()
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -936,6 +936,20 @@ where
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        //SerializeAsWrap::<T, U>::new(source).serialize(serializer)
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -3010,7 +3010,7 @@ mod test {
 }
 
 #[cfg(all(test, feature = "serde"))]
-mod tests {
+mod tests_for_number_or_string {
     use super::*;
     use serde::{Deserialize, Serialize};
     use serde_json;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -33,6 +33,9 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -959,7 +959,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e)))
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
     }
 }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -2222,8 +2222,10 @@ where
 /// It has a JsonSchema implementation that only advertises that the allowed format is a String.
 /// This is because the type is intended to soften the changing of fields from JSON Number to JSON
 /// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
 struct NumberOrString;
 
+#[cfg(feature = "serde")]
 impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
     where
@@ -2281,6 +2283,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
     where
@@ -2338,6 +2341,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     }
 }
 
+#[cfg(feature = "serde")]
 impl serde_with::SerializeAs<i64> for NumberOrString {
     fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -2348,6 +2352,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     }
 }
 
+#[cfg(feature = "serde")]
 impl serde_with::SerializeAs<u64> for NumberOrString {
     fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -2358,6 +2363,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     }
 }
 
+#[cfg(feature = "schemars")]
 impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
     fn schema_name() -> String {
         <String as schemars::JsonSchema>::schema_name()

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -917,7 +917,7 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
 #[cfg(feature = "schemars")]
 impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
 where
-    TA: serde_with::JsonSchemaAs<T>,
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
 {
     fn schema_name() -> String {
         <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -979,7 +979,7 @@ where
 
                 while let Some(value) = seq
                     .next_element()?
-                    .map(|v: DeserializeAsWrap<T, U>| v.into_inner())
+                    .map(|v: serde_with::de::DeserializeAsWrap<T, U>| v.into_inner())
                 {
                     if (values.len() + 1) > MAX as usize {
                         panic!("over size");

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -984,7 +984,7 @@ where
                     if (values.len() + 1) > MAX as usize {
                         panic!("over size");
                     }
-                    values.append(value);
+                    values.push(value);
                 }
 
                 Ok(values.try_into().unwrap())

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -33,9 +33,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2212,6 +2209,172 @@ where
         }
     }
 }
+
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+struct NumberOrString;
+
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        source.to_string().serialize(serializer)
+    }
+}
+
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        source.to_string().serialize(serializer)
+    }
+}
+
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
 
 #[cfg(all(test, feature = "std"))]
 mod tests {

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -914,6 +914,28 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as JsonSchema>::is_referenceable()
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -945,8 +945,20 @@ where
     where
         S: serde::Serializer,
     {
-        //SerializeAsWrap::<T, U>::new(source).serialize(serializer)
         serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        todo!()
     }
 }
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -28,7 +28,7 @@ use alloc::{
     vec::Vec,
 };
 #[cfg(feature = "std")]
-use std::string::FromUtf8Error;
+use std::{string::FromUtf8Error, borrow::Cow};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -36,9 +36,9 @@ use arbitrary::Arbitrary;
 #[cfg(feature = "serde")]
 use serde_with::DisplayFromStr;
 
-#[cfg(all(feature = "schemars", feature = "alloc", feature = "std")]
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
-#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std"))]
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
 use alloc::borrow::Cow;
 
 // TODO: Add support for read/write xdr fns when std not available.

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -36,6 +36,11 @@ use arbitrary::Arbitrary;
 #[cfg(feature = "serde")]
 use serde_with::DisplayFromStr;
 
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std")]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std"))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -936,7 +941,7 @@ where
     }
 }
 
-#[cfg(feature = "schemars")]
+#[cfg(feature = "serde")]
 impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
 where
     U: serde_with::SerializeAs<T>,
@@ -949,7 +954,7 @@ where
     }
 }
 
-#[cfg(feature = "schemars")]
+#[cfg(feature = "serde")]
 impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
 where
     U: serde_with::DeserializeAs<'de, T>,

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -961,7 +961,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        vec.try_into().map_err(serde::de::Error::custom)?
     }
 }
 
@@ -2232,7 +2232,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2240,27 +2240,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2268,15 +2268,15 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2298,31 +2298,31 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2330,11 +2330,11 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -2363,8 +2363,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2374,8 +2373,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/lib/xdrgen/output_file.rb
+++ b/lib/xdrgen/output_file.rb
@@ -20,6 +20,10 @@ module Xdrgen
       @io.puts indented(s)
     end
 
+    def puts_if(s=nil)
+      self.puts if s
+    end
+
     def indent(step=1)
       @current_indent += step
       yield

--- a/lib/xdrgen/output_file.rb
+++ b/lib/xdrgen/output_file.rb
@@ -21,7 +21,7 @@ module Xdrgen
     end
 
     def puts_if(s=nil)
-      self.puts if s
+      self.puts(s) if s
     end
 
     def indent(step=1)

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2854,7 +2908,7 @@ impl fmt::Display for AccountFlags {
 impl TryFrom<i32> for AccountFlags {
     type Error = Error;
 
-    fn try_from(i: i32) -> Result<Self> {
+    fn try_from(i: i32) -> Result<Self, Error> {
         let e = match i {
             1 => AccountFlags::AuthRequiredFlag,
             #[allow(unreachable_patterns)]
@@ -2873,7 +2927,7 @@ impl From<AccountFlags> for i32 {
 
 impl ReadXdr for AccountFlags {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let e = i32::read_xdr(r)?;
             let v: Self = e.try_into()?;
@@ -2884,7 +2938,7 @@ impl ReadXdr for AccountFlags {
 
 impl WriteXdr for AccountFlags {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i: i32 = (*self).into();
             i.write_xdr(w)
@@ -2947,7 +3001,7 @@ impl Variants<TypeVariant> for TypeVariant {
 impl core::str::FromStr for TypeVariant {
     type Err = Error;
     #[allow(clippy::too_many_lines)]
-    fn from_str(s: &str) -> Result<Self> {
+    fn from_str(s: &str) -> Result<Self, Error> {
         match s {
             "AccountFlags" => Ok(Self::AccountFlags),
             _ => Err(Error::Invalid),
@@ -2973,21 +3027,21 @@ impl Type {
 
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+    pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
         match v {
             TypeVariant::AccountFlags => r.with_limited_depth(|r| Ok(Self::AccountFlags(Box::new(AccountFlags::read_xdr(r)?)))),
         }
     }
 
     #[cfg(feature = "base64")]
-    pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+    pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
         let t = Self::read_xdr(v, &mut dec)?;
         Ok(t)
     }
 
     #[cfg(feature = "std")]
-    pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+    pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(v, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -2999,7 +3053,7 @@ impl Type {
     }
 
     #[cfg(feature = "base64")]
-    pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+    pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
@@ -3007,7 +3061,7 @@ impl Type {
 
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+    pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
         match v {
             TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
@@ -3015,7 +3069,7 @@ impl Type {
 
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+    pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
         match v {
             TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, Frame<AccountFlags>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t.0))))),
         }
@@ -3023,7 +3077,7 @@ impl Type {
 
     #[cfg(feature = "base64")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+    pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         match v {
             TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
@@ -3031,14 +3085,14 @@ impl Type {
     }
 
     #[cfg(feature = "std")]
-    pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+    pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(v, &mut cursor)?;
         Ok(t)
     }
 
     #[cfg(feature = "base64")]
-    pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
         let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -3047,13 +3101,13 @@ impl Type {
 
     #[cfg(all(feature = "std", feature = "serde_json"))]
     #[deprecated(note = "use from_json")]
-    pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+    pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
         Self::from_json(v, r)
     }
 
     #[cfg(all(feature = "std", feature = "serde_json"))]
     #[allow(clippy::too_many_lines)]
-    pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+    pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
         match v {
             TypeVariant::AccountFlags => Ok(Self::AccountFlags(Box::new(serde_json::from_reader(r)?))),
         }
@@ -3061,7 +3115,7 @@ impl Type {
 
     #[cfg(all(feature = "std", feature = "serde_json"))]
     #[allow(clippy::too_many_lines)]
-    pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+    pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
         match v {
             TypeVariant::AccountFlags => Ok(Self::AccountFlags(Box::new(serde::de::Deserialize::deserialize(r)?))),
         }
@@ -3116,7 +3170,7 @@ impl Variants<TypeVariant> for Type {
 impl WriteXdr for Type {
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         match self {
             Self::AccountFlags(v) => v.write_xdr(w),
         }

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2816,7 +2870,7 @@ pub type TestArray = [i32; Foo];
 /// typedef int TestArray2<FOO>;
 /// ```
 ///
-pub type TestArray2 = VecM::<i32, 1>;
+pub type TestArray2 = VecM<i32, 1>;
 
         #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
         #[cfg_attr(
@@ -2878,7 +2932,7 @@ Self::TestArray2 => gen.into_root_schema_for::<TestArray2>(),
         impl core::str::FromStr for TypeVariant {
             type Err = Error;
             #[allow(clippy::too_many_lines)]
-            fn from_str(s: &str) -> Result<Self> {
+            fn from_str(s: &str) -> Result<Self, Error> {
                 match s {
                     "TestArray" => Ok(Self::TestArray),
 "TestArray2" => Ok(Self::TestArray2),
@@ -2908,7 +2962,7 @@ TypeVariant::TestArray2, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::TestArray => r.with_limited_depth(|r| Ok(Self::TestArray(Box::new(TestArray::read_xdr(r)?)))),
 TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new(TestArray2::read_xdr(r)?)))),
@@ -2916,14 +2970,14 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2935,7 +2989,7 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
@@ -2943,7 +2997,7 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
 TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
@@ -2952,7 +3006,7 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inn
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::TestArray => Box::new(ReadXdrIter::<_, Frame<TestArray>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::TestArray(Box::new(t.0))))),
 TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::TestArray2(Box::new(t.0))))),
@@ -2961,7 +3015,7 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mu
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
                     TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
@@ -2970,14 +3024,14 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.lim
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
                 let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
                 let mut b64_reader = Cursor::new(b64);
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -2986,13 +3040,13 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.lim
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[deprecated(note = "use from_json")]
-            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 Self::from_json(v, r)
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 match v {
                     TypeVariant::TestArray => Ok(Self::TestArray(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::TestArray2 => Ok(Self::TestArray2(Box::new(serde_json::from_reader(r)?))),
@@ -3001,7 +3055,7 @@ TypeVariant::TestArray2 => Ok(Self::TestArray2(Box::new(serde_json::from_reader(
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::TestArray => Ok(Self::TestArray(Box::new(serde::de::Deserialize::deserialize(r)?))),
 TypeVariant::TestArray2 => Ok(Self::TestArray2(Box::new(serde::de::Deserialize::deserialize(r)?))),
@@ -3060,7 +3114,7 @@ Self::TestArray2(_) => TypeVariant::TestArray2,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 match self {
                     Self::TestArray(v) => v.write_xdr(w),
 Self::TestArray2(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2925,7 +2979,7 @@ Self::FbaMessage => "FbaMessage",
         impl TryFrom<i32> for MessageType {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     0 => MessageType::ErrorMsg,
 1 => MessageType::Hello,
@@ -2957,7 +3011,7 @@ Self::FbaMessage => "FbaMessage",
 
         impl ReadXdr for MessageType {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -2968,7 +3022,7 @@ Self::FbaMessage => "FbaMessage",
 
         impl WriteXdr for MessageType {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -3045,7 +3099,7 @@ Self::Blue => "Blue",
         impl TryFrom<i32> for Color {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     0 => Color::Red,
 1 => Color::Green,
@@ -3066,7 +3120,7 @@ Self::Blue => "Blue",
 
         impl ReadXdr for Color {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -3077,7 +3131,7 @@ Self::Blue => "Blue",
 
         impl WriteXdr for Color {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -3154,7 +3208,7 @@ Self::Blue2 => "Blue2",
         impl TryFrom<i32> for Color2 {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     0 => Color2::Red2,
 1 => Color2::Green2,
@@ -3175,7 +3229,7 @@ Self::Blue2 => "Blue2",
 
         impl ReadXdr for Color2 {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -3186,7 +3240,7 @@ Self::Blue2 => "Blue2",
 
         impl WriteXdr for Color2 {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -3263,7 +3317,7 @@ Self::R3 => "R3",
         impl TryFrom<i32> for Color3 {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     1 => Color3::R1,
 2 => Color3::R2Two,
@@ -3284,7 +3338,7 @@ Self::R3 => "R3",
 
         impl ReadXdr for Color3 {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -3295,7 +3349,7 @@ Self::R3 => "R3",
 
         impl WriteXdr for Color3 {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -3373,7 +3427,7 @@ Self::Color3 => gen.into_root_schema_for::<Color3>(),
         impl core::str::FromStr for TypeVariant {
             type Err = Error;
             #[allow(clippy::too_many_lines)]
-            fn from_str(s: &str) -> Result<Self> {
+            fn from_str(s: &str) -> Result<Self, Error> {
                 match s {
                     "MessageType" => Ok(Self::MessageType),
 "Color" => Ok(Self::Color),
@@ -3411,7 +3465,7 @@ TypeVariant::Color3, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::MessageType => r.with_limited_depth(|r| Ok(Self::MessageType(Box::new(MessageType::read_xdr(r)?)))),
 TypeVariant::Color => r.with_limited_depth(|r| Ok(Self::Color(Box::new(Color::read_xdr(r)?)))),
@@ -3421,14 +3475,14 @@ TypeVariant::Color3 => r.with_limited_depth(|r| Ok(Self::Color3(Box::new(Color3:
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -3440,7 +3494,7 @@ TypeVariant::Color3 => r.with_limited_depth(|r| Ok(Self::Color3(Box::new(Color3:
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
@@ -3448,7 +3502,7 @@ TypeVariant::Color3 => r.with_limited_depth(|r| Ok(Self::Color3(Box::new(Color3:
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
 TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
@@ -3459,7 +3513,7 @@ TypeVariant::Color3 => Box::new(ReadXdrIter::<_, Color3>::new(&mut r.inner, r.li
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::MessageType => Box::new(ReadXdrIter::<_, Frame<MessageType>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MessageType(Box::new(t.0))))),
 TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
@@ -3470,7 +3524,7 @@ TypeVariant::Color3 => Box::new(ReadXdrIter::<_, Frame<Color3>>::new(&mut r.inne
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
                     TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
@@ -3481,14 +3535,14 @@ TypeVariant::Color3 => Box::new(ReadXdrIter::<_, Color3>::new(dec, r.limits.clon
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
                 let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
                 let mut b64_reader = Cursor::new(b64);
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -3497,13 +3551,13 @@ TypeVariant::Color3 => Box::new(ReadXdrIter::<_, Color3>::new(dec, r.limits.clon
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[deprecated(note = "use from_json")]
-            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 Self::from_json(v, r)
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 match v {
                     TypeVariant::MessageType => Ok(Self::MessageType(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Color => Ok(Self::Color(Box::new(serde_json::from_reader(r)?))),
@@ -3514,7 +3568,7 @@ TypeVariant::Color3 => Ok(Self::Color3(Box::new(serde_json::from_reader(r)?))),
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::MessageType => Ok(Self::MessageType(Box::new(serde::de::Deserialize::deserialize(r)?))),
 TypeVariant::Color => Ok(Self::Color(Box::new(serde::de::Deserialize::deserialize(r)?))),
@@ -3581,7 +3635,7 @@ Self::Color3(_) => TypeVariant::Color3,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 match self {
                     Self::MessageType(v) => v.write_xdr(w),
 Self::Color(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2863,7 +2917,7 @@ Self::Offer => "Offer",
         impl TryFrom<i32> for UnionKey {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     1 => UnionKey::One,
 2 => UnionKey::Two,
@@ -2884,7 +2938,7 @@ Self::Offer => "Offer",
 
         impl ReadXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -2895,7 +2949,7 @@ Self::Offer => "Offer",
 
         impl WriteXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -2920,6 +2974,7 @@ pub type Foo = i32;
 /// ```
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_eval::cfg_eval]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -2929,7 +2984,7 @@ pub struct MyUnionOne {
 
 impl ReadXdr for MyUnionOne {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             Ok(Self{
               some_int: i32::read_xdr(r)?,
@@ -2940,7 +2995,7 @@ impl ReadXdr for MyUnionOne {
 
 impl WriteXdr for MyUnionOne {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             self.some_int.write_xdr(w)?;
             Ok(())
@@ -2958,6 +3013,7 @@ impl WriteXdr for MyUnionOne {
 /// ```
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_eval::cfg_eval]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -2968,7 +3024,7 @@ pub struct MyUnionTwo {
 
         impl ReadXdr for MyUnionTwo {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       some_int: i32::read_xdr(r)?,
@@ -2980,7 +3036,7 @@ foo: i32::read_xdr(r)?,
 
         impl WriteXdr for MyUnionTwo {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     self.some_int.write_xdr(w)?;
 self.foo.write_xdr(w)?;
@@ -3011,9 +3067,10 @@ self.foo.write_xdr(w)?;
 /// ```
 ///
 // union with discriminant UnionKey
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
@@ -3087,7 +3144,7 @@ Self::Offer => UnionKey::Offer,
 
         impl ReadXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let dv: UnionKey = <UnionKey as ReadXdr>::read_xdr(r)?;
                     #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
@@ -3105,7 +3162,7 @@ UnionKey::Offer => Self::Offer,
 
         impl WriteXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     self.discriminant().write_xdr(w)?;
                     #[allow(clippy::match_same_arms)]
@@ -3194,7 +3251,7 @@ Self::MyUnionTwo => gen.into_root_schema_for::<MyUnionTwo>(),
         impl core::str::FromStr for TypeVariant {
             type Err = Error;
             #[allow(clippy::too_many_lines)]
-            fn from_str(s: &str) -> Result<Self> {
+            fn from_str(s: &str) -> Result<Self, Error> {
                 match s {
                     "UnionKey" => Ok(Self::UnionKey),
 "Foo" => Ok(Self::Foo),
@@ -3236,7 +3293,7 @@ TypeVariant::MyUnionTwo, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::UnionKey => r.with_limited_depth(|r| Ok(Self::UnionKey(Box::new(UnionKey::read_xdr(r)?)))),
 TypeVariant::Foo => r.with_limited_depth(|r| Ok(Self::Foo(Box::new(Foo::read_xdr(r)?)))),
@@ -3247,14 +3304,14 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -3266,7 +3323,7 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
@@ -3274,7 +3331,7 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
 TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
@@ -3286,7 +3343,7 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(&mut r.inn
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
 TypeVariant::Foo => Box::new(ReadXdrIter::<_, Frame<Foo>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Foo(Box::new(t.0))))),
@@ -3298,7 +3355,7 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(&mu
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
                     TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
@@ -3310,14 +3367,14 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.lim
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
                 let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
                 let mut b64_reader = Cursor::new(b64);
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -3326,13 +3383,13 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.lim
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[deprecated(note = "use from_json")]
-            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 Self::from_json(v, r)
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 match v {
                     TypeVariant::UnionKey => Ok(Self::UnionKey(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Foo => Ok(Self::Foo(Box::new(serde_json::from_reader(r)?))),
@@ -3344,7 +3401,7 @@ TypeVariant::MyUnionTwo => Ok(Self::MyUnionTwo(Box::new(serde_json::from_reader(
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::UnionKey => Ok(Self::UnionKey(Box::new(serde::de::Deserialize::deserialize(r)?))),
 TypeVariant::Foo => Ok(Self::Foo(Box::new(serde::de::Deserialize::deserialize(r)?))),
@@ -3415,7 +3472,7 @@ Self::MyUnionTwo(_) => TypeVariant::MyUnionTwo,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 match self {
                     Self::UnionKey(v) => v.write_xdr(w),
 Self::Foo(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -2924,7 +2924,6 @@ pub type Foo = i32;
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MyUnionOne {
-
   pub some_int: i32,
 }
 
@@ -2963,9 +2962,7 @@ impl WriteXdr for MyUnionOne {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MyUnionTwo {
-
   pub some_int: i32,
-
   pub foo: i32,
 }
 
@@ -3021,11 +3018,9 @@ self.foo.write_xdr(w)?;
 #[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
   One(
-    
     MyUnionOne
   ),
   Two(
-    
     MyUnionTwo
   ),
   Offer,

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -2921,9 +2921,10 @@ pub type Foo = i32;
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MyUnionOne {
+
   pub some_int: i32,
 }
 
@@ -2959,10 +2960,12 @@ impl WriteXdr for MyUnionOne {
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MyUnionTwo {
+
   pub some_int: i32,
+
   pub foo: i32,
 }
 
@@ -3017,8 +3020,14 @@ self.foo.write_xdr(w)?;
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
-  One(MyUnionOne),
-  Two(MyUnionTwo),
+  One(
+    
+    MyUnionOne
+  ),
+  Two(
+    
+    MyUnionTwo
+  ),
   Offer,
 }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -2815,11 +2815,14 @@ pub type Arr = [i32; 2];
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct HasOptions {
+
   pub first_option: Option<i32>,
+
   pub second_option: Option<i32>,
+
   pub third_option: Option<i32>,
 }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -2818,11 +2818,8 @@ pub type Arr = [i32; 2];
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct HasOptions {
-
   pub first_option: Option<i32>,
-
   pub second_option: Option<i32>,
-
   pub third_option: Option<i32>,
 }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2814,6 +2868,7 @@ pub type Arr = [i32; 2];
 /// ```
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_eval::cfg_eval]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -2825,7 +2880,7 @@ pub struct HasOptions {
 
         impl ReadXdr for HasOptions {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       first_option: Option::<i32>::read_xdr(r)?,
@@ -2838,7 +2893,7 @@ third_option: Option::<i32>::read_xdr(r)?,
 
         impl WriteXdr for HasOptions {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     self.first_option.write_xdr(w)?;
 self.second_option.write_xdr(w)?;
@@ -2908,7 +2963,7 @@ Self::HasOptions => gen.into_root_schema_for::<HasOptions>(),
         impl core::str::FromStr for TypeVariant {
             type Err = Error;
             #[allow(clippy::too_many_lines)]
-            fn from_str(s: &str) -> Result<Self> {
+            fn from_str(s: &str) -> Result<Self, Error> {
                 match s {
                     "Arr" => Ok(Self::Arr),
 "HasOptions" => Ok(Self::HasOptions),
@@ -2938,7 +2993,7 @@ TypeVariant::HasOptions, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::Arr => r.with_limited_depth(|r| Ok(Self::Arr(Box::new(Arr::read_xdr(r)?)))),
 TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new(HasOptions::read_xdr(r)?)))),
@@ -2946,14 +3001,14 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2965,7 +3020,7 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
@@ -2973,7 +3028,7 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
 TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
@@ -2982,7 +3037,7 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inn
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::Arr => Box::new(ReadXdrIter::<_, Frame<Arr>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Arr(Box::new(t.0))))),
 TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::HasOptions(Box::new(t.0))))),
@@ -2991,7 +3046,7 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mu
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
                     TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
@@ -3000,14 +3055,14 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.lim
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
                 let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
                 let mut b64_reader = Cursor::new(b64);
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -3016,13 +3071,13 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.lim
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[deprecated(note = "use from_json")]
-            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 Self::from_json(v, r)
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 match v {
                     TypeVariant::Arr => Ok(Self::Arr(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::HasOptions => Ok(Self::HasOptions(Box::new(serde_json::from_reader(r)?))),
@@ -3031,7 +3086,7 @@ TypeVariant::HasOptions => Ok(Self::HasOptions(Box::new(serde_json::from_reader(
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::Arr => Ok(Self::Arr(Box::new(serde::de::Deserialize::deserialize(r)?))),
 TypeVariant::HasOptions => Ok(Self::HasOptions(Box::new(serde::de::Deserialize::deserialize(r)?))),
@@ -3090,7 +3145,7 @@ Self::HasOptions(_) => TypeVariant::HasOptions,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 match self {
                     Self::Arr(v) => v.write_xdr(w),
 Self::HasOptions(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2816,12 +2870,13 @@ pub type Int64 = i64;
 /// ```
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_eval::cfg_eval]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MyStruct {
   pub some_int: i32,
-  #[serde_as(as = "serde_with::DisplayFromStr")]
+  #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_as(as = "DisplayFromStr"))]
   pub a_big_int: i64,
   pub some_opaque: [u8; 10],
   pub some_string: StringM,
@@ -2830,7 +2885,7 @@ pub struct MyStruct {
 
         impl ReadXdr for MyStruct {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       some_int: i32::read_xdr(r)?,
@@ -2845,7 +2900,7 @@ max_string: StringM::<100>::read_xdr(r)?,
 
         impl WriteXdr for MyStruct {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     self.some_int.write_xdr(w)?;
 self.a_big_int.write_xdr(w)?;
@@ -2917,7 +2972,7 @@ Self::MyStruct => gen.into_root_schema_for::<MyStruct>(),
         impl core::str::FromStr for TypeVariant {
             type Err = Error;
             #[allow(clippy::too_many_lines)]
-            fn from_str(s: &str) -> Result<Self> {
+            fn from_str(s: &str) -> Result<Self, Error> {
                 match s {
                     "Int64" => Ok(Self::Int64),
 "MyStruct" => Ok(Self::MyStruct),
@@ -2947,7 +3002,7 @@ TypeVariant::MyStruct, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::Int64 => r.with_limited_depth(|r| Ok(Self::Int64(Box::new(Int64::read_xdr(r)?)))),
 TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyStruct::read_xdr(r)?)))),
@@ -2955,14 +3010,14 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2974,7 +3029,7 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
@@ -2982,7 +3037,7 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
 TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
@@ -2991,7 +3046,7 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, 
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Frame<Int64>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int64(Box::new(t.0))))),
 TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
@@ -3000,7 +3055,7 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
                     TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
@@ -3009,14 +3064,14 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits.
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
                 let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
                 let mut b64_reader = Cursor::new(b64);
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -3025,13 +3080,13 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits.
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[deprecated(note = "use from_json")]
-            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 Self::from_json(v, r)
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 match v {
                     TypeVariant::Int64 => Ok(Self::Int64(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::MyStruct => Ok(Self::MyStruct(Box::new(serde_json::from_reader(r)?))),
@@ -3040,7 +3095,7 @@ TypeVariant::MyStruct => Ok(Self::MyStruct(Box::new(serde_json::from_reader(r)?)
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::Int64 => Ok(Self::Int64(Box::new(serde::de::Deserialize::deserialize(r)?))),
 TypeVariant::MyStruct => Ok(Self::MyStruct(Box::new(serde::de::Deserialize::deserialize(r)?))),
@@ -3099,7 +3154,7 @@ Self::MyStruct(_) => TypeVariant::MyStruct,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 match self {
                     Self::Int64(v) => v.write_xdr(w),
 Self::MyStruct(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -2817,13 +2817,18 @@ pub type Int64 = i64;
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MyStruct {
+
   pub some_int: i32,
+
   pub a_big_int: i64,
+
   pub some_opaque: [u8; 10],
+
   pub some_string: StringM,
+
   pub max_string: StringM::<100>,
 }
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -2821,6 +2821,7 @@ pub type Int64 = i64;
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MyStruct {
   pub some_int: i32,
+  #[serde_as(as = "serde_with::DisplayFromStr")]
   pub a_big_int: i64,
   pub some_opaque: [u8; 10],
   pub some_string: StringM,

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2848,6 +3019,839 @@ mod test {
     }
 }
 
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+}
+
 /// Int64 is an XDR Typedef defines as:
 ///
 /// ```text
@@ -2876,7 +3880,7 @@ pub type Int64 = i64;
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MyStruct {
   pub some_int: i32,
-  #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_as(as = "DisplayFromStr"))]
+  #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_as(as = "NumberOrString"))]
   pub a_big_int: i64,
   pub some_opaque: [u8; 10],
   pub some_string: StringM,

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -2820,15 +2820,10 @@ pub type Int64 = i64;
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MyStruct {
-
   pub some_int: i32,
-
   pub a_big_int: i64,
-
   pub some_opaque: [u8; 10],
-
   pub some_string: StringM,
-
   pub max_string: StringM::<100>,
 }
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -2804,7 +2804,6 @@ mod test {
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
 pub struct Uint512(
-  
   pub [u8; 64]
 );
 
@@ -2958,7 +2957,6 @@ impl AsRef<[u8]> for Uint512 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Uint513(
-  
   pub BytesM::<64>
 );
 
@@ -3063,7 +3061,6 @@ impl AsRef<[u8]> for Uint513 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Uint514(
-  
   pub BytesM
 );
 
@@ -3168,7 +3165,6 @@ impl AsRef<[u8]> for Uint514 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Str(
-  
   pub StringM::<64>
 );
 
@@ -3273,7 +3269,6 @@ impl AsRef<[u8]> for Str {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Str2(
-  
   pub StringM
 );
 
@@ -3375,7 +3370,6 @@ impl AsRef<[u8]> for Str2 {
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
 pub struct Hash(
-  
   pub [u8; 32]
 );
 
@@ -3528,7 +3522,6 @@ impl AsRef<[u8]> for Hash {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Hashes1(
-  
   pub [Hash; 12]
 );
 
@@ -3621,7 +3614,6 @@ impl AsRef<[Hash]> for Hashes1 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Hashes2(
-  
   pub VecM::<Hash, 12>
 );
 
@@ -3726,7 +3718,6 @@ impl AsRef<[Hash]> for Hashes2 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Hashes3(
-  
   pub VecM::<Hash>
 );
 
@@ -3830,7 +3821,6 @@ impl AsRef<[Hash]> for Hashes3 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct OptHash1(
-  
   pub Option<Hash>
 );
 
@@ -3885,7 +3875,6 @@ impl WriteXdr for OptHash1 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct OptHash2(
-  
   pub Option<Hash>
 );
 
@@ -3980,19 +3969,12 @@ pub type Int4 = u64;
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MyStruct {
-
   pub field1: Uint512,
-
   pub field2: OptHash1,
-
   pub field3: i32,
-
   pub field4: u32,
-
   pub field5: f32,
-
   pub field6: f64,
-
   pub field7: bool,
 }
 
@@ -4043,7 +4025,6 @@ self.field7.write_xdr(w)?;
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct LotsOfMyStructs {
-
   pub members: VecM::<MyStruct>,
 }
 
@@ -4082,7 +4063,6 @@ impl WriteXdr for LotsOfMyStructs {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct HasStuff {
-
   pub data: LotsOfMyStructs,
 }
 
@@ -4348,7 +4328,6 @@ Self::B2 => "B2",
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct NesterNestedStruct {
-
   pub blah: i32,
 }
 
@@ -4505,11 +4484,8 @@ impl WriteXdr for NesterNestedUnion {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Nester {
-
   pub nested_enum: NesterNestedEnum,
-
   pub nested_struct: NesterNestedStruct,
-
   pub nested_union: NesterNestedUnion,
 }
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -2803,7 +2803,10 @@ mod test {
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
-pub struct Uint512(pub [u8; 64]);
+pub struct Uint512(
+  
+  pub [u8; 64]
+);
 
 impl core::fmt::Debug for Uint512 {
   fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2954,7 +2957,10 @@ impl AsRef<[u8]> for Uint512 {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct Uint513(pub BytesM::<64>);
+pub struct Uint513(
+  
+  pub BytesM::<64>
+);
 
 impl From<Uint513> for BytesM::<64> {
     #[must_use]
@@ -3056,7 +3062,10 @@ impl AsRef<[u8]> for Uint513 {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct Uint514(pub BytesM);
+pub struct Uint514(
+  
+  pub BytesM
+);
 
 impl From<Uint514> for BytesM {
     #[must_use]
@@ -3158,7 +3167,10 @@ impl AsRef<[u8]> for Uint514 {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct Str(pub StringM::<64>);
+pub struct Str(
+  
+  pub StringM::<64>
+);
 
 impl From<Str> for StringM::<64> {
     #[must_use]
@@ -3260,7 +3272,10 @@ impl AsRef<[u8]> for Str {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct Str2(pub StringM);
+pub struct Str2(
+  
+  pub StringM
+);
 
 impl From<Str2> for StringM {
     #[must_use]
@@ -3359,7 +3374,10 @@ impl AsRef<[u8]> for Str2 {
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
-pub struct Hash(pub [u8; 32]);
+pub struct Hash(
+  
+  pub [u8; 32]
+);
 
 impl core::fmt::Debug for Hash {
   fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3509,7 +3527,10 @@ impl AsRef<[u8]> for Hash {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct Hashes1(pub [Hash; 12]);
+pub struct Hashes1(
+  
+  pub [Hash; 12]
+);
 
 impl From<Hashes1> for [Hash; 12] {
     #[must_use]
@@ -3599,7 +3620,10 @@ impl AsRef<[Hash]> for Hashes1 {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct Hashes2(pub VecM::<Hash, 12>);
+pub struct Hashes2(
+  
+  pub VecM::<Hash, 12>
+);
 
 impl From<Hashes2> for VecM::<Hash, 12> {
     #[must_use]
@@ -3701,7 +3725,10 @@ impl AsRef<[Hash]> for Hashes2 {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct Hashes3(pub VecM::<Hash>);
+pub struct Hashes3(
+  
+  pub VecM::<Hash>
+);
 
 impl From<Hashes3> for VecM::<Hash> {
     #[must_use]
@@ -3802,7 +3829,10 @@ impl AsRef<[Hash]> for Hashes3 {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct OptHash1(pub Option<Hash>);
+pub struct OptHash1(
+  
+  pub Option<Hash>
+);
 
 impl From<OptHash1> for Option<Hash> {
     #[must_use]
@@ -3854,7 +3884,10 @@ impl WriteXdr for OptHash1 {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct OptHash2(pub Option<Hash>);
+pub struct OptHash2(
+  
+  pub Option<Hash>
+);
 
 impl From<OptHash2> for Option<Hash> {
     #[must_use]
@@ -3944,15 +3977,22 @@ pub type Int4 = u64;
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MyStruct {
+
   pub field1: Uint512,
+
   pub field2: OptHash1,
+
   pub field3: i32,
+
   pub field4: u32,
+
   pub field5: f32,
+
   pub field6: f64,
+
   pub field7: bool,
 }
 
@@ -4000,9 +4040,10 @@ self.field7.write_xdr(w)?;
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct LotsOfMyStructs {
+
   pub members: VecM::<MyStruct>,
 }
 
@@ -4038,9 +4079,10 @@ impl WriteXdr for LotsOfMyStructs {
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct HasStuff {
+
   pub data: LotsOfMyStructs,
 }
 
@@ -4303,9 +4345,10 @@ Self::B2 => "B2",
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct NesterNestedStruct {
+
   pub blah: i32,
 }
 
@@ -4459,11 +4502,14 @@ impl WriteXdr for NesterNestedUnion {
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Nester {
+
   pub nested_enum: NesterNestedEnum,
+
   pub nested_struct: NesterNestedStruct,
+
   pub nested_union: NesterNestedUnion,
 }
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -2934,8 +2934,14 @@ Self::Multi => "Multi",
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
-  Error(i32),
-  Multi(VecM::<i32>),
+  Error(
+    
+    i32
+  ),
+  Multi(
+    
+    VecM::<i32>
+  ),
 }
 
         impl MyUnion {
@@ -3045,8 +3051,14 @@ Self::Multi(v) => v.write_xdr(w)?,
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(clippy::large_enum_variant)]
 pub enum IntUnion {
-  V0(i32),
-  V1(VecM::<i32>),
+  V0(
+    
+    i32
+  ),
+  V1(
+    
+    VecM::<i32>
+  ),
 }
 
         impl IntUnion {
@@ -3147,7 +3159,10 @@ Self::V1(v) => v.write_xdr(w)?,
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct IntUnion2(pub IntUnion);
+pub struct IntUnion2(
+  
+  pub IntUnion
+);
 
 impl From<IntUnion2> for IntUnion {
     #[must_use]

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2874,7 +2928,7 @@ Self::Multi => "Multi",
         impl TryFrom<i32> for UnionKey {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     0 => UnionKey::Error,
 1 => UnionKey::Multi,
@@ -2894,7 +2948,7 @@ Self::Multi => "Multi",
 
         impl ReadXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -2905,7 +2959,7 @@ Self::Multi => "Multi",
 
         impl WriteXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -2928,9 +2982,10 @@ Self::Multi => "Multi",
 /// ```
 ///
 // union with discriminant UnionKey
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
@@ -2938,7 +2993,7 @@ pub enum MyUnion {
     i32
   ),
   Multi(
-    VecM::<i32>
+    VecM<i32>
   ),
 }
 
@@ -2999,7 +3054,7 @@ Self::Multi(_) => UnionKey::Multi,
 
         impl ReadXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let dv: UnionKey = <UnionKey as ReadXdr>::read_xdr(r)?;
                     #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
@@ -3016,7 +3071,7 @@ UnionKey::Multi => Self::Multi(VecM::<i32>::read_xdr(r)?),
 
         impl WriteXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     self.discriminant().write_xdr(w)?;
                     #[allow(clippy::match_same_arms)]
@@ -3043,9 +3098,10 @@ Self::Multi(v) => v.write_xdr(w)?,
 /// ```
 ///
 // union with discriminant i32
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(clippy::large_enum_variant)]
 pub enum IntUnion {
@@ -3053,7 +3109,7 @@ pub enum IntUnion {
     i32
   ),
   V1(
-    VecM::<i32>
+    VecM<i32>
   ),
 }
 
@@ -3114,7 +3170,7 @@ Self::V1(_) => 1,
 
         impl ReadXdr for IntUnion {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let dv: i32 = <i32 as ReadXdr>::read_xdr(r)?;
                     #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
@@ -3131,7 +3187,7 @@ Self::V1(_) => 1,
 
         impl WriteXdr for IntUnion {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     self.discriminant().write_xdr(w)?;
                     #[allow(clippy::match_same_arms)]
@@ -3150,9 +3206,10 @@ Self::V1(v) => v.write_xdr(w)?,
 /// typedef IntUnion IntUnion2;
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct IntUnion2(
@@ -3182,7 +3239,7 @@ impl AsRef<IntUnion> for IntUnion2 {
 
 impl ReadXdr for IntUnion2 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = IntUnion::read_xdr(r)?;
             let v = IntUnion2(i);
@@ -3193,7 +3250,7 @@ impl ReadXdr for IntUnion2 {
 
 impl WriteXdr for IntUnion2 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -3278,7 +3335,7 @@ Self::IntUnion2 => gen.into_root_schema_for::<IntUnion2>(),
         impl core::str::FromStr for TypeVariant {
             type Err = Error;
             #[allow(clippy::too_many_lines)]
-            fn from_str(s: &str) -> Result<Self> {
+            fn from_str(s: &str) -> Result<Self, Error> {
                 match s {
                     "SError" => Ok(Self::SError),
 "Multi" => Ok(Self::Multi),
@@ -3324,7 +3381,7 @@ TypeVariant::IntUnion2, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::SError => r.with_limited_depth(|r| Ok(Self::SError(Box::new(SError::read_xdr(r)?)))),
 TypeVariant::Multi => r.with_limited_depth(|r| Ok(Self::Multi(Box::new(Multi::read_xdr(r)?)))),
@@ -3336,14 +3393,14 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -3355,7 +3412,7 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
@@ -3363,7 +3420,7 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::SError(Box::new(t))))),
 TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
@@ -3376,7 +3433,7 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(&mut r.inner
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::SError => Box::new(ReadXdrIter::<_, Frame<SError>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::SError(Box::new(t.0))))),
 TypeVariant::Multi => Box::new(ReadXdrIter::<_, Frame<Multi>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Multi(Box::new(t.0))))),
@@ -3389,7 +3446,7 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, Frame<IntUnion2>>::new(&mut 
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
                     TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::SError(Box::new(t))))),
@@ -3402,14 +3459,14 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.limit
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
                 let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
                 let mut b64_reader = Cursor::new(b64);
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -3418,13 +3475,13 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.limit
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[deprecated(note = "use from_json")]
-            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 Self::from_json(v, r)
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 match v {
                     TypeVariant::SError => Ok(Self::SError(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Multi => Ok(Self::Multi(Box::new(serde_json::from_reader(r)?))),
@@ -3437,7 +3494,7 @@ TypeVariant::IntUnion2 => Ok(Self::IntUnion2(Box::new(serde_json::from_reader(r)
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::SError => Ok(Self::SError(Box::new(serde::de::Deserialize::deserialize(r)?))),
 TypeVariant::Multi => Ok(Self::Multi(Box::new(serde::de::Deserialize::deserialize(r)?))),
@@ -3512,7 +3569,7 @@ Self::IntUnion2(_) => TypeVariant::IntUnion2,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 match self {
                     Self::SError(v) => v.write_xdr(w),
 Self::Multi(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -2935,11 +2935,9 @@ Self::Multi => "Multi",
 #[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
   Error(
-    
     i32
   ),
   Multi(
-    
     VecM::<i32>
   ),
 }
@@ -3052,11 +3050,9 @@ Self::Multi(v) => v.write_xdr(w)?,
 #[allow(clippy::large_enum_variant)]
 pub enum IntUnion {
   V0(
-    
     i32
   ),
   V1(
-    
     VecM::<i32>
   ),
 }
@@ -3160,7 +3156,6 @@ Self::V1(v) => v.write_xdr(w)?,
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct IntUnion2(
-  
   pub IntUnion
 );
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2854,7 +2908,7 @@ impl fmt::Display for AccountFlags {
 impl TryFrom<i32> for AccountFlags {
     type Error = Error;
 
-    fn try_from(i: i32) -> Result<Self> {
+    fn try_from(i: i32) -> Result<Self, Error> {
         let e = match i {
             1 => AccountFlags::AuthRequiredFlag,
             #[allow(unreachable_patterns)]
@@ -2873,7 +2927,7 @@ impl From<AccountFlags> for i32 {
 
 impl ReadXdr for AccountFlags {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let e = i32::read_xdr(r)?;
             let v: Self = e.try_into()?;
@@ -2884,7 +2938,7 @@ impl ReadXdr for AccountFlags {
 
 impl WriteXdr for AccountFlags {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i: i32 = (*self).into();
             i.write_xdr(w)
@@ -2947,7 +3001,7 @@ impl Variants<TypeVariant> for TypeVariant {
 impl core::str::FromStr for TypeVariant {
     type Err = Error;
     #[allow(clippy::too_many_lines)]
-    fn from_str(s: &str) -> Result<Self> {
+    fn from_str(s: &str) -> Result<Self, Error> {
         match s {
             "AccountFlags" => Ok(Self::AccountFlags),
             _ => Err(Error::Invalid),
@@ -2973,21 +3027,21 @@ impl Type {
 
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+    pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
         match v {
             TypeVariant::AccountFlags => r.with_limited_depth(|r| Ok(Self::AccountFlags(Box::new(AccountFlags::read_xdr(r)?)))),
         }
     }
 
     #[cfg(feature = "base64")]
-    pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+    pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
         let t = Self::read_xdr(v, &mut dec)?;
         Ok(t)
     }
 
     #[cfg(feature = "std")]
-    pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+    pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(v, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -2999,7 +3053,7 @@ impl Type {
     }
 
     #[cfg(feature = "base64")]
-    pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+    pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
@@ -3007,7 +3061,7 @@ impl Type {
 
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+    pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
         match v {
             TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
@@ -3015,7 +3069,7 @@ impl Type {
 
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+    pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
         match v {
             TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, Frame<AccountFlags>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t.0))))),
         }
@@ -3023,7 +3077,7 @@ impl Type {
 
     #[cfg(feature = "base64")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+    pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         match v {
             TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
@@ -3031,14 +3085,14 @@ impl Type {
     }
 
     #[cfg(feature = "std")]
-    pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+    pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(v, &mut cursor)?;
         Ok(t)
     }
 
     #[cfg(feature = "base64")]
-    pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
         let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -3047,13 +3101,13 @@ impl Type {
 
     #[cfg(all(feature = "std", feature = "serde_json"))]
     #[deprecated(note = "use from_json")]
-    pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+    pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
         Self::from_json(v, r)
     }
 
     #[cfg(all(feature = "std", feature = "serde_json"))]
     #[allow(clippy::too_many_lines)]
-    pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+    pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
         match v {
             TypeVariant::AccountFlags => Ok(Self::AccountFlags(Box::new(serde_json::from_reader(r)?))),
         }
@@ -3061,7 +3115,7 @@ impl Type {
 
     #[cfg(all(feature = "std", feature = "serde_json"))]
     #[allow(clippy::too_many_lines)]
-    pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+    pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
         match v {
             TypeVariant::AccountFlags => Ok(Self::AccountFlags(Box::new(serde::de::Deserialize::deserialize(r)?))),
         }
@@ -3116,7 +3170,7 @@ impl Variants<TypeVariant> for Type {
 impl WriteXdr for Type {
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         match self {
             Self::AccountFlags(v) => v.write_xdr(w),
         }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2816,7 +2870,7 @@ pub type TestArray = [i32; Foo];
 /// typedef int TestArray2<FOO>;
 /// ```
 ///
-pub type TestArray2 = VecM::<i32, 1>;
+pub type TestArray2 = VecM<i32, 1>;
 
         #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
         #[cfg_attr(
@@ -2878,7 +2932,7 @@ Self::TestArray2 => gen.into_root_schema_for::<TestArray2>(),
         impl core::str::FromStr for TypeVariant {
             type Err = Error;
             #[allow(clippy::too_many_lines)]
-            fn from_str(s: &str) -> Result<Self> {
+            fn from_str(s: &str) -> Result<Self, Error> {
                 match s {
                     "TestArray" => Ok(Self::TestArray),
 "TestArray2" => Ok(Self::TestArray2),
@@ -2908,7 +2962,7 @@ TypeVariant::TestArray2, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::TestArray => r.with_limited_depth(|r| Ok(Self::TestArray(Box::new(TestArray::read_xdr(r)?)))),
 TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new(TestArray2::read_xdr(r)?)))),
@@ -2916,14 +2970,14 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2935,7 +2989,7 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
@@ -2943,7 +2997,7 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
 TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
@@ -2952,7 +3006,7 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inn
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::TestArray => Box::new(ReadXdrIter::<_, Frame<TestArray>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::TestArray(Box::new(t.0))))),
 TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::TestArray2(Box::new(t.0))))),
@@ -2961,7 +3015,7 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mu
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
                     TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
@@ -2970,14 +3024,14 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.lim
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
                 let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
                 let mut b64_reader = Cursor::new(b64);
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -2986,13 +3040,13 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.lim
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[deprecated(note = "use from_json")]
-            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 Self::from_json(v, r)
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 match v {
                     TypeVariant::TestArray => Ok(Self::TestArray(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::TestArray2 => Ok(Self::TestArray2(Box::new(serde_json::from_reader(r)?))),
@@ -3001,7 +3055,7 @@ TypeVariant::TestArray2 => Ok(Self::TestArray2(Box::new(serde_json::from_reader(
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::TestArray => Ok(Self::TestArray(Box::new(serde::de::Deserialize::deserialize(r)?))),
 TypeVariant::TestArray2 => Ok(Self::TestArray2(Box::new(serde::de::Deserialize::deserialize(r)?))),
@@ -3060,7 +3114,7 @@ Self::TestArray2(_) => TypeVariant::TestArray2,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 match self {
                     Self::TestArray(v) => v.write_xdr(w),
 Self::TestArray2(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2925,7 +2979,7 @@ Self::FbaMessage => "FbaMessage",
         impl TryFrom<i32> for MessageType {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     0 => MessageType::ErrorMsg,
 1 => MessageType::Hello,
@@ -2957,7 +3011,7 @@ Self::FbaMessage => "FbaMessage",
 
         impl ReadXdr for MessageType {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -2968,7 +3022,7 @@ Self::FbaMessage => "FbaMessage",
 
         impl WriteXdr for MessageType {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -3045,7 +3099,7 @@ Self::Blue => "Blue",
         impl TryFrom<i32> for Color {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     0 => Color::Red,
 1 => Color::Green,
@@ -3066,7 +3120,7 @@ Self::Blue => "Blue",
 
         impl ReadXdr for Color {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -3077,7 +3131,7 @@ Self::Blue => "Blue",
 
         impl WriteXdr for Color {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -3153,7 +3207,7 @@ Self::Blue2 => "Blue2",
         impl TryFrom<i32> for Color2 {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     0 => Color2::Red2,
 1 => Color2::Green2,
@@ -3174,7 +3228,7 @@ Self::Blue2 => "Blue2",
 
         impl ReadXdr for Color2 {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -3185,7 +3239,7 @@ Self::Blue2 => "Blue2",
 
         impl WriteXdr for Color2 {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -3262,7 +3316,7 @@ Self::R3 => "R3",
         impl TryFrom<i32> for Color3 {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     1 => Color3::R1,
 2 => Color3::R2Two,
@@ -3283,7 +3337,7 @@ Self::R3 => "R3",
 
         impl ReadXdr for Color3 {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -3294,7 +3348,7 @@ Self::R3 => "R3",
 
         impl WriteXdr for Color3 {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -3372,7 +3426,7 @@ Self::Color3 => gen.into_root_schema_for::<Color3>(),
         impl core::str::FromStr for TypeVariant {
             type Err = Error;
             #[allow(clippy::too_many_lines)]
-            fn from_str(s: &str) -> Result<Self> {
+            fn from_str(s: &str) -> Result<Self, Error> {
                 match s {
                     "MessageType" => Ok(Self::MessageType),
 "Color" => Ok(Self::Color),
@@ -3410,7 +3464,7 @@ TypeVariant::Color3, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::MessageType => r.with_limited_depth(|r| Ok(Self::MessageType(Box::new(MessageType::read_xdr(r)?)))),
 TypeVariant::Color => r.with_limited_depth(|r| Ok(Self::Color(Box::new(Color::read_xdr(r)?)))),
@@ -3420,14 +3474,14 @@ TypeVariant::Color3 => r.with_limited_depth(|r| Ok(Self::Color3(Box::new(Color3:
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -3439,7 +3493,7 @@ TypeVariant::Color3 => r.with_limited_depth(|r| Ok(Self::Color3(Box::new(Color3:
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
@@ -3447,7 +3501,7 @@ TypeVariant::Color3 => r.with_limited_depth(|r| Ok(Self::Color3(Box::new(Color3:
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
 TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
@@ -3458,7 +3512,7 @@ TypeVariant::Color3 => Box::new(ReadXdrIter::<_, Color3>::new(&mut r.inner, r.li
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::MessageType => Box::new(ReadXdrIter::<_, Frame<MessageType>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MessageType(Box::new(t.0))))),
 TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
@@ -3469,7 +3523,7 @@ TypeVariant::Color3 => Box::new(ReadXdrIter::<_, Frame<Color3>>::new(&mut r.inne
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
                     TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
@@ -3480,14 +3534,14 @@ TypeVariant::Color3 => Box::new(ReadXdrIter::<_, Color3>::new(dec, r.limits.clon
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
                 let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
                 let mut b64_reader = Cursor::new(b64);
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -3496,13 +3550,13 @@ TypeVariant::Color3 => Box::new(ReadXdrIter::<_, Color3>::new(dec, r.limits.clon
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[deprecated(note = "use from_json")]
-            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 Self::from_json(v, r)
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 match v {
                     TypeVariant::MessageType => Ok(Self::MessageType(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Color => Ok(Self::Color(Box::new(serde_json::from_reader(r)?))),
@@ -3513,7 +3567,7 @@ TypeVariant::Color3 => Ok(Self::Color3(Box::new(serde_json::from_reader(r)?))),
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::MessageType => Ok(Self::MessageType(Box::new(serde::de::Deserialize::deserialize(r)?))),
 TypeVariant::Color => Ok(Self::Color(Box::new(serde::de::Deserialize::deserialize(r)?))),
@@ -3580,7 +3634,7 @@ Self::Color3(_) => TypeVariant::Color3,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 match self {
                     Self::MessageType(v) => v.write_xdr(w),
 Self::Color(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -2923,7 +2923,6 @@ pub type Foo = i32;
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MyUnionOne {
-
   pub some_int: i32,
 }
 
@@ -2962,9 +2961,7 @@ impl WriteXdr for MyUnionOne {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MyUnionTwo {
-
   pub some_int: i32,
-
   pub foo: i32,
 }
 
@@ -3019,11 +3016,9 @@ self.foo.write_xdr(w)?;
 #[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
   One(
-    
     MyUnionOne
   ),
   Two(
-    
     MyUnionTwo
   ),
   Offer,

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2862,7 +2916,7 @@ Self::Offer => "Offer",
         impl TryFrom<i32> for UnionKey {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     1 => UnionKey::One,
 2 => UnionKey::Two,
@@ -2883,7 +2937,7 @@ Self::Offer => "Offer",
 
         impl ReadXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -2894,7 +2948,7 @@ Self::Offer => "Offer",
 
         impl WriteXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -2919,6 +2973,7 @@ pub type Foo = i32;
 /// ```
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_eval::cfg_eval]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -2928,7 +2983,7 @@ pub struct MyUnionOne {
 
 impl ReadXdr for MyUnionOne {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             Ok(Self{
               some_int: i32::read_xdr(r)?,
@@ -2939,7 +2994,7 @@ impl ReadXdr for MyUnionOne {
 
 impl WriteXdr for MyUnionOne {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             self.some_int.write_xdr(w)?;
             Ok(())
@@ -2957,6 +3012,7 @@ impl WriteXdr for MyUnionOne {
 /// ```
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_eval::cfg_eval]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -2967,7 +3023,7 @@ pub struct MyUnionTwo {
 
         impl ReadXdr for MyUnionTwo {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       some_int: i32::read_xdr(r)?,
@@ -2979,7 +3035,7 @@ foo: i32::read_xdr(r)?,
 
         impl WriteXdr for MyUnionTwo {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     self.some_int.write_xdr(w)?;
 self.foo.write_xdr(w)?;
@@ -3010,9 +3066,10 @@ self.foo.write_xdr(w)?;
 /// ```
 ///
 // union with discriminant UnionKey
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
   One(
@@ -3085,7 +3142,7 @@ Self::Offer => UnionKey::Offer,
 
         impl ReadXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let dv: UnionKey = <UnionKey as ReadXdr>::read_xdr(r)?;
                     #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
@@ -3103,7 +3160,7 @@ UnionKey::Offer => Self::Offer,
 
         impl WriteXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     self.discriminant().write_xdr(w)?;
                     #[allow(clippy::match_same_arms)]
@@ -3192,7 +3249,7 @@ Self::MyUnionTwo => gen.into_root_schema_for::<MyUnionTwo>(),
         impl core::str::FromStr for TypeVariant {
             type Err = Error;
             #[allow(clippy::too_many_lines)]
-            fn from_str(s: &str) -> Result<Self> {
+            fn from_str(s: &str) -> Result<Self, Error> {
                 match s {
                     "UnionKey" => Ok(Self::UnionKey),
 "Foo" => Ok(Self::Foo),
@@ -3234,7 +3291,7 @@ TypeVariant::MyUnionTwo, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::UnionKey => r.with_limited_depth(|r| Ok(Self::UnionKey(Box::new(UnionKey::read_xdr(r)?)))),
 TypeVariant::Foo => r.with_limited_depth(|r| Ok(Self::Foo(Box::new(Foo::read_xdr(r)?)))),
@@ -3245,14 +3302,14 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -3264,7 +3321,7 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
@@ -3272,7 +3329,7 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
 TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
@@ -3284,7 +3341,7 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(&mut r.inn
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
 TypeVariant::Foo => Box::new(ReadXdrIter::<_, Frame<Foo>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Foo(Box::new(t.0))))),
@@ -3296,7 +3353,7 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(&mu
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
                     TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
@@ -3308,14 +3365,14 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.lim
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
                 let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
                 let mut b64_reader = Cursor::new(b64);
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -3324,13 +3381,13 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.lim
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[deprecated(note = "use from_json")]
-            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 Self::from_json(v, r)
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 match v {
                     TypeVariant::UnionKey => Ok(Self::UnionKey(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Foo => Ok(Self::Foo(Box::new(serde_json::from_reader(r)?))),
@@ -3342,7 +3399,7 @@ TypeVariant::MyUnionTwo => Ok(Self::MyUnionTwo(Box::new(serde_json::from_reader(
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::UnionKey => Ok(Self::UnionKey(Box::new(serde::de::Deserialize::deserialize(r)?))),
 TypeVariant::Foo => Ok(Self::Foo(Box::new(serde::de::Deserialize::deserialize(r)?))),
@@ -3413,7 +3470,7 @@ Self::MyUnionTwo(_) => TypeVariant::MyUnionTwo,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 match self {
                     Self::UnionKey(v) => v.write_xdr(w),
 Self::Foo(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -2920,9 +2920,10 @@ pub type Foo = i32;
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MyUnionOne {
+
   pub some_int: i32,
 }
 
@@ -2958,10 +2959,12 @@ impl WriteXdr for MyUnionOne {
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MyUnionTwo {
+
   pub some_int: i32,
+
   pub foo: i32,
 }
 
@@ -3015,8 +3018,14 @@ self.foo.write_xdr(w)?;
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
-  One(MyUnionOne),
-  Two(MyUnionTwo),
+  One(
+    
+    MyUnionOne
+  ),
+  Two(
+    
+    MyUnionTwo
+  ),
   Offer,
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2814,6 +2868,7 @@ pub type Arr = [i32; 2];
 /// ```
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_eval::cfg_eval]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 pub struct HasOptions {
@@ -2824,7 +2879,7 @@ pub struct HasOptions {
 
         impl ReadXdr for HasOptions {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       first_option: Option::<i32>::read_xdr(r)?,
@@ -2837,7 +2892,7 @@ third_option: Option::<i32>::read_xdr(r)?,
 
         impl WriteXdr for HasOptions {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     self.first_option.write_xdr(w)?;
 self.second_option.write_xdr(w)?;
@@ -2907,7 +2962,7 @@ Self::HasOptions => gen.into_root_schema_for::<HasOptions>(),
         impl core::str::FromStr for TypeVariant {
             type Err = Error;
             #[allow(clippy::too_many_lines)]
-            fn from_str(s: &str) -> Result<Self> {
+            fn from_str(s: &str) -> Result<Self, Error> {
                 match s {
                     "Arr" => Ok(Self::Arr),
 "HasOptions" => Ok(Self::HasOptions),
@@ -2937,7 +2992,7 @@ TypeVariant::HasOptions, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::Arr => r.with_limited_depth(|r| Ok(Self::Arr(Box::new(Arr::read_xdr(r)?)))),
 TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new(HasOptions::read_xdr(r)?)))),
@@ -2945,14 +3000,14 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2964,7 +3019,7 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
@@ -2972,7 +3027,7 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
 TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
@@ -2981,7 +3036,7 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inn
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::Arr => Box::new(ReadXdrIter::<_, Frame<Arr>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Arr(Box::new(t.0))))),
 TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::HasOptions(Box::new(t.0))))),
@@ -2990,7 +3045,7 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mu
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
                     TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
@@ -2999,14 +3054,14 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.lim
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
                 let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
                 let mut b64_reader = Cursor::new(b64);
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -3015,13 +3070,13 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.lim
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[deprecated(note = "use from_json")]
-            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 Self::from_json(v, r)
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 match v {
                     TypeVariant::Arr => Ok(Self::Arr(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::HasOptions => Ok(Self::HasOptions(Box::new(serde_json::from_reader(r)?))),
@@ -3030,7 +3085,7 @@ TypeVariant::HasOptions => Ok(Self::HasOptions(Box::new(serde_json::from_reader(
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::Arr => Ok(Self::Arr(Box::new(serde::de::Deserialize::deserialize(r)?))),
 TypeVariant::HasOptions => Ok(Self::HasOptions(Box::new(serde::de::Deserialize::deserialize(r)?))),
@@ -3089,7 +3144,7 @@ Self::HasOptions(_) => TypeVariant::HasOptions,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 match self {
                     Self::Arr(v) => v.write_xdr(w),
 Self::HasOptions(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -2817,11 +2817,8 @@ pub type Arr = [i32; 2];
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 pub struct HasOptions {
-
   pub first_option: Option<i32>,
-
   pub second_option: Option<i32>,
-
   pub third_option: Option<i32>,
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -2815,10 +2815,13 @@ pub type Arr = [i32; 2];
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 pub struct HasOptions {
+
   pub first_option: Option<i32>,
+
   pub second_option: Option<i32>,
+
   pub third_option: Option<i32>,
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -2819,15 +2819,10 @@ pub type Int64 = i64;
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 pub struct MyStruct {
-
   pub some_int: i32,
-
   pub a_big_int: i64,
-
   pub some_opaque: [u8; 10],
-
   pub some_string: StringM,
-
   pub max_string: StringM::<100>,
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -2820,6 +2820,7 @@ pub type Int64 = i64;
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 pub struct MyStruct {
   pub some_int: i32,
+  #[serde_as(as = "serde_with::DisplayFromStr")]
   pub a_big_int: i64,
   pub some_opaque: [u8; 10],
   pub some_string: StringM,

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2848,6 +3019,839 @@ mod test {
     }
 }
 
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+}
+
 /// Int64 is an XDR Typedef defines as:
 ///
 /// ```text
@@ -2875,7 +3879,7 @@ pub type Int64 = i64;
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 pub struct MyStruct {
   pub some_int: i32,
-  #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_as(as = "DisplayFromStr"))]
+  #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_as(as = "NumberOrString"))]
   pub a_big_int: i64,
   pub some_opaque: [u8; 10],
   pub some_string: StringM,

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -2817,12 +2817,17 @@ pub type Int64 = i64;
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 pub struct MyStruct {
+
   pub some_int: i32,
+
   pub a_big_int: i64,
+
   pub some_opaque: [u8; 10],
+
   pub some_string: StringM,
+
   pub max_string: StringM::<100>,
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -2803,7 +2803,10 @@ mod test {
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
-pub struct Uint512(pub [u8; 64]);
+pub struct Uint512(
+  
+  pub [u8; 64]
+);
 
 impl core::fmt::Debug for Uint512 {
   fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2954,7 +2957,10 @@ impl AsRef<[u8]> for Uint512 {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct Uint513(pub BytesM::<64>);
+pub struct Uint513(
+  
+  pub BytesM::<64>
+);
 
 impl From<Uint513> for BytesM::<64> {
     #[must_use]
@@ -3056,7 +3062,10 @@ impl AsRef<[u8]> for Uint513 {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct Uint514(pub BytesM);
+pub struct Uint514(
+  
+  pub BytesM
+);
 
 impl From<Uint514> for BytesM {
     #[must_use]
@@ -3158,7 +3167,10 @@ impl AsRef<[u8]> for Uint514 {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct Str(pub StringM::<64>);
+pub struct Str(
+  
+  pub StringM::<64>
+);
 
 impl From<Str> for StringM::<64> {
     #[must_use]
@@ -3260,7 +3272,10 @@ impl AsRef<[u8]> for Str {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct Str2(pub StringM);
+pub struct Str2(
+  
+  pub StringM
+);
 
 impl From<Str2> for StringM {
     #[must_use]
@@ -3359,7 +3374,10 @@ impl AsRef<[u8]> for Str2 {
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
-pub struct Hash(pub [u8; 32]);
+pub struct Hash(
+  
+  pub [u8; 32]
+);
 
 impl core::fmt::Debug for Hash {
   fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3509,7 +3527,10 @@ impl AsRef<[u8]> for Hash {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct Hashes1(pub [Hash; 12]);
+pub struct Hashes1(
+  
+  pub [Hash; 12]
+);
 
 impl From<Hashes1> for [Hash; 12] {
     #[must_use]
@@ -3599,7 +3620,10 @@ impl AsRef<[Hash]> for Hashes1 {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct Hashes2(pub VecM::<Hash, 12>);
+pub struct Hashes2(
+  
+  pub VecM::<Hash, 12>
+);
 
 impl From<Hashes2> for VecM::<Hash, 12> {
     #[must_use]
@@ -3701,7 +3725,10 @@ impl AsRef<[Hash]> for Hashes2 {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct Hashes3(pub VecM::<Hash>);
+pub struct Hashes3(
+  
+  pub VecM::<Hash>
+);
 
 impl From<Hashes3> for VecM::<Hash> {
     #[must_use]
@@ -3802,7 +3829,10 @@ impl AsRef<[Hash]> for Hashes3 {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct OptHash1(pub Option<Hash>);
+pub struct OptHash1(
+  
+  pub Option<Hash>
+);
 
 impl From<OptHash1> for Option<Hash> {
     #[must_use]
@@ -3854,7 +3884,10 @@ impl WriteXdr for OptHash1 {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct OptHash2(pub Option<Hash>);
+pub struct OptHash2(
+  
+  pub Option<Hash>
+);
 
 impl From<OptHash2> for Option<Hash> {
     #[must_use]
@@ -3944,14 +3977,21 @@ pub type Int4 = u64;
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 pub struct MyStruct {
+
   pub field1: Uint512,
+
   pub field2: OptHash1,
+
   pub field3: i32,
+
   pub field4: u32,
+
   pub field5: f32,
+
   pub field6: f64,
+
   pub field7: bool,
 }
 
@@ -3999,8 +4039,9 @@ self.field7.write_xdr(w)?;
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 pub struct LotsOfMyStructs {
+
   pub members: VecM::<MyStruct>,
 }
 
@@ -4036,9 +4077,10 @@ impl WriteXdr for LotsOfMyStructs {
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct HasStuff {
+
   pub data: LotsOfMyStructs,
 }
 
@@ -4301,9 +4343,10 @@ Self::B2 => "B2",
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct NesterNestedStruct {
+
   pub blah: i32,
 }
 
@@ -4457,11 +4500,14 @@ impl WriteXdr for NesterNestedUnion {
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Nester {
+
   pub nested_enum: NesterNestedEnum,
+
   pub nested_struct: NesterNestedStruct,
+
   pub nested_union: NesterNestedUnion,
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -2804,7 +2804,6 @@ mod test {
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
 pub struct Uint512(
-  
   pub [u8; 64]
 );
 
@@ -2958,7 +2957,6 @@ impl AsRef<[u8]> for Uint512 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Uint513(
-  
   pub BytesM::<64>
 );
 
@@ -3063,7 +3061,6 @@ impl AsRef<[u8]> for Uint513 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Uint514(
-  
   pub BytesM
 );
 
@@ -3168,7 +3165,6 @@ impl AsRef<[u8]> for Uint514 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Str(
-  
   pub StringM::<64>
 );
 
@@ -3273,7 +3269,6 @@ impl AsRef<[u8]> for Str {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Str2(
-  
   pub StringM
 );
 
@@ -3375,7 +3370,6 @@ impl AsRef<[u8]> for Str2 {
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
 pub struct Hash(
-  
   pub [u8; 32]
 );
 
@@ -3528,7 +3522,6 @@ impl AsRef<[u8]> for Hash {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Hashes1(
-  
   pub [Hash; 12]
 );
 
@@ -3621,7 +3614,6 @@ impl AsRef<[Hash]> for Hashes1 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Hashes2(
-  
   pub VecM::<Hash, 12>
 );
 
@@ -3726,7 +3718,6 @@ impl AsRef<[Hash]> for Hashes2 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Hashes3(
-  
   pub VecM::<Hash>
 );
 
@@ -3830,7 +3821,6 @@ impl AsRef<[Hash]> for Hashes3 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct OptHash1(
-  
   pub Option<Hash>
 );
 
@@ -3885,7 +3875,6 @@ impl WriteXdr for OptHash1 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct OptHash2(
-  
   pub Option<Hash>
 );
 
@@ -3979,19 +3968,12 @@ pub type Int4 = u64;
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 pub struct MyStruct {
-
   pub field1: Uint512,
-
   pub field2: OptHash1,
-
   pub field3: i32,
-
   pub field4: u32,
-
   pub field5: f32,
-
   pub field6: f64,
-
   pub field7: bool,
 }
 
@@ -4041,7 +4023,6 @@ self.field7.write_xdr(w)?;
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 pub struct LotsOfMyStructs {
-
   pub members: VecM::<MyStruct>,
 }
 
@@ -4080,7 +4061,6 @@ impl WriteXdr for LotsOfMyStructs {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct HasStuff {
-
   pub data: LotsOfMyStructs,
 }
 
@@ -4346,7 +4326,6 @@ Self::B2 => "B2",
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct NesterNestedStruct {
-
   pub blah: i32,
 }
 
@@ -4503,11 +4482,8 @@ impl WriteXdr for NesterNestedUnion {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Nester {
-
   pub nested_enum: NesterNestedEnum,
-
   pub nested_struct: NesterNestedStruct,
-
   pub nested_union: NesterNestedUnion,
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2800,6 +2854,7 @@ mod test {
 /// typedef opaque uint512[64];
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
@@ -2891,7 +2946,7 @@ impl AsRef<[u8; 64]> for Uint512 {
 
 impl ReadXdr for Uint512 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = <[u8; 64]>::read_xdr(r)?;
             let v = Uint512(i);
@@ -2902,7 +2957,7 @@ impl ReadXdr for Uint512 {
 
 impl WriteXdr for Uint512 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -2917,7 +2972,7 @@ impl Uint512 {
 #[cfg(feature = "alloc")]
 impl TryFrom<Vec<u8>> for Uint512 {
     type Error = Error;
-    fn try_from(x: Vec<u8>) -> Result<Self> {
+    fn try_from(x: Vec<u8>) -> Result<Self, Error> {
         x.as_slice().try_into()
     }
 }
@@ -2925,14 +2980,14 @@ impl TryFrom<Vec<u8>> for Uint512 {
 #[cfg(feature = "alloc")]
 impl TryFrom<&Vec<u8>> for Uint512 {
     type Error = Error;
-    fn try_from(x: &Vec<u8>) -> Result<Self> {
+    fn try_from(x: &Vec<u8>) -> Result<Self, Error> {
         x.as_slice().try_into()
     }
 }
 
 impl TryFrom<&[u8]> for Uint512 {
     type Error = Error;
-    fn try_from(x: &[u8]) -> Result<Self> {
+    fn try_from(x: &[u8]) -> Result<Self, Error> {
         Ok(Uint512(x.try_into()?))
     }
 }
@@ -2950,10 +3005,11 @@ impl AsRef<[u8]> for Uint512 {
 /// typedef opaque uint513<64>;
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Uint513(
@@ -2983,7 +3039,7 @@ impl AsRef<BytesM::<64>> for Uint513 {
 
 impl ReadXdr for Uint513 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = BytesM::<64>::read_xdr(r)?;
             let v = Uint513(i);
@@ -2994,7 +3050,7 @@ impl ReadXdr for Uint513 {
 
 impl WriteXdr for Uint513 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -3015,7 +3071,7 @@ impl From<Uint513> for Vec<u8> {
 
 impl TryFrom<Vec<u8>> for Uint513 {
     type Error = Error;
-    fn try_from(x: Vec<u8>) -> Result<Self> {
+    fn try_from(x: Vec<u8>) -> Result<Self, Error> {
         Ok(Uint513(x.try_into()?))
     }
 }
@@ -3023,7 +3079,7 @@ impl TryFrom<Vec<u8>> for Uint513 {
 #[cfg(feature = "alloc")]
 impl TryFrom<&Vec<u8>> for Uint513 {
     type Error = Error;
-    fn try_from(x: &Vec<u8>) -> Result<Self> {
+    fn try_from(x: &Vec<u8>) -> Result<Self, Error> {
         Ok(Uint513(x.try_into()?))
     }
 }
@@ -3054,10 +3110,11 @@ impl AsRef<[u8]> for Uint513 {
 /// typedef opaque uint514<>;
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Uint514(
@@ -3087,7 +3144,7 @@ impl AsRef<BytesM> for Uint514 {
 
 impl ReadXdr for Uint514 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = BytesM::read_xdr(r)?;
             let v = Uint514(i);
@@ -3098,7 +3155,7 @@ impl ReadXdr for Uint514 {
 
 impl WriteXdr for Uint514 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -3119,7 +3176,7 @@ impl From<Uint514> for Vec<u8> {
 
 impl TryFrom<Vec<u8>> for Uint514 {
     type Error = Error;
-    fn try_from(x: Vec<u8>) -> Result<Self> {
+    fn try_from(x: Vec<u8>) -> Result<Self, Error> {
         Ok(Uint514(x.try_into()?))
     }
 }
@@ -3127,7 +3184,7 @@ impl TryFrom<Vec<u8>> for Uint514 {
 #[cfg(feature = "alloc")]
 impl TryFrom<&Vec<u8>> for Uint514 {
     type Error = Error;
-    fn try_from(x: &Vec<u8>) -> Result<Self> {
+    fn try_from(x: &Vec<u8>) -> Result<Self, Error> {
         Ok(Uint514(x.try_into()?))
     }
 }
@@ -3158,10 +3215,11 @@ impl AsRef<[u8]> for Uint514 {
 /// typedef string str<64>;
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Str(
@@ -3191,7 +3249,7 @@ impl AsRef<StringM::<64>> for Str {
 
 impl ReadXdr for Str {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = StringM::<64>::read_xdr(r)?;
             let v = Str(i);
@@ -3202,7 +3260,7 @@ impl ReadXdr for Str {
 
 impl WriteXdr for Str {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -3223,7 +3281,7 @@ impl From<Str> for Vec<u8> {
 
 impl TryFrom<Vec<u8>> for Str {
     type Error = Error;
-    fn try_from(x: Vec<u8>) -> Result<Self> {
+    fn try_from(x: Vec<u8>) -> Result<Self, Error> {
         Ok(Str(x.try_into()?))
     }
 }
@@ -3231,7 +3289,7 @@ impl TryFrom<Vec<u8>> for Str {
 #[cfg(feature = "alloc")]
 impl TryFrom<&Vec<u8>> for Str {
     type Error = Error;
-    fn try_from(x: &Vec<u8>) -> Result<Self> {
+    fn try_from(x: &Vec<u8>) -> Result<Self, Error> {
         Ok(Str(x.try_into()?))
     }
 }
@@ -3262,10 +3320,11 @@ impl AsRef<[u8]> for Str {
 /// typedef string str2<>;
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Str2(
@@ -3295,7 +3354,7 @@ impl AsRef<StringM> for Str2 {
 
 impl ReadXdr for Str2 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = StringM::read_xdr(r)?;
             let v = Str2(i);
@@ -3306,7 +3365,7 @@ impl ReadXdr for Str2 {
 
 impl WriteXdr for Str2 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -3327,7 +3386,7 @@ impl From<Str2> for Vec<u8> {
 
 impl TryFrom<Vec<u8>> for Str2 {
     type Error = Error;
-    fn try_from(x: Vec<u8>) -> Result<Self> {
+    fn try_from(x: Vec<u8>) -> Result<Self, Error> {
         Ok(Str2(x.try_into()?))
     }
 }
@@ -3335,7 +3394,7 @@ impl TryFrom<Vec<u8>> for Str2 {
 #[cfg(feature = "alloc")]
 impl TryFrom<&Vec<u8>> for Str2 {
     type Error = Error;
-    fn try_from(x: &Vec<u8>) -> Result<Self> {
+    fn try_from(x: &Vec<u8>) -> Result<Self, Error> {
         Ok(Str2(x.try_into()?))
     }
 }
@@ -3366,6 +3425,7 @@ impl AsRef<[u8]> for Str2 {
 /// typedef opaque Hash[32];
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
@@ -3457,7 +3517,7 @@ impl AsRef<[u8; 32]> for Hash {
 
 impl ReadXdr for Hash {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = <[u8; 32]>::read_xdr(r)?;
             let v = Hash(i);
@@ -3468,7 +3528,7 @@ impl ReadXdr for Hash {
 
 impl WriteXdr for Hash {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -3483,7 +3543,7 @@ impl Hash {
 #[cfg(feature = "alloc")]
 impl TryFrom<Vec<u8>> for Hash {
     type Error = Error;
-    fn try_from(x: Vec<u8>) -> Result<Self> {
+    fn try_from(x: Vec<u8>) -> Result<Self, Error> {
         x.as_slice().try_into()
     }
 }
@@ -3491,14 +3551,14 @@ impl TryFrom<Vec<u8>> for Hash {
 #[cfg(feature = "alloc")]
 impl TryFrom<&Vec<u8>> for Hash {
     type Error = Error;
-    fn try_from(x: &Vec<u8>) -> Result<Self> {
+    fn try_from(x: &Vec<u8>) -> Result<Self, Error> {
         x.as_slice().try_into()
     }
 }
 
 impl TryFrom<&[u8]> for Hash {
     type Error = Error;
-    fn try_from(x: &[u8]) -> Result<Self> {
+    fn try_from(x: &[u8]) -> Result<Self, Error> {
         Ok(Hash(x.try_into()?))
     }
 }
@@ -3516,9 +3576,10 @@ impl AsRef<[u8]> for Hash {
 /// typedef Hash Hashes1[12];
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Hashes1(
@@ -3548,7 +3609,7 @@ impl AsRef<[Hash; 12]> for Hashes1 {
 
 impl ReadXdr for Hashes1 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = <[Hash; 12]>::read_xdr(r)?;
             let v = Hashes1(i);
@@ -3559,7 +3620,7 @@ impl ReadXdr for Hashes1 {
 
 impl WriteXdr for Hashes1 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -3574,7 +3635,7 @@ impl Hashes1 {
 #[cfg(feature = "alloc")]
 impl TryFrom<Vec<Hash>> for Hashes1 {
     type Error = Error;
-    fn try_from(x: Vec<Hash>) -> Result<Self> {
+    fn try_from(x: Vec<Hash>) -> Result<Self, Error> {
         x.as_slice().try_into()
     }
 }
@@ -3582,14 +3643,14 @@ impl TryFrom<Vec<Hash>> for Hashes1 {
 #[cfg(feature = "alloc")]
 impl TryFrom<&Vec<Hash>> for Hashes1 {
     type Error = Error;
-    fn try_from(x: &Vec<Hash>) -> Result<Self> {
+    fn try_from(x: &Vec<Hash>) -> Result<Self, Error> {
         x.as_slice().try_into()
     }
 }
 
 impl TryFrom<&[Hash]> for Hashes1 {
     type Error = Error;
-    fn try_from(x: &[Hash]) -> Result<Self> {
+    fn try_from(x: &[Hash]) -> Result<Self, Error> {
         Ok(Hashes1(x.try_into()?))
     }
 }
@@ -3607,40 +3668,41 @@ impl AsRef<[Hash]> for Hashes1 {
 /// typedef Hash Hashes2<12>;
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Hashes2(
-  pub VecM::<Hash, 12>
+  pub VecM<Hash, 12>
 );
 
-impl From<Hashes2> for VecM::<Hash, 12> {
+impl From<Hashes2> for VecM<Hash, 12> {
     #[must_use]
     fn from(x: Hashes2) -> Self {
         x.0
     }
 }
 
-impl From<VecM::<Hash, 12>> for Hashes2 {
+impl From<VecM<Hash, 12>> for Hashes2 {
     #[must_use]
-    fn from(x: VecM::<Hash, 12>) -> Self {
+    fn from(x: VecM<Hash, 12>) -> Self {
         Hashes2(x)
     }
 }
 
-impl AsRef<VecM::<Hash, 12>> for Hashes2 {
+impl AsRef<VecM<Hash, 12>> for Hashes2 {
     #[must_use]
-    fn as_ref(&self) -> &VecM::<Hash, 12> {
+    fn as_ref(&self) -> &VecM<Hash, 12> {
         &self.0
     }
 }
 
 impl ReadXdr for Hashes2 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = VecM::<Hash, 12>::read_xdr(r)?;
             let v = Hashes2(i);
@@ -3651,13 +3713,13 @@ impl ReadXdr for Hashes2 {
 
 impl WriteXdr for Hashes2 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
 
 impl Deref for Hashes2 {
-  type Target = VecM::<Hash, 12>;
+  type Target = VecM<Hash, 12>;
   fn deref(&self) -> &Self::Target {
       &self.0
   }
@@ -3672,7 +3734,7 @@ impl From<Hashes2> for Vec<Hash> {
 
 impl TryFrom<Vec<Hash>> for Hashes2 {
     type Error = Error;
-    fn try_from(x: Vec<Hash>) -> Result<Self> {
+    fn try_from(x: Vec<Hash>) -> Result<Self, Error> {
         Ok(Hashes2(x.try_into()?))
     }
 }
@@ -3680,7 +3742,7 @@ impl TryFrom<Vec<Hash>> for Hashes2 {
 #[cfg(feature = "alloc")]
 impl TryFrom<&Vec<Hash>> for Hashes2 {
     type Error = Error;
-    fn try_from(x: &Vec<Hash>) -> Result<Self> {
+    fn try_from(x: &Vec<Hash>) -> Result<Self, Error> {
         Ok(Hashes2(x.try_into()?))
     }
 }
@@ -3711,40 +3773,41 @@ impl AsRef<[Hash]> for Hashes2 {
 /// typedef Hash Hashes3<>;
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Hashes3(
-  pub VecM::<Hash>
+  pub VecM<Hash>
 );
 
-impl From<Hashes3> for VecM::<Hash> {
+impl From<Hashes3> for VecM<Hash> {
     #[must_use]
     fn from(x: Hashes3) -> Self {
         x.0
     }
 }
 
-impl From<VecM::<Hash>> for Hashes3 {
+impl From<VecM<Hash>> for Hashes3 {
     #[must_use]
-    fn from(x: VecM::<Hash>) -> Self {
+    fn from(x: VecM<Hash>) -> Self {
         Hashes3(x)
     }
 }
 
-impl AsRef<VecM::<Hash>> for Hashes3 {
+impl AsRef<VecM<Hash>> for Hashes3 {
     #[must_use]
-    fn as_ref(&self) -> &VecM::<Hash> {
+    fn as_ref(&self) -> &VecM<Hash> {
         &self.0
     }
 }
 
 impl ReadXdr for Hashes3 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = VecM::<Hash>::read_xdr(r)?;
             let v = Hashes3(i);
@@ -3755,13 +3818,13 @@ impl ReadXdr for Hashes3 {
 
 impl WriteXdr for Hashes3 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
 
 impl Deref for Hashes3 {
-  type Target = VecM::<Hash>;
+  type Target = VecM<Hash>;
   fn deref(&self) -> &Self::Target {
       &self.0
   }
@@ -3776,7 +3839,7 @@ impl From<Hashes3> for Vec<Hash> {
 
 impl TryFrom<Vec<Hash>> for Hashes3 {
     type Error = Error;
-    fn try_from(x: Vec<Hash>) -> Result<Self> {
+    fn try_from(x: Vec<Hash>) -> Result<Self, Error> {
         Ok(Hashes3(x.try_into()?))
     }
 }
@@ -3784,7 +3847,7 @@ impl TryFrom<Vec<Hash>> for Hashes3 {
 #[cfg(feature = "alloc")]
 impl TryFrom<&Vec<Hash>> for Hashes3 {
     type Error = Error;
-    fn try_from(x: &Vec<Hash>) -> Result<Self> {
+    fn try_from(x: &Vec<Hash>) -> Result<Self, Error> {
         Ok(Hashes3(x.try_into()?))
     }
 }
@@ -3815,9 +3878,10 @@ impl AsRef<[Hash]> for Hashes3 {
 /// typedef Hash *optHash1;
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct OptHash1(
@@ -3847,7 +3911,7 @@ impl AsRef<Option<Hash>> for OptHash1 {
 
 impl ReadXdr for OptHash1 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = Option::<Hash>::read_xdr(r)?;
             let v = OptHash1(i);
@@ -3858,7 +3922,7 @@ impl ReadXdr for OptHash1 {
 
 impl WriteXdr for OptHash1 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -3869,9 +3933,10 @@ impl WriteXdr for OptHash1 {
 /// typedef Hash* optHash2;
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct OptHash2(
@@ -3901,7 +3966,7 @@ impl AsRef<Option<Hash>> for OptHash2 {
 
 impl ReadXdr for OptHash2 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = Option::<Hash>::read_xdr(r)?;
             let v = OptHash2(i);
@@ -3912,7 +3977,7 @@ impl ReadXdr for OptHash2 {
 
 impl WriteXdr for OptHash2 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -3965,6 +4030,7 @@ pub type Int4 = u64;
 /// ```
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_eval::cfg_eval]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 pub struct MyStruct {
@@ -3979,7 +4045,7 @@ pub struct MyStruct {
 
         impl ReadXdr for MyStruct {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       field1: Uint512::read_xdr(r)?,
@@ -3996,7 +4062,7 @@ field7: bool::read_xdr(r)?,
 
         impl WriteXdr for MyStruct {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     self.field1.write_xdr(w)?;
 self.field2.write_xdr(w)?;
@@ -4020,15 +4086,16 @@ self.field7.write_xdr(w)?;
 /// ```
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_eval::cfg_eval]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 pub struct LotsOfMyStructs {
-  pub members: VecM::<MyStruct>,
+  pub members: VecM<MyStruct>,
 }
 
 impl ReadXdr for LotsOfMyStructs {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             Ok(Self{
               members: VecM::<MyStruct>::read_xdr(r)?,
@@ -4039,7 +4106,7 @@ impl ReadXdr for LotsOfMyStructs {
 
 impl WriteXdr for LotsOfMyStructs {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             self.members.write_xdr(w)?;
             Ok(())
@@ -4057,6 +4124,7 @@ impl WriteXdr for LotsOfMyStructs {
 /// ```
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_eval::cfg_eval]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -4066,7 +4134,7 @@ pub struct HasStuff {
 
 impl ReadXdr for HasStuff {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             Ok(Self{
               data: LotsOfMyStructs::read_xdr(r)?,
@@ -4077,7 +4145,7 @@ impl ReadXdr for HasStuff {
 
 impl WriteXdr for HasStuff {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             self.data.write_xdr(w)?;
             Ok(())
@@ -4154,7 +4222,7 @@ Self::Green => "Green",
         impl TryFrom<i32> for Color {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     0 => Color::Red,
 5 => Color::Blue,
@@ -4175,7 +4243,7 @@ Self::Green => "Green",
 
         impl ReadXdr for Color {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -4186,7 +4254,7 @@ Self::Green => "Green",
 
         impl WriteXdr for Color {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -4274,7 +4342,7 @@ Self::B2 => "B2",
         impl TryFrom<i32> for NesterNestedEnum {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     0 => NesterNestedEnum::B1,
 1 => NesterNestedEnum::B2,
@@ -4294,7 +4362,7 @@ Self::B2 => "B2",
 
         impl ReadXdr for NesterNestedEnum {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -4305,7 +4373,7 @@ Self::B2 => "B2",
 
         impl WriteXdr for NesterNestedEnum {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -4322,6 +4390,7 @@ Self::B2 => "B2",
 /// ```
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_eval::cfg_eval]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -4331,7 +4400,7 @@ pub struct NesterNestedStruct {
 
 impl ReadXdr for NesterNestedStruct {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             Ok(Self{
               blah: i32::read_xdr(r)?,
@@ -4342,7 +4411,7 @@ impl ReadXdr for NesterNestedStruct {
 
 impl WriteXdr for NesterNestedStruct {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             self.blah.write_xdr(w)?;
             Ok(())
@@ -4362,9 +4431,10 @@ impl WriteXdr for NesterNestedStruct {
 /// ```
 ///
 // union with discriminant Color
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(clippy::large_enum_variant)]
 pub enum NesterNestedUnion {
@@ -4424,7 +4494,7 @@ impl Union<Color> for NesterNestedUnion {}
 
 impl ReadXdr for NesterNestedUnion {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let dv: Color = <Color as ReadXdr>::read_xdr(r)?;
             #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
@@ -4440,7 +4510,7 @@ impl ReadXdr for NesterNestedUnion {
 
 impl WriteXdr for NesterNestedUnion {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             self.discriminant().write_xdr(w)?;
             #[allow(clippy::match_same_arms)]
@@ -4478,6 +4548,7 @@ impl WriteXdr for NesterNestedUnion {
 /// ```
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_eval::cfg_eval]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -4489,7 +4560,7 @@ pub struct Nester {
 
         impl ReadXdr for Nester {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       nested_enum: NesterNestedEnum::read_xdr(r)?,
@@ -4502,7 +4573,7 @@ nested_union: NesterNestedUnion::read_xdr(r)?,
 
         impl WriteXdr for Nester {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     self.nested_enum.write_xdr(w)?;
 self.nested_struct.write_xdr(w)?;
@@ -4677,7 +4748,7 @@ Self::NesterNestedUnion => gen.into_root_schema_for::<NesterNestedUnion>(),
         impl core::str::FromStr for TypeVariant {
             type Err = Error;
             #[allow(clippy::too_many_lines)]
-            fn from_str(s: &str) -> Result<Self> {
+            fn from_str(s: &str) -> Result<Self, Error> {
                 match s {
                     "Uint512" => Ok(Self::Uint512),
 "Uint513" => Ok(Self::Uint513),
@@ -4791,7 +4862,7 @@ TypeVariant::NesterNestedUnion, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::Uint512 => r.with_limited_depth(|r| Ok(Self::Uint512(Box::new(Uint512::read_xdr(r)?)))),
 TypeVariant::Uint513 => r.with_limited_depth(|r| Ok(Self::Uint513(Box::new(Uint513::read_xdr(r)?)))),
@@ -4820,14 +4891,14 @@ TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNested
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -4839,7 +4910,7 @@ TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNested
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
@@ -4847,7 +4918,7 @@ TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNested
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
 TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Uint513>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Uint513(Box::new(t))))),
@@ -4877,7 +4948,7 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Frame<Uint512>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Uint512(Box::new(t.0))))),
 TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Frame<Uint513>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Uint513(Box::new(t.0))))),
@@ -4907,7 +4978,7 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, Frame<NesterNestedUn
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
                     TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
@@ -4937,14 +5008,14 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
                 let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
                 let mut b64_reader = Cursor::new(b64);
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -4953,13 +5024,13 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[deprecated(note = "use from_json")]
-            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 Self::from_json(v, r)
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 match v {
                     TypeVariant::Uint512 => Ok(Self::Uint512(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Uint513 => Ok(Self::Uint513(Box::new(serde_json::from_reader(r)?))),
@@ -4989,7 +5060,7 @@ TypeVariant::NesterNestedUnion => Ok(Self::NesterNestedUnion(Box::new(serde_json
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::Uint512 => Ok(Self::Uint512(Box::new(serde::de::Deserialize::deserialize(r)?))),
 TypeVariant::Uint513 => Ok(Self::Uint513(Box::new(serde::de::Deserialize::deserialize(r)?))),
@@ -5132,7 +5203,7 @@ Self::NesterNestedUnion(_) => TypeVariant::NesterNestedUnion,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 match self {
                     Self::Uint512(v) => v.write_xdr(w),
 Self::Uint513(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -2932,8 +2932,14 @@ Self::Multi => "Multi",
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
-  Error(i32),
-  Multi(VecM::<i32>),
+  Error(
+    
+    i32
+  ),
+  Multi(
+    
+    VecM::<i32>
+  ),
 }
 
         impl MyUnion {
@@ -3043,8 +3049,14 @@ Self::Multi(v) => v.write_xdr(w)?,
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(clippy::large_enum_variant)]
 pub enum IntUnion {
-  V0(i32),
-  V1(VecM::<i32>),
+  V0(
+    
+    i32
+  ),
+  V1(
+    
+    VecM::<i32>
+  ),
 }
 
         impl IntUnion {
@@ -3145,7 +3157,10 @@ Self::V1(v) => v.write_xdr(w)?,
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct IntUnion2(pub IntUnion);
+pub struct IntUnion2(
+  
+  pub IntUnion
+);
 
 impl From<IntUnion2> for IntUnion {
     #[must_use]

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2873,7 +2927,7 @@ Self::Multi => "Multi",
         impl TryFrom<i32> for UnionKey {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     0 => UnionKey::Error,
 1 => UnionKey::Multi,
@@ -2893,7 +2947,7 @@ Self::Multi => "Multi",
 
         impl ReadXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -2904,7 +2958,7 @@ Self::Multi => "Multi",
 
         impl WriteXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -2927,16 +2981,17 @@ Self::Multi => "Multi",
 /// ```
 ///
 // union with discriminant UnionKey
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
   Error(
     i32
   ),
   Multi(
-    VecM::<i32>
+    VecM<i32>
   ),
 }
 
@@ -2997,7 +3052,7 @@ Self::Multi(_) => UnionKey::Multi,
 
         impl ReadXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let dv: UnionKey = <UnionKey as ReadXdr>::read_xdr(r)?;
                     #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
@@ -3014,7 +3069,7 @@ UnionKey::Multi => Self::Multi(VecM::<i32>::read_xdr(r)?),
 
         impl WriteXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     self.discriminant().write_xdr(w)?;
                     #[allow(clippy::match_same_arms)]
@@ -3041,9 +3096,10 @@ Self::Multi(v) => v.write_xdr(w)?,
 /// ```
 ///
 // union with discriminant i32
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(clippy::large_enum_variant)]
 pub enum IntUnion {
@@ -3051,7 +3107,7 @@ pub enum IntUnion {
     i32
   ),
   V1(
-    VecM::<i32>
+    VecM<i32>
   ),
 }
 
@@ -3112,7 +3168,7 @@ Self::V1(_) => 1,
 
         impl ReadXdr for IntUnion {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let dv: i32 = <i32 as ReadXdr>::read_xdr(r)?;
                     #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
@@ -3129,7 +3185,7 @@ Self::V1(_) => 1,
 
         impl WriteXdr for IntUnion {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     self.discriminant().write_xdr(w)?;
                     #[allow(clippy::match_same_arms)]
@@ -3148,9 +3204,10 @@ Self::V1(v) => v.write_xdr(w)?,
 /// typedef IntUnion IntUnion2;
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct IntUnion2(
@@ -3180,7 +3237,7 @@ impl AsRef<IntUnion> for IntUnion2 {
 
 impl ReadXdr for IntUnion2 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = IntUnion::read_xdr(r)?;
             let v = IntUnion2(i);
@@ -3191,7 +3248,7 @@ impl ReadXdr for IntUnion2 {
 
 impl WriteXdr for IntUnion2 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -3276,7 +3333,7 @@ Self::IntUnion2 => gen.into_root_schema_for::<IntUnion2>(),
         impl core::str::FromStr for TypeVariant {
             type Err = Error;
             #[allow(clippy::too_many_lines)]
-            fn from_str(s: &str) -> Result<Self> {
+            fn from_str(s: &str) -> Result<Self, Error> {
                 match s {
                     "SError" => Ok(Self::SError),
 "Multi" => Ok(Self::Multi),
@@ -3322,7 +3379,7 @@ TypeVariant::IntUnion2, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::SError => r.with_limited_depth(|r| Ok(Self::SError(Box::new(SError::read_xdr(r)?)))),
 TypeVariant::Multi => r.with_limited_depth(|r| Ok(Self::Multi(Box::new(Multi::read_xdr(r)?)))),
@@ -3334,14 +3391,14 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -3353,7 +3410,7 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
@@ -3361,7 +3418,7 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::SError(Box::new(t))))),
 TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
@@ -3374,7 +3431,7 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(&mut r.inner
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::SError => Box::new(ReadXdrIter::<_, Frame<SError>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::SError(Box::new(t.0))))),
 TypeVariant::Multi => Box::new(ReadXdrIter::<_, Frame<Multi>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Multi(Box::new(t.0))))),
@@ -3387,7 +3444,7 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, Frame<IntUnion2>>::new(&mut 
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
                     TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::SError(Box::new(t))))),
@@ -3400,14 +3457,14 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.limit
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
                 let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
                 let mut b64_reader = Cursor::new(b64);
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -3416,13 +3473,13 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.limit
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[deprecated(note = "use from_json")]
-            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 Self::from_json(v, r)
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 match v {
                     TypeVariant::SError => Ok(Self::SError(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Multi => Ok(Self::Multi(Box::new(serde_json::from_reader(r)?))),
@@ -3435,7 +3492,7 @@ TypeVariant::IntUnion2 => Ok(Self::IntUnion2(Box::new(serde_json::from_reader(r)
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::SError => Ok(Self::SError(Box::new(serde::de::Deserialize::deserialize(r)?))),
 TypeVariant::Multi => Ok(Self::Multi(Box::new(serde::de::Deserialize::deserialize(r)?))),
@@ -3510,7 +3567,7 @@ Self::IntUnion2(_) => TypeVariant::IntUnion2,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 match self {
                     Self::SError(v) => v.write_xdr(w),
 Self::Multi(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -2933,11 +2933,9 @@ Self::Multi => "Multi",
 #[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
   Error(
-    
     i32
   ),
   Multi(
-    
     VecM::<i32>
   ),
 }
@@ -3050,11 +3048,9 @@ Self::Multi(v) => v.write_xdr(w)?,
 #[allow(clippy::large_enum_variant)]
 pub enum IntUnion {
   V0(
-    
     i32
   ),
   V1(
-    
     VecM::<i32>
   ),
 }
@@ -3158,7 +3154,6 @@ Self::V1(v) => v.write_xdr(w)?,
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct IntUnion2(
-  
   pub IntUnion
 );
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2854,7 +2908,7 @@ impl fmt::Display for AccountFlags {
 impl TryFrom<i32> for AccountFlags {
     type Error = Error;
 
-    fn try_from(i: i32) -> Result<Self> {
+    fn try_from(i: i32) -> Result<Self, Error> {
         let e = match i {
             1 => AccountFlags::AuthRequiredFlag,
             #[allow(unreachable_patterns)]
@@ -2873,7 +2927,7 @@ impl From<AccountFlags> for i32 {
 
 impl ReadXdr for AccountFlags {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let e = i32::read_xdr(r)?;
             let v: Self = e.try_into()?;
@@ -2884,7 +2938,7 @@ impl ReadXdr for AccountFlags {
 
 impl WriteXdr for AccountFlags {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i: i32 = (*self).into();
             i.write_xdr(w)
@@ -2947,7 +3001,7 @@ impl Variants<TypeVariant> for TypeVariant {
 impl core::str::FromStr for TypeVariant {
     type Err = Error;
     #[allow(clippy::too_many_lines)]
-    fn from_str(s: &str) -> Result<Self> {
+    fn from_str(s: &str) -> Result<Self, Error> {
         match s {
             "AccountFlags" => Ok(Self::AccountFlags),
             _ => Err(Error::Invalid),
@@ -2973,21 +3027,21 @@ impl Type {
 
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+    pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
         match v {
             TypeVariant::AccountFlags => r.with_limited_depth(|r| Ok(Self::AccountFlags(Box::new(AccountFlags::read_xdr(r)?)))),
         }
     }
 
     #[cfg(feature = "base64")]
-    pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+    pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
         let t = Self::read_xdr(v, &mut dec)?;
         Ok(t)
     }
 
     #[cfg(feature = "std")]
-    pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+    pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(v, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -2999,7 +3053,7 @@ impl Type {
     }
 
     #[cfg(feature = "base64")]
-    pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+    pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
         let t = Self::read_xdr_to_end(v, &mut dec)?;
         Ok(t)
@@ -3007,7 +3061,7 @@ impl Type {
 
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+    pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
         match v {
             TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
         }
@@ -3015,7 +3069,7 @@ impl Type {
 
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+    pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
         match v {
             TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, Frame<AccountFlags>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t.0))))),
         }
@@ -3023,7 +3077,7 @@ impl Type {
 
     #[cfg(feature = "base64")]
     #[allow(clippy::too_many_lines)]
-    pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+    pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
         let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
         match v {
             TypeVariant::AccountFlags => Box::new(ReadXdrIter::<_, AccountFlags>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::AccountFlags(Box::new(t))))),
@@ -3031,14 +3085,14 @@ impl Type {
     }
 
     #[cfg(feature = "std")]
-    pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+    pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(v, &mut cursor)?;
         Ok(t)
     }
 
     #[cfg(feature = "base64")]
-    pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
         let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -3047,13 +3101,13 @@ impl Type {
 
     #[cfg(all(feature = "std", feature = "serde_json"))]
     #[deprecated(note = "use from_json")]
-    pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+    pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
         Self::from_json(v, r)
     }
 
     #[cfg(all(feature = "std", feature = "serde_json"))]
     #[allow(clippy::too_many_lines)]
-    pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+    pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
         match v {
             TypeVariant::AccountFlags => Ok(Self::AccountFlags(Box::new(serde_json::from_reader(r)?))),
         }
@@ -3061,7 +3115,7 @@ impl Type {
 
     #[cfg(all(feature = "std", feature = "serde_json"))]
     #[allow(clippy::too_many_lines)]
-    pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+    pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
         match v {
             TypeVariant::AccountFlags => Ok(Self::AccountFlags(Box::new(serde::de::Deserialize::deserialize(r)?))),
         }
@@ -3116,7 +3170,7 @@ impl Variants<TypeVariant> for Type {
 impl WriteXdr for Type {
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_lines)]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         match self {
             Self::AccountFlags(v) => v.write_xdr(w),
         }

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2816,7 +2870,7 @@ pub type TestArray = [i32; Foo];
 /// typedef int TestArray2<FOO>;
 /// ```
 ///
-pub type TestArray2 = VecM::<i32, 1>;
+pub type TestArray2 = VecM<i32, 1>;
 
         #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
         #[cfg_attr(
@@ -2878,7 +2932,7 @@ Self::TestArray2 => gen.into_root_schema_for::<TestArray2>(),
         impl core::str::FromStr for TypeVariant {
             type Err = Error;
             #[allow(clippy::too_many_lines)]
-            fn from_str(s: &str) -> Result<Self> {
+            fn from_str(s: &str) -> Result<Self, Error> {
                 match s {
                     "TestArray" => Ok(Self::TestArray),
 "TestArray2" => Ok(Self::TestArray2),
@@ -2908,7 +2962,7 @@ TypeVariant::TestArray2, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::TestArray => r.with_limited_depth(|r| Ok(Self::TestArray(Box::new(TestArray::read_xdr(r)?)))),
 TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new(TestArray2::read_xdr(r)?)))),
@@ -2916,14 +2970,14 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2935,7 +2989,7 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
@@ -2943,7 +2997,7 @@ TypeVariant::TestArray2 => r.with_limited_depth(|r| Ok(Self::TestArray2(Box::new
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
 TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::TestArray2(Box::new(t))))),
@@ -2952,7 +3006,7 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(&mut r.inn
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::TestArray => Box::new(ReadXdrIter::<_, Frame<TestArray>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::TestArray(Box::new(t.0))))),
 TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::TestArray2(Box::new(t.0))))),
@@ -2961,7 +3015,7 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, Frame<TestArray2>>::new(&mu
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
                     TypeVariant::TestArray => Box::new(ReadXdrIter::<_, TestArray>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::TestArray(Box::new(t))))),
@@ -2970,14 +3024,14 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.lim
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
                 let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
                 let mut b64_reader = Cursor::new(b64);
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -2986,13 +3040,13 @@ TypeVariant::TestArray2 => Box::new(ReadXdrIter::<_, TestArray2>::new(dec, r.lim
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[deprecated(note = "use from_json")]
-            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 Self::from_json(v, r)
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 match v {
                     TypeVariant::TestArray => Ok(Self::TestArray(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::TestArray2 => Ok(Self::TestArray2(Box::new(serde_json::from_reader(r)?))),
@@ -3001,7 +3055,7 @@ TypeVariant::TestArray2 => Ok(Self::TestArray2(Box::new(serde_json::from_reader(
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::TestArray => Ok(Self::TestArray(Box::new(serde::de::Deserialize::deserialize(r)?))),
 TypeVariant::TestArray2 => Ok(Self::TestArray2(Box::new(serde::de::Deserialize::deserialize(r)?))),
@@ -3060,7 +3114,7 @@ Self::TestArray2(_) => TypeVariant::TestArray2,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 match self {
                     Self::TestArray(v) => v.write_xdr(w),
 Self::TestArray2(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2925,7 +2979,7 @@ Self::FbaMessage => "FbaMessage",
         impl TryFrom<i32> for MessageType {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     0 => MessageType::ErrorMsg,
 1 => MessageType::Hello,
@@ -2957,7 +3011,7 @@ Self::FbaMessage => "FbaMessage",
 
         impl ReadXdr for MessageType {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -2968,7 +3022,7 @@ Self::FbaMessage => "FbaMessage",
 
         impl WriteXdr for MessageType {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -3045,7 +3099,7 @@ Self::Blue => "Blue",
         impl TryFrom<i32> for Color {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     0 => Color::Red,
 1 => Color::Green,
@@ -3066,7 +3120,7 @@ Self::Blue => "Blue",
 
         impl ReadXdr for Color {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -3077,7 +3131,7 @@ Self::Blue => "Blue",
 
         impl WriteXdr for Color {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -3154,7 +3208,7 @@ Self::Blue2 => "Blue2",
         impl TryFrom<i32> for Color2 {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     0 => Color2::Red2,
 1 => Color2::Green2,
@@ -3175,7 +3229,7 @@ Self::Blue2 => "Blue2",
 
         impl ReadXdr for Color2 {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -3186,7 +3240,7 @@ Self::Blue2 => "Blue2",
 
         impl WriteXdr for Color2 {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -3263,7 +3317,7 @@ Self::R3 => "R3",
         impl TryFrom<i32> for Color3 {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     1 => Color3::R1,
 2 => Color3::R2Two,
@@ -3284,7 +3338,7 @@ Self::R3 => "R3",
 
         impl ReadXdr for Color3 {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -3295,7 +3349,7 @@ Self::R3 => "R3",
 
         impl WriteXdr for Color3 {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -3373,7 +3427,7 @@ Self::Color3 => gen.into_root_schema_for::<Color3>(),
         impl core::str::FromStr for TypeVariant {
             type Err = Error;
             #[allow(clippy::too_many_lines)]
-            fn from_str(s: &str) -> Result<Self> {
+            fn from_str(s: &str) -> Result<Self, Error> {
                 match s {
                     "MessageType" => Ok(Self::MessageType),
 "Color" => Ok(Self::Color),
@@ -3411,7 +3465,7 @@ TypeVariant::Color3, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::MessageType => r.with_limited_depth(|r| Ok(Self::MessageType(Box::new(MessageType::read_xdr(r)?)))),
 TypeVariant::Color => r.with_limited_depth(|r| Ok(Self::Color(Box::new(Color::read_xdr(r)?)))),
@@ -3421,14 +3475,14 @@ TypeVariant::Color3 => r.with_limited_depth(|r| Ok(Self::Color3(Box::new(Color3:
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -3440,7 +3494,7 @@ TypeVariant::Color3 => r.with_limited_depth(|r| Ok(Self::Color3(Box::new(Color3:
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
@@ -3448,7 +3502,7 @@ TypeVariant::Color3 => r.with_limited_depth(|r| Ok(Self::Color3(Box::new(Color3:
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
 TypeVariant::Color => Box::new(ReadXdrIter::<_, Color>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Color(Box::new(t))))),
@@ -3459,7 +3513,7 @@ TypeVariant::Color3 => Box::new(ReadXdrIter::<_, Color3>::new(&mut r.inner, r.li
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::MessageType => Box::new(ReadXdrIter::<_, Frame<MessageType>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MessageType(Box::new(t.0))))),
 TypeVariant::Color => Box::new(ReadXdrIter::<_, Frame<Color>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Color(Box::new(t.0))))),
@@ -3470,7 +3524,7 @@ TypeVariant::Color3 => Box::new(ReadXdrIter::<_, Frame<Color3>>::new(&mut r.inne
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
                     TypeVariant::MessageType => Box::new(ReadXdrIter::<_, MessageType>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::MessageType(Box::new(t))))),
@@ -3481,14 +3535,14 @@ TypeVariant::Color3 => Box::new(ReadXdrIter::<_, Color3>::new(dec, r.limits.clon
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
                 let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
                 let mut b64_reader = Cursor::new(b64);
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -3497,13 +3551,13 @@ TypeVariant::Color3 => Box::new(ReadXdrIter::<_, Color3>::new(dec, r.limits.clon
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[deprecated(note = "use from_json")]
-            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 Self::from_json(v, r)
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 match v {
                     TypeVariant::MessageType => Ok(Self::MessageType(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Color => Ok(Self::Color(Box::new(serde_json::from_reader(r)?))),
@@ -3514,7 +3568,7 @@ TypeVariant::Color3 => Ok(Self::Color3(Box::new(serde_json::from_reader(r)?))),
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::MessageType => Ok(Self::MessageType(Box::new(serde::de::Deserialize::deserialize(r)?))),
 TypeVariant::Color => Ok(Self::Color(Box::new(serde::de::Deserialize::deserialize(r)?))),
@@ -3581,7 +3635,7 @@ Self::Color3(_) => TypeVariant::Color3,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 match self {
                     Self::MessageType(v) => v.write_xdr(w),
 Self::Color(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -2921,9 +2921,10 @@ pub type Foo = i32;
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MyUnionOne {
+
   pub some_int: i32,
 }
 
@@ -2959,10 +2960,12 @@ impl WriteXdr for MyUnionOne {
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MyUnionTwo {
+
   pub some_int: i32,
+
   pub foo: i32,
 }
 
@@ -3017,8 +3020,12 @@ self.foo.write_xdr(w)?;
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
-  One(MyUnionOne),
-  Two(MyUnionTwo),
+  One(
+    MyUnionOne
+  ),
+  Two(
+    MyUnionTwo
+  ),
   Offer,
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -2924,7 +2924,6 @@ pub type Foo = i32;
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MyUnionOne {
-
   pub some_int: i32,
 }
 
@@ -2963,9 +2962,7 @@ impl WriteXdr for MyUnionOne {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MyUnionTwo {
-
   pub some_int: i32,
-
   pub foo: i32,
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2863,7 +2917,7 @@ Self::Offer => "Offer",
         impl TryFrom<i32> for UnionKey {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     1 => UnionKey::One,
 2 => UnionKey::Two,
@@ -2884,7 +2938,7 @@ Self::Offer => "Offer",
 
         impl ReadXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -2895,7 +2949,7 @@ Self::Offer => "Offer",
 
         impl WriteXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -2920,6 +2974,7 @@ pub type Foo = i32;
 /// ```
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_eval::cfg_eval]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -2929,7 +2984,7 @@ pub struct MyUnionOne {
 
 impl ReadXdr for MyUnionOne {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             Ok(Self{
               some_int: i32::read_xdr(r)?,
@@ -2940,7 +2995,7 @@ impl ReadXdr for MyUnionOne {
 
 impl WriteXdr for MyUnionOne {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             self.some_int.write_xdr(w)?;
             Ok(())
@@ -2958,6 +3013,7 @@ impl WriteXdr for MyUnionOne {
 /// ```
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_eval::cfg_eval]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -2968,7 +3024,7 @@ pub struct MyUnionTwo {
 
         impl ReadXdr for MyUnionTwo {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       some_int: i32::read_xdr(r)?,
@@ -2980,7 +3036,7 @@ foo: i32::read_xdr(r)?,
 
         impl WriteXdr for MyUnionTwo {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     self.some_int.write_xdr(w)?;
 self.foo.write_xdr(w)?;
@@ -3011,6 +3067,7 @@ self.foo.write_xdr(w)?;
 /// ```
 ///
 // union with discriminant UnionKey
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
@@ -3087,7 +3144,7 @@ Self::Offer => UnionKey::Offer,
 
         impl ReadXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let dv: UnionKey = <UnionKey as ReadXdr>::read_xdr(r)?;
                     #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
@@ -3105,7 +3162,7 @@ UnionKey::Offer => Self::Offer,
 
         impl WriteXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     self.discriminant().write_xdr(w)?;
                     #[allow(clippy::match_same_arms)]
@@ -3194,7 +3251,7 @@ Self::MyUnionTwo => gen.into_root_schema_for::<MyUnionTwo>(),
         impl core::str::FromStr for TypeVariant {
             type Err = Error;
             #[allow(clippy::too_many_lines)]
-            fn from_str(s: &str) -> Result<Self> {
+            fn from_str(s: &str) -> Result<Self, Error> {
                 match s {
                     "UnionKey" => Ok(Self::UnionKey),
 "Foo" => Ok(Self::Foo),
@@ -3236,7 +3293,7 @@ TypeVariant::MyUnionTwo, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::UnionKey => r.with_limited_depth(|r| Ok(Self::UnionKey(Box::new(UnionKey::read_xdr(r)?)))),
 TypeVariant::Foo => r.with_limited_depth(|r| Ok(Self::Foo(Box::new(Foo::read_xdr(r)?)))),
@@ -3247,14 +3304,14 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -3266,7 +3323,7 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
@@ -3274,7 +3331,7 @@ TypeVariant::MyUnionTwo => r.with_limited_depth(|r| Ok(Self::MyUnionTwo(Box::new
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
 TypeVariant::Foo => Box::new(ReadXdrIter::<_, Foo>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Foo(Box::new(t))))),
@@ -3286,7 +3343,7 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(&mut r.inn
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, Frame<UnionKey>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::UnionKey(Box::new(t.0))))),
 TypeVariant::Foo => Box::new(ReadXdrIter::<_, Frame<Foo>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Foo(Box::new(t.0))))),
@@ -3298,7 +3355,7 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, Frame<MyUnionTwo>>::new(&mu
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
                     TypeVariant::UnionKey => Box::new(ReadXdrIter::<_, UnionKey>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::UnionKey(Box::new(t))))),
@@ -3310,14 +3367,14 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.lim
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
                 let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
                 let mut b64_reader = Cursor::new(b64);
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -3326,13 +3383,13 @@ TypeVariant::MyUnionTwo => Box::new(ReadXdrIter::<_, MyUnionTwo>::new(dec, r.lim
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[deprecated(note = "use from_json")]
-            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 Self::from_json(v, r)
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 match v {
                     TypeVariant::UnionKey => Ok(Self::UnionKey(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Foo => Ok(Self::Foo(Box::new(serde_json::from_reader(r)?))),
@@ -3344,7 +3401,7 @@ TypeVariant::MyUnionTwo => Ok(Self::MyUnionTwo(Box::new(serde_json::from_reader(
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::UnionKey => Ok(Self::UnionKey(Box::new(serde::de::Deserialize::deserialize(r)?))),
 TypeVariant::Foo => Ok(Self::Foo(Box::new(serde::de::Deserialize::deserialize(r)?))),
@@ -3415,7 +3472,7 @@ Self::MyUnionTwo(_) => TypeVariant::MyUnionTwo,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 match self {
                     Self::UnionKey(v) => v.write_xdr(w),
 Self::Foo(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2814,6 +2868,7 @@ pub type Arr = [i32; 2];
 /// ```
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_eval::cfg_eval]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -2825,7 +2880,7 @@ pub struct HasOptions {
 
         impl ReadXdr for HasOptions {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       first_option: Option::<i32>::read_xdr(r)?,
@@ -2838,7 +2893,7 @@ third_option: Option::<i32>::read_xdr(r)?,
 
         impl WriteXdr for HasOptions {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     self.first_option.write_xdr(w)?;
 self.second_option.write_xdr(w)?;
@@ -2908,7 +2963,7 @@ Self::HasOptions => gen.into_root_schema_for::<HasOptions>(),
         impl core::str::FromStr for TypeVariant {
             type Err = Error;
             #[allow(clippy::too_many_lines)]
-            fn from_str(s: &str) -> Result<Self> {
+            fn from_str(s: &str) -> Result<Self, Error> {
                 match s {
                     "Arr" => Ok(Self::Arr),
 "HasOptions" => Ok(Self::HasOptions),
@@ -2938,7 +2993,7 @@ TypeVariant::HasOptions, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::Arr => r.with_limited_depth(|r| Ok(Self::Arr(Box::new(Arr::read_xdr(r)?)))),
 TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new(HasOptions::read_xdr(r)?)))),
@@ -2946,14 +3001,14 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2965,7 +3020,7 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
@@ -2973,7 +3028,7 @@ TypeVariant::HasOptions => r.with_limited_depth(|r| Ok(Self::HasOptions(Box::new
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
 TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::HasOptions(Box::new(t))))),
@@ -2982,7 +3037,7 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(&mut r.inn
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::Arr => Box::new(ReadXdrIter::<_, Frame<Arr>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Arr(Box::new(t.0))))),
 TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::HasOptions(Box::new(t.0))))),
@@ -2991,7 +3046,7 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, Frame<HasOptions>>::new(&mu
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
                     TypeVariant::Arr => Box::new(ReadXdrIter::<_, Arr>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Arr(Box::new(t))))),
@@ -3000,14 +3055,14 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.lim
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
                 let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
                 let mut b64_reader = Cursor::new(b64);
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -3016,13 +3071,13 @@ TypeVariant::HasOptions => Box::new(ReadXdrIter::<_, HasOptions>::new(dec, r.lim
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[deprecated(note = "use from_json")]
-            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 Self::from_json(v, r)
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 match v {
                     TypeVariant::Arr => Ok(Self::Arr(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::HasOptions => Ok(Self::HasOptions(Box::new(serde_json::from_reader(r)?))),
@@ -3031,7 +3086,7 @@ TypeVariant::HasOptions => Ok(Self::HasOptions(Box::new(serde_json::from_reader(
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::Arr => Ok(Self::Arr(Box::new(serde::de::Deserialize::deserialize(r)?))),
 TypeVariant::HasOptions => Ok(Self::HasOptions(Box::new(serde::de::Deserialize::deserialize(r)?))),
@@ -3090,7 +3145,7 @@ Self::HasOptions(_) => TypeVariant::HasOptions,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 match self {
                     Self::Arr(v) => v.write_xdr(w),
 Self::HasOptions(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2816,6 +2870,7 @@ pub type Int64 = i64;
 /// ```
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_eval::cfg_eval]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -2829,7 +2884,7 @@ pub struct MyStruct {
 
         impl ReadXdr for MyStruct {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       some_int: i32::read_xdr(r)?,
@@ -2844,7 +2899,7 @@ max_string: StringM::<100>::read_xdr(r)?,
 
         impl WriteXdr for MyStruct {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     self.some_int.write_xdr(w)?;
 self.a_big_int.write_xdr(w)?;
@@ -2916,7 +2971,7 @@ Self::MyStruct => gen.into_root_schema_for::<MyStruct>(),
         impl core::str::FromStr for TypeVariant {
             type Err = Error;
             #[allow(clippy::too_many_lines)]
-            fn from_str(s: &str) -> Result<Self> {
+            fn from_str(s: &str) -> Result<Self, Error> {
                 match s {
                     "Int64" => Ok(Self::Int64),
 "MyStruct" => Ok(Self::MyStruct),
@@ -2946,7 +3001,7 @@ TypeVariant::MyStruct, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::Int64 => r.with_limited_depth(|r| Ok(Self::Int64(Box::new(Int64::read_xdr(r)?)))),
 TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyStruct::read_xdr(r)?)))),
@@ -2954,14 +3009,14 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -2973,7 +3028,7 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
@@ -2981,7 +3036,7 @@ TypeVariant::MyStruct => r.with_limited_depth(|r| Ok(Self::MyStruct(Box::new(MyS
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
 TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyStruct(Box::new(t))))),
@@ -2990,7 +3045,7 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(&mut r.inner, 
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Frame<Int64>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Int64(Box::new(t.0))))),
 TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::MyStruct(Box::new(t.0))))),
@@ -2999,7 +3054,7 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, Frame<MyStruct>>::new(&mut r.
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
                     TypeVariant::Int64 => Box::new(ReadXdrIter::<_, Int64>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Int64(Box::new(t))))),
@@ -3008,14 +3063,14 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits.
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
                 let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
                 let mut b64_reader = Cursor::new(b64);
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -3024,13 +3079,13 @@ TypeVariant::MyStruct => Box::new(ReadXdrIter::<_, MyStruct>::new(dec, r.limits.
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[deprecated(note = "use from_json")]
-            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 Self::from_json(v, r)
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 match v {
                     TypeVariant::Int64 => Ok(Self::Int64(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::MyStruct => Ok(Self::MyStruct(Box::new(serde_json::from_reader(r)?))),
@@ -3039,7 +3094,7 @@ TypeVariant::MyStruct => Ok(Self::MyStruct(Box::new(serde_json::from_reader(r)?)
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::Int64 => Ok(Self::Int64(Box::new(serde::de::Deserialize::deserialize(r)?))),
 TypeVariant::MyStruct => Ok(Self::MyStruct(Box::new(serde::de::Deserialize::deserialize(r)?))),
@@ -3098,7 +3153,7 @@ Self::MyStruct(_) => TypeVariant::MyStruct,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 match self {
                     Self::Int64(v) => v.write_xdr(w),
 Self::MyStruct(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -2804,7 +2804,6 @@ mod test {
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
 pub struct Uint512(
-  
   pub [u8; 64]
 );
 
@@ -2958,7 +2957,6 @@ impl AsRef<[u8]> for Uint512 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Uint513(
-  
   pub BytesM::<64>
 );
 
@@ -3063,7 +3061,6 @@ impl AsRef<[u8]> for Uint513 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Uint514(
-  
   pub BytesM
 );
 
@@ -3168,7 +3165,6 @@ impl AsRef<[u8]> for Uint514 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Str(
-  
   pub StringM::<64>
 );
 
@@ -3273,7 +3269,6 @@ impl AsRef<[u8]> for Str {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Str2(
-  
   pub StringM
 );
 
@@ -3375,7 +3370,6 @@ impl AsRef<[u8]> for Str2 {
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
 pub struct Hash(
-  
   pub [u8; 32]
 );
 
@@ -3528,7 +3522,6 @@ impl AsRef<[u8]> for Hash {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Hashes1(
-  
   pub [Hash; 12]
 );
 
@@ -3621,7 +3614,6 @@ impl AsRef<[Hash]> for Hashes1 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Hashes2(
-  
   pub VecM::<Hash, 12>
 );
 
@@ -3726,7 +3718,6 @@ impl AsRef<[Hash]> for Hashes2 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Hashes3(
-  
   pub VecM::<Hash>
 );
 
@@ -3830,7 +3821,6 @@ impl AsRef<[Hash]> for Hashes3 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct OptHash1(
-  
   pub Option<Hash>
 );
 
@@ -3885,7 +3875,6 @@ impl WriteXdr for OptHash1 {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct OptHash2(
-  
   pub Option<Hash>
 );
 
@@ -4074,7 +4063,6 @@ impl WriteXdr for LotsOfMyStructs {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct HasStuff {
-
   pub data: LotsOfMyStructs,
 }
 
@@ -4340,7 +4328,6 @@ Self::B2 => "B2",
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct NesterNestedStruct {
-
   pub blah: i32,
 }
 
@@ -4497,11 +4484,8 @@ impl WriteXdr for NesterNestedUnion {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Nester {
-
   pub nested_enum: NesterNestedEnum,
-
   pub nested_struct: NesterNestedStruct,
-
   pub nested_union: NesterNestedUnion,
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -2803,7 +2803,10 @@ mod test {
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
-pub struct Uint512(pub [u8; 64]);
+pub struct Uint512(
+  
+  pub [u8; 64]
+);
 
 impl core::fmt::Debug for Uint512 {
   fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2954,7 +2957,10 @@ impl AsRef<[u8]> for Uint512 {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct Uint513(pub BytesM::<64>);
+pub struct Uint513(
+  
+  pub BytesM::<64>
+);
 
 impl From<Uint513> for BytesM::<64> {
     #[must_use]
@@ -3056,7 +3062,10 @@ impl AsRef<[u8]> for Uint513 {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct Uint514(pub BytesM);
+pub struct Uint514(
+  
+  pub BytesM
+);
 
 impl From<Uint514> for BytesM {
     #[must_use]
@@ -3158,7 +3167,10 @@ impl AsRef<[u8]> for Uint514 {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct Str(pub StringM::<64>);
+pub struct Str(
+  
+  pub StringM::<64>
+);
 
 impl From<Str> for StringM::<64> {
     #[must_use]
@@ -3260,7 +3272,10 @@ impl AsRef<[u8]> for Str {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct Str2(pub StringM);
+pub struct Str2(
+  
+  pub StringM
+);
 
 impl From<Str2> for StringM {
     #[must_use]
@@ -3359,7 +3374,10 @@ impl AsRef<[u8]> for Str2 {
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
-pub struct Hash(pub [u8; 32]);
+pub struct Hash(
+  
+  pub [u8; 32]
+);
 
 impl core::fmt::Debug for Hash {
   fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3509,7 +3527,10 @@ impl AsRef<[u8]> for Hash {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct Hashes1(pub [Hash; 12]);
+pub struct Hashes1(
+  
+  pub [Hash; 12]
+);
 
 impl From<Hashes1> for [Hash; 12] {
     #[must_use]
@@ -3599,7 +3620,10 @@ impl AsRef<[Hash]> for Hashes1 {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct Hashes2(pub VecM::<Hash, 12>);
+pub struct Hashes2(
+  
+  pub VecM::<Hash, 12>
+);
 
 impl From<Hashes2> for VecM::<Hash, 12> {
     #[must_use]
@@ -3701,7 +3725,10 @@ impl AsRef<[Hash]> for Hashes2 {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct Hashes3(pub VecM::<Hash>);
+pub struct Hashes3(
+  
+  pub VecM::<Hash>
+);
 
 impl From<Hashes3> for VecM::<Hash> {
     #[must_use]
@@ -3802,7 +3829,10 @@ impl AsRef<[Hash]> for Hashes3 {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct OptHash1(pub Option<Hash>);
+pub struct OptHash1(
+  
+  pub Option<Hash>
+);
 
 impl From<OptHash1> for Option<Hash> {
     #[must_use]
@@ -3854,7 +3884,10 @@ impl WriteXdr for OptHash1 {
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct OptHash2(pub Option<Hash>);
+pub struct OptHash2(
+  
+  pub Option<Hash>
+);
 
 impl From<OptHash2> for Option<Hash> {
     #[must_use]
@@ -4038,9 +4071,10 @@ impl WriteXdr for LotsOfMyStructs {
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct HasStuff {
+
   pub data: LotsOfMyStructs,
 }
 
@@ -4303,9 +4337,10 @@ Self::B2 => "B2",
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct NesterNestedStruct {
+
   pub blah: i32,
 }
 
@@ -4459,11 +4494,14 @@ impl WriteXdr for NesterNestedUnion {
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Nester {
+
   pub nested_enum: NesterNestedEnum,
+
   pub nested_struct: NesterNestedStruct,
+
   pub nested_union: NesterNestedUnion,
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -5145,7 +5145,7 @@ impl<'de> serde::Deserialize<'de> for LotsOfMyStructs {
         use serde::Deserialize;
         #[derive(Deserialize)]
         struct LotsOfMyStructs {
-            members: VecM::<MyStruct>,
+            members: VecM<MyStruct>,
         }
         #[derive(Deserialize)]
         #[serde(untagged)]

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2800,6 +2854,7 @@ mod test {
 /// typedef opaque uint512[64];
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
@@ -2891,7 +2946,7 @@ impl AsRef<[u8; 64]> for Uint512 {
 
 impl ReadXdr for Uint512 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = <[u8; 64]>::read_xdr(r)?;
             let v = Uint512(i);
@@ -2902,7 +2957,7 @@ impl ReadXdr for Uint512 {
 
 impl WriteXdr for Uint512 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -2917,7 +2972,7 @@ impl Uint512 {
 #[cfg(feature = "alloc")]
 impl TryFrom<Vec<u8>> for Uint512 {
     type Error = Error;
-    fn try_from(x: Vec<u8>) -> Result<Self> {
+    fn try_from(x: Vec<u8>) -> Result<Self, Error> {
         x.as_slice().try_into()
     }
 }
@@ -2925,14 +2980,14 @@ impl TryFrom<Vec<u8>> for Uint512 {
 #[cfg(feature = "alloc")]
 impl TryFrom<&Vec<u8>> for Uint512 {
     type Error = Error;
-    fn try_from(x: &Vec<u8>) -> Result<Self> {
+    fn try_from(x: &Vec<u8>) -> Result<Self, Error> {
         x.as_slice().try_into()
     }
 }
 
 impl TryFrom<&[u8]> for Uint512 {
     type Error = Error;
-    fn try_from(x: &[u8]) -> Result<Self> {
+    fn try_from(x: &[u8]) -> Result<Self, Error> {
         Ok(Uint512(x.try_into()?))
     }
 }
@@ -2950,10 +3005,11 @@ impl AsRef<[u8]> for Uint512 {
 /// typedef opaque uint513<64>;
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Uint513(
@@ -2983,7 +3039,7 @@ impl AsRef<BytesM::<64>> for Uint513 {
 
 impl ReadXdr for Uint513 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = BytesM::<64>::read_xdr(r)?;
             let v = Uint513(i);
@@ -2994,7 +3050,7 @@ impl ReadXdr for Uint513 {
 
 impl WriteXdr for Uint513 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -3015,7 +3071,7 @@ impl From<Uint513> for Vec<u8> {
 
 impl TryFrom<Vec<u8>> for Uint513 {
     type Error = Error;
-    fn try_from(x: Vec<u8>) -> Result<Self> {
+    fn try_from(x: Vec<u8>) -> Result<Self, Error> {
         Ok(Uint513(x.try_into()?))
     }
 }
@@ -3023,7 +3079,7 @@ impl TryFrom<Vec<u8>> for Uint513 {
 #[cfg(feature = "alloc")]
 impl TryFrom<&Vec<u8>> for Uint513 {
     type Error = Error;
-    fn try_from(x: &Vec<u8>) -> Result<Self> {
+    fn try_from(x: &Vec<u8>) -> Result<Self, Error> {
         Ok(Uint513(x.try_into()?))
     }
 }
@@ -3054,10 +3110,11 @@ impl AsRef<[u8]> for Uint513 {
 /// typedef opaque uint514<>;
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Uint514(
@@ -3087,7 +3144,7 @@ impl AsRef<BytesM> for Uint514 {
 
 impl ReadXdr for Uint514 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = BytesM::read_xdr(r)?;
             let v = Uint514(i);
@@ -3098,7 +3155,7 @@ impl ReadXdr for Uint514 {
 
 impl WriteXdr for Uint514 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -3119,7 +3176,7 @@ impl From<Uint514> for Vec<u8> {
 
 impl TryFrom<Vec<u8>> for Uint514 {
     type Error = Error;
-    fn try_from(x: Vec<u8>) -> Result<Self> {
+    fn try_from(x: Vec<u8>) -> Result<Self, Error> {
         Ok(Uint514(x.try_into()?))
     }
 }
@@ -3127,7 +3184,7 @@ impl TryFrom<Vec<u8>> for Uint514 {
 #[cfg(feature = "alloc")]
 impl TryFrom<&Vec<u8>> for Uint514 {
     type Error = Error;
-    fn try_from(x: &Vec<u8>) -> Result<Self> {
+    fn try_from(x: &Vec<u8>) -> Result<Self, Error> {
         Ok(Uint514(x.try_into()?))
     }
 }
@@ -3158,10 +3215,11 @@ impl AsRef<[u8]> for Uint514 {
 /// typedef string str<64>;
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Str(
@@ -3191,7 +3249,7 @@ impl AsRef<StringM::<64>> for Str {
 
 impl ReadXdr for Str {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = StringM::<64>::read_xdr(r)?;
             let v = Str(i);
@@ -3202,7 +3260,7 @@ impl ReadXdr for Str {
 
 impl WriteXdr for Str {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -3223,7 +3281,7 @@ impl From<Str> for Vec<u8> {
 
 impl TryFrom<Vec<u8>> for Str {
     type Error = Error;
-    fn try_from(x: Vec<u8>) -> Result<Self> {
+    fn try_from(x: Vec<u8>) -> Result<Self, Error> {
         Ok(Str(x.try_into()?))
     }
 }
@@ -3231,7 +3289,7 @@ impl TryFrom<Vec<u8>> for Str {
 #[cfg(feature = "alloc")]
 impl TryFrom<&Vec<u8>> for Str {
     type Error = Error;
-    fn try_from(x: &Vec<u8>) -> Result<Self> {
+    fn try_from(x: &Vec<u8>) -> Result<Self, Error> {
         Ok(Str(x.try_into()?))
     }
 }
@@ -3262,10 +3320,11 @@ impl AsRef<[u8]> for Str {
 /// typedef string str2<>;
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Str2(
@@ -3295,7 +3354,7 @@ impl AsRef<StringM> for Str2 {
 
 impl ReadXdr for Str2 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = StringM::read_xdr(r)?;
             let v = Str2(i);
@@ -3306,7 +3365,7 @@ impl ReadXdr for Str2 {
 
 impl WriteXdr for Str2 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -3327,7 +3386,7 @@ impl From<Str2> for Vec<u8> {
 
 impl TryFrom<Vec<u8>> for Str2 {
     type Error = Error;
-    fn try_from(x: Vec<u8>) -> Result<Self> {
+    fn try_from(x: Vec<u8>) -> Result<Self, Error> {
         Ok(Str2(x.try_into()?))
     }
 }
@@ -3335,7 +3394,7 @@ impl TryFrom<Vec<u8>> for Str2 {
 #[cfg(feature = "alloc")]
 impl TryFrom<&Vec<u8>> for Str2 {
     type Error = Error;
-    fn try_from(x: &Vec<u8>) -> Result<Self> {
+    fn try_from(x: &Vec<u8>) -> Result<Self, Error> {
         Ok(Str2(x.try_into()?))
     }
 }
@@ -3366,6 +3425,7 @@ impl AsRef<[u8]> for Str2 {
 /// typedef opaque Hash[32];
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
@@ -3457,7 +3517,7 @@ impl AsRef<[u8; 32]> for Hash {
 
 impl ReadXdr for Hash {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = <[u8; 32]>::read_xdr(r)?;
             let v = Hash(i);
@@ -3468,7 +3528,7 @@ impl ReadXdr for Hash {
 
 impl WriteXdr for Hash {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -3483,7 +3543,7 @@ impl Hash {
 #[cfg(feature = "alloc")]
 impl TryFrom<Vec<u8>> for Hash {
     type Error = Error;
-    fn try_from(x: Vec<u8>) -> Result<Self> {
+    fn try_from(x: Vec<u8>) -> Result<Self, Error> {
         x.as_slice().try_into()
     }
 }
@@ -3491,14 +3551,14 @@ impl TryFrom<Vec<u8>> for Hash {
 #[cfg(feature = "alloc")]
 impl TryFrom<&Vec<u8>> for Hash {
     type Error = Error;
-    fn try_from(x: &Vec<u8>) -> Result<Self> {
+    fn try_from(x: &Vec<u8>) -> Result<Self, Error> {
         x.as_slice().try_into()
     }
 }
 
 impl TryFrom<&[u8]> for Hash {
     type Error = Error;
-    fn try_from(x: &[u8]) -> Result<Self> {
+    fn try_from(x: &[u8]) -> Result<Self, Error> {
         Ok(Hash(x.try_into()?))
     }
 }
@@ -3516,9 +3576,10 @@ impl AsRef<[u8]> for Hash {
 /// typedef Hash Hashes1[12];
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Hashes1(
@@ -3548,7 +3609,7 @@ impl AsRef<[Hash; 12]> for Hashes1 {
 
 impl ReadXdr for Hashes1 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = <[Hash; 12]>::read_xdr(r)?;
             let v = Hashes1(i);
@@ -3559,7 +3620,7 @@ impl ReadXdr for Hashes1 {
 
 impl WriteXdr for Hashes1 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -3574,7 +3635,7 @@ impl Hashes1 {
 #[cfg(feature = "alloc")]
 impl TryFrom<Vec<Hash>> for Hashes1 {
     type Error = Error;
-    fn try_from(x: Vec<Hash>) -> Result<Self> {
+    fn try_from(x: Vec<Hash>) -> Result<Self, Error> {
         x.as_slice().try_into()
     }
 }
@@ -3582,14 +3643,14 @@ impl TryFrom<Vec<Hash>> for Hashes1 {
 #[cfg(feature = "alloc")]
 impl TryFrom<&Vec<Hash>> for Hashes1 {
     type Error = Error;
-    fn try_from(x: &Vec<Hash>) -> Result<Self> {
+    fn try_from(x: &Vec<Hash>) -> Result<Self, Error> {
         x.as_slice().try_into()
     }
 }
 
 impl TryFrom<&[Hash]> for Hashes1 {
     type Error = Error;
-    fn try_from(x: &[Hash]) -> Result<Self> {
+    fn try_from(x: &[Hash]) -> Result<Self, Error> {
         Ok(Hashes1(x.try_into()?))
     }
 }
@@ -3607,40 +3668,41 @@ impl AsRef<[Hash]> for Hashes1 {
 /// typedef Hash Hashes2<12>;
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Hashes2(
-  pub VecM::<Hash, 12>
+  pub VecM<Hash, 12>
 );
 
-impl From<Hashes2> for VecM::<Hash, 12> {
+impl From<Hashes2> for VecM<Hash, 12> {
     #[must_use]
     fn from(x: Hashes2) -> Self {
         x.0
     }
 }
 
-impl From<VecM::<Hash, 12>> for Hashes2 {
+impl From<VecM<Hash, 12>> for Hashes2 {
     #[must_use]
-    fn from(x: VecM::<Hash, 12>) -> Self {
+    fn from(x: VecM<Hash, 12>) -> Self {
         Hashes2(x)
     }
 }
 
-impl AsRef<VecM::<Hash, 12>> for Hashes2 {
+impl AsRef<VecM<Hash, 12>> for Hashes2 {
     #[must_use]
-    fn as_ref(&self) -> &VecM::<Hash, 12> {
+    fn as_ref(&self) -> &VecM<Hash, 12> {
         &self.0
     }
 }
 
 impl ReadXdr for Hashes2 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = VecM::<Hash, 12>::read_xdr(r)?;
             let v = Hashes2(i);
@@ -3651,13 +3713,13 @@ impl ReadXdr for Hashes2 {
 
 impl WriteXdr for Hashes2 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
 
 impl Deref for Hashes2 {
-  type Target = VecM::<Hash, 12>;
+  type Target = VecM<Hash, 12>;
   fn deref(&self) -> &Self::Target {
       &self.0
   }
@@ -3672,7 +3734,7 @@ impl From<Hashes2> for Vec<Hash> {
 
 impl TryFrom<Vec<Hash>> for Hashes2 {
     type Error = Error;
-    fn try_from(x: Vec<Hash>) -> Result<Self> {
+    fn try_from(x: Vec<Hash>) -> Result<Self, Error> {
         Ok(Hashes2(x.try_into()?))
     }
 }
@@ -3680,7 +3742,7 @@ impl TryFrom<Vec<Hash>> for Hashes2 {
 #[cfg(feature = "alloc")]
 impl TryFrom<&Vec<Hash>> for Hashes2 {
     type Error = Error;
-    fn try_from(x: &Vec<Hash>) -> Result<Self> {
+    fn try_from(x: &Vec<Hash>) -> Result<Self, Error> {
         Ok(Hashes2(x.try_into()?))
     }
 }
@@ -3711,40 +3773,41 @@ impl AsRef<[Hash]> for Hashes2 {
 /// typedef Hash Hashes3<>;
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Default)]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct Hashes3(
-  pub VecM::<Hash>
+  pub VecM<Hash>
 );
 
-impl From<Hashes3> for VecM::<Hash> {
+impl From<Hashes3> for VecM<Hash> {
     #[must_use]
     fn from(x: Hashes3) -> Self {
         x.0
     }
 }
 
-impl From<VecM::<Hash>> for Hashes3 {
+impl From<VecM<Hash>> for Hashes3 {
     #[must_use]
-    fn from(x: VecM::<Hash>) -> Self {
+    fn from(x: VecM<Hash>) -> Self {
         Hashes3(x)
     }
 }
 
-impl AsRef<VecM::<Hash>> for Hashes3 {
+impl AsRef<VecM<Hash>> for Hashes3 {
     #[must_use]
-    fn as_ref(&self) -> &VecM::<Hash> {
+    fn as_ref(&self) -> &VecM<Hash> {
         &self.0
     }
 }
 
 impl ReadXdr for Hashes3 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = VecM::<Hash>::read_xdr(r)?;
             let v = Hashes3(i);
@@ -3755,13 +3818,13 @@ impl ReadXdr for Hashes3 {
 
 impl WriteXdr for Hashes3 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
 
 impl Deref for Hashes3 {
-  type Target = VecM::<Hash>;
+  type Target = VecM<Hash>;
   fn deref(&self) -> &Self::Target {
       &self.0
   }
@@ -3776,7 +3839,7 @@ impl From<Hashes3> for Vec<Hash> {
 
 impl TryFrom<Vec<Hash>> for Hashes3 {
     type Error = Error;
-    fn try_from(x: Vec<Hash>) -> Result<Self> {
+    fn try_from(x: Vec<Hash>) -> Result<Self, Error> {
         Ok(Hashes3(x.try_into()?))
     }
 }
@@ -3784,7 +3847,7 @@ impl TryFrom<Vec<Hash>> for Hashes3 {
 #[cfg(feature = "alloc")]
 impl TryFrom<&Vec<Hash>> for Hashes3 {
     type Error = Error;
-    fn try_from(x: &Vec<Hash>) -> Result<Self> {
+    fn try_from(x: &Vec<Hash>) -> Result<Self, Error> {
         Ok(Hashes3(x.try_into()?))
     }
 }
@@ -3815,9 +3878,10 @@ impl AsRef<[Hash]> for Hashes3 {
 /// typedef Hash *optHash1;
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct OptHash1(
@@ -3847,7 +3911,7 @@ impl AsRef<Option<Hash>> for OptHash1 {
 
 impl ReadXdr for OptHash1 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = Option::<Hash>::read_xdr(r)?;
             let v = OptHash1(i);
@@ -3858,7 +3922,7 @@ impl ReadXdr for OptHash1 {
 
 impl WriteXdr for OptHash1 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -3869,9 +3933,10 @@ impl WriteXdr for OptHash1 {
 /// typedef Hash* optHash2;
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct OptHash2(
@@ -3901,7 +3966,7 @@ impl AsRef<Option<Hash>> for OptHash2 {
 
 impl ReadXdr for OptHash2 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = Option::<Hash>::read_xdr(r)?;
             let v = OptHash2(i);
@@ -3912,7 +3977,7 @@ impl ReadXdr for OptHash2 {
 
 impl WriteXdr for OptHash2 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -3965,6 +4030,7 @@ pub type Int4 = u64;
 /// ```
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_eval::cfg_eval]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -3980,7 +4046,7 @@ pub struct MyStruct {
 
         impl ReadXdr for MyStruct {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       field1: Uint512::read_xdr(r)?,
@@ -3997,7 +4063,7 @@ field7: bool::read_xdr(r)?,
 
         impl WriteXdr for MyStruct {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     self.field1.write_xdr(w)?;
 self.field2.write_xdr(w)?;
@@ -4021,16 +4087,17 @@ self.field7.write_xdr(w)?;
 /// ```
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_eval::cfg_eval]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct LotsOfMyStructs {
-  pub members: VecM::<MyStruct>,
+  pub members: VecM<MyStruct>,
 }
 
 impl ReadXdr for LotsOfMyStructs {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             Ok(Self{
               members: VecM::<MyStruct>::read_xdr(r)?,
@@ -4041,7 +4108,7 @@ impl ReadXdr for LotsOfMyStructs {
 
 impl WriteXdr for LotsOfMyStructs {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             self.members.write_xdr(w)?;
             Ok(())
@@ -4059,6 +4126,7 @@ impl WriteXdr for LotsOfMyStructs {
 /// ```
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_eval::cfg_eval]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -4068,7 +4136,7 @@ pub struct HasStuff {
 
 impl ReadXdr for HasStuff {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             Ok(Self{
               data: LotsOfMyStructs::read_xdr(r)?,
@@ -4079,7 +4147,7 @@ impl ReadXdr for HasStuff {
 
 impl WriteXdr for HasStuff {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             self.data.write_xdr(w)?;
             Ok(())
@@ -4156,7 +4224,7 @@ Self::Green => "Green",
         impl TryFrom<i32> for Color {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     0 => Color::Red,
 5 => Color::Blue,
@@ -4177,7 +4245,7 @@ Self::Green => "Green",
 
         impl ReadXdr for Color {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -4188,7 +4256,7 @@ Self::Green => "Green",
 
         impl WriteXdr for Color {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -4276,7 +4344,7 @@ Self::B2 => "B2",
         impl TryFrom<i32> for NesterNestedEnum {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     0 => NesterNestedEnum::B1,
 1 => NesterNestedEnum::B2,
@@ -4296,7 +4364,7 @@ Self::B2 => "B2",
 
         impl ReadXdr for NesterNestedEnum {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -4307,7 +4375,7 @@ Self::B2 => "B2",
 
         impl WriteXdr for NesterNestedEnum {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -4324,6 +4392,7 @@ Self::B2 => "B2",
 /// ```
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_eval::cfg_eval]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -4333,7 +4402,7 @@ pub struct NesterNestedStruct {
 
 impl ReadXdr for NesterNestedStruct {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             Ok(Self{
               blah: i32::read_xdr(r)?,
@@ -4344,7 +4413,7 @@ impl ReadXdr for NesterNestedStruct {
 
 impl WriteXdr for NesterNestedStruct {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             self.blah.write_xdr(w)?;
             Ok(())
@@ -4364,9 +4433,10 @@ impl WriteXdr for NesterNestedStruct {
 /// ```
 ///
 // union with discriminant Color
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(clippy::large_enum_variant)]
 pub enum NesterNestedUnion {
@@ -4426,7 +4496,7 @@ impl Union<Color> for NesterNestedUnion {}
 
 impl ReadXdr for NesterNestedUnion {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let dv: Color = <Color as ReadXdr>::read_xdr(r)?;
             #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
@@ -4442,7 +4512,7 @@ impl ReadXdr for NesterNestedUnion {
 
 impl WriteXdr for NesterNestedUnion {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             self.discriminant().write_xdr(w)?;
             #[allow(clippy::match_same_arms)]
@@ -4480,6 +4550,7 @@ impl WriteXdr for NesterNestedUnion {
 /// ```
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_eval::cfg_eval]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -4491,7 +4562,7 @@ pub struct Nester {
 
         impl ReadXdr for Nester {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     Ok(Self{
                       nested_enum: NesterNestedEnum::read_xdr(r)?,
@@ -4504,7 +4575,7 @@ nested_union: NesterNestedUnion::read_xdr(r)?,
 
         impl WriteXdr for Nester {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     self.nested_enum.write_xdr(w)?;
 self.nested_struct.write_xdr(w)?;
@@ -4679,7 +4750,7 @@ Self::NesterNestedUnion => gen.into_root_schema_for::<NesterNestedUnion>(),
         impl core::str::FromStr for TypeVariant {
             type Err = Error;
             #[allow(clippy::too_many_lines)]
-            fn from_str(s: &str) -> Result<Self> {
+            fn from_str(s: &str) -> Result<Self, Error> {
                 match s {
                     "Uint512" => Ok(Self::Uint512),
 "Uint513" => Ok(Self::Uint513),
@@ -4793,7 +4864,7 @@ TypeVariant::NesterNestedUnion, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::Uint512 => r.with_limited_depth(|r| Ok(Self::Uint512(Box::new(Uint512::read_xdr(r)?)))),
 TypeVariant::Uint513 => r.with_limited_depth(|r| Ok(Self::Uint513(Box::new(Uint513::read_xdr(r)?)))),
@@ -4822,14 +4893,14 @@ TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNested
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -4841,7 +4912,7 @@ TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNested
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
@@ -4849,7 +4920,7 @@ TypeVariant::NesterNestedUnion => r.with_limited_depth(|r| Ok(Self::NesterNested
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
 TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Uint513>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Uint513(Box::new(t))))),
@@ -4879,7 +4950,7 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Frame<Uint512>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Uint512(Box::new(t.0))))),
 TypeVariant::Uint513 => Box::new(ReadXdrIter::<_, Frame<Uint513>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Uint513(Box::new(t.0))))),
@@ -4909,7 +4980,7 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, Frame<NesterNestedUn
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
                     TypeVariant::Uint512 => Box::new(ReadXdrIter::<_, Uint512>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::Uint512(Box::new(t))))),
@@ -4939,14 +5010,14 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
                 let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
                 let mut b64_reader = Cursor::new(b64);
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -4955,13 +5026,13 @@ TypeVariant::NesterNestedUnion => Box::new(ReadXdrIter::<_, NesterNestedUnion>::
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[deprecated(note = "use from_json")]
-            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 Self::from_json(v, r)
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 match v {
                     TypeVariant::Uint512 => Ok(Self::Uint512(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Uint513 => Ok(Self::Uint513(Box::new(serde_json::from_reader(r)?))),
@@ -4991,7 +5062,7 @@ TypeVariant::NesterNestedUnion => Ok(Self::NesterNestedUnion(Box::new(serde_json
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::Uint512 => Ok(Self::Uint512(Box::new(serde::de::Deserialize::deserialize(r)?))),
 TypeVariant::Uint513 => Ok(Self::Uint513(Box::new(serde::de::Deserialize::deserialize(r)?))),
@@ -5134,7 +5205,7 @@ Self::NesterNestedUnion(_) => TypeVariant::NesterNestedUnion,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 match self {
                     Self::Uint512(v) => v.write_xdr(w),
 Self::Uint513(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
+        vec.try_into().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2308,7 +2308,7 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = u64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -3252,15 +3252,15 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_i64_error_from_string_overflow() {
-        let overflow_val = (i64::MAX as i128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = i128::from(i64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
     
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
-        let underflow_val = (i64::MIN as i128) - 1;
-        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        let underflow_val = i128::from(i64::MIN) - 1;
+        let json = format!(r#"{{"val": "{underflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
 
@@ -3480,8 +3480,8 @@ mod tests_for_number_or_string {
 
     #[test]
     fn deserialize_u64_error_from_string_overflow() {
-        let overflow_val = (u64::MAX as u128) + 1;
-        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        let overflow_val = u128::from(u64::MAX) + 1;
+        let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestU64>(&json).is_err());
     }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -2934,8 +2934,12 @@ Self::Multi => "Multi",
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(clippy::large_enum_variant)]
 pub enum MyUnion {
-  Error(i32),
-  Multi(VecM::<i32>),
+  Error(
+    i32
+  ),
+  Multi(
+    VecM::<i32>
+  ),
 }
 
         impl MyUnion {
@@ -3045,8 +3049,14 @@ Self::Multi(v) => v.write_xdr(w)?,
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(clippy::large_enum_variant)]
 pub enum IntUnion {
-  V0(i32),
-  V1(VecM::<i32>),
+  V0(
+    
+    i32
+  ),
+  V1(
+    
+    VecM::<i32>
+  ),
 }
 
         impl IntUnion {
@@ -3147,7 +3157,10 @@ Self::V1(v) => v.write_xdr(w)?,
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
-pub struct IntUnion2(pub IntUnion);
+pub struct IntUnion2(
+  
+  pub IntUnion
+);
 
 impl From<IntUnion2> for IntUnion {
     #[must_use]

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -43,6 +43,14 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
+#[cfg(feature = "serde")]
+use serde_with::DisplayFromStr;
+
+#[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
+use std::borrow::Cow;
+#[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
+use alloc::borrow::Cow;
+
 // TODO: Add support for read/write xdr fns when std not available.
 
 #[cfg(feature = "std")]
@@ -164,9 +172,6 @@ impl From<Error> for () {
     fn from(_: Error) {}
 }
 
-#[allow(dead_code)]
-type Result<T> = core::result::Result<T, Error>;
-
 /// Name defines types that assign a static name to their value, such as the
 /// name given to an identifier in an XDR enum, or the name given to the case in
 /// a union.
@@ -270,7 +275,7 @@ impl<L> Limited<L> {
     ///
     /// If the length would consume more length than the remaining length limit
     /// allows.
-    pub(crate) fn consume_len(&mut self, len: usize) -> Result<()> {
+    pub(crate) fn consume_len(&mut self, len: usize) -> Result<(), Error> {
         if let Some(len) = self.limits.len.checked_sub(len) {
             self.limits.len = len;
             Ok(())
@@ -284,9 +289,9 @@ impl<L> Limited<L> {
     /// ### Errors
     ///
     /// If the depth limit is already exhausted.
-    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T>
+    pub(crate) fn with_limited_depth<T, F>(&mut self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&mut Self) -> Result<T>,
+        F: FnOnce(&mut Self) -> Result<T, Error>,
     {
         if let Some(depth) = self.limits.depth.checked_sub(1) {
             self.limits.depth = depth;
@@ -354,7 +359,7 @@ impl<R: Read, S: ReadXdr> ReadXdrIter<R, S> {
 
 #[cfg(feature = "std")]
 impl<R: Read, S: ReadXdr> Iterator for ReadXdrIter<R, S> {
-    type Item = Result<S>;
+    type Item = Result<S, Error>;
 
     // Next reads the internal reader and XDR decodes it into the Self type. If
     // the EOF is reached without reading any new bytes `None` is returned. If
@@ -407,14 +412,14 @@ where
     /// Use [`ReadXdR: Read_xdr_to_end`] when the intent is for all bytes in the
     /// read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self>;
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error>;
 
     /// Construct the type from the XDR bytes base64 encoded.
     ///
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -442,7 +447,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let s = Self::read_xdr(r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -458,7 +463,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr_base64_to_end<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD),
             r.limits.clone(),
@@ -482,7 +487,7 @@ where
     /// Use [`ReadXdR: Read_xdr_into_to_end`] when the intent is for all bytes
     /// in the read implementation to be consumed by the read.
     #[cfg(feature = "std")]
-    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         *self = Self::read_xdr(r)?;
         Ok(())
     }
@@ -506,7 +511,7 @@ where
     /// All implementations should continue if the read implementation returns
     /// [`ErrorKind::Interrupted`](std::io::ErrorKind::Interrupted).
     #[cfg(feature = "std")]
-    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<()> {
+    fn read_xdr_into_to_end<R: Read>(&mut self, r: &mut Limited<R>) -> Result<(), Error> {
         Self::read_xdr_into(self, r)?;
         // Check that any further reads, such as this read of one byte, read no
         // data, indicating EOF. If a byte is read the data is invalid.
@@ -555,7 +560,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "std")]
-    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr(bytes: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
         let t = Self::read_xdr_to_end(&mut cursor)?;
         Ok(t)
@@ -566,7 +571,7 @@ where
     /// An error is returned if the bytes are not completely consumed by the
     /// deserialization.
     #[cfg(feature = "base64")]
-    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+    fn from_xdr_base64(b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
         let mut b64_reader = Cursor::new(b64);
         let mut dec = Limited::new(
             base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD),
@@ -579,10 +584,10 @@ where
 
 pub trait WriteXdr {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()>;
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error>;
 
     #[cfg(feature = "std")]
-    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>> {
+    fn to_xdr(&self, limits: Limits) -> Result<Vec<u8>, Error> {
         let mut cursor = Limited::new(Cursor::new(vec![]), limits);
         self.write_xdr(&mut cursor)?;
         let bytes = cursor.inner.into_inner();
@@ -590,7 +595,7 @@ pub trait WriteXdr {
     }
 
     #[cfg(feature = "base64")]
-    fn to_xdr_base64(&self, limits: Limits) -> Result<String> {
+    fn to_xdr_base64(&self, limits: Limits) -> Result<String, Error> {
         let mut enc = Limited::new(
             base64::write::EncoderStringWriter::new(base64::STANDARD),
             limits,
@@ -610,7 +615,7 @@ fn pad_len(len: usize) -> usize {
 
 impl ReadXdr for i32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -622,7 +627,7 @@ impl ReadXdr for i32 {
 
 impl WriteXdr for i32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -633,7 +638,7 @@ impl WriteXdr for i32 {
 
 impl ReadXdr for u32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 4];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -645,7 +650,7 @@ impl ReadXdr for u32 {
 
 impl WriteXdr for u32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 4] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -656,7 +661,7 @@ impl WriteXdr for u32 {
 
 impl ReadXdr for i64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -668,7 +673,7 @@ impl ReadXdr for i64 {
 
 impl WriteXdr for i64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -679,7 +684,7 @@ impl WriteXdr for i64 {
 
 impl ReadXdr for u64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         let mut b = [0u8; 8];
         r.with_limited_depth(|r| {
             r.consume_len(b.len())?;
@@ -691,7 +696,7 @@ impl ReadXdr for u64 {
 
 impl WriteXdr for u64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         let b: [u8; 8] = self.to_be_bytes();
         w.with_limited_depth(|w| {
             w.consume_len(b.len())?;
@@ -702,35 +707,35 @@ impl WriteXdr for u64 {
 
 impl ReadXdr for f32 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f32 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for f64 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         todo!()
     }
 }
 
 impl WriteXdr for f64 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         todo!()
     }
 }
 
 impl ReadXdr for bool {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             let b = i == 1;
@@ -741,7 +746,7 @@ impl ReadXdr for bool {
 
 impl WriteXdr for bool {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let i = u32::from(*self); // true = 1, false = 0
             i.write_xdr(w)
@@ -751,7 +756,7 @@ impl WriteXdr for bool {
 
 impl<T: ReadXdr> ReadXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = u32::read_xdr(r)?;
             match i {
@@ -768,7 +773,7 @@ impl<T: ReadXdr> ReadXdr for Option<T> {
 
 impl<T: WriteXdr> WriteXdr for Option<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             if let Some(t) = self {
                 1u32.write_xdr(w)?;
@@ -783,35 +788,35 @@ impl<T: WriteXdr> WriteXdr for Option<T> {
 
 impl<T: ReadXdr> ReadXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| Ok(Box::new(T::read_xdr(r)?)))
     }
 }
 
 impl<T: WriteXdr> WriteXdr for Box<T> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| T::write_xdr(self, w))
     }
 }
 
 impl ReadXdr for () {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(_r: &mut Limited<R>) -> Result<Self, Error> {
         Ok(())
     }
 }
 
 impl WriteXdr for () {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, _w: &mut Limited<W>) -> Result<(), Error> {
         Ok(())
     }
 }
 
 impl<const N: usize> ReadXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             r.consume_len(N)?;
             let padding = pad_len(N);
@@ -830,7 +835,7 @@ impl<const N: usize> ReadXdr for [u8; N] {
 
 impl<const N: usize> WriteXdr for [u8; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             w.consume_len(N)?;
             let padding = pad_len(N);
@@ -844,7 +849,7 @@ impl<const N: usize> WriteXdr for [u8; N] {
 
 impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let mut vec = Vec::with_capacity(N);
             for _ in 0..N {
@@ -859,7 +864,7 @@ impl<T: ReadXdr, const N: usize> ReadXdr for [T; N] {
 
 impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             for t in self {
                 t.write_xdr(w)?;
@@ -873,7 +878,7 @@ impl<T: WriteXdr, const N: usize> WriteXdr for [T; N] {
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde_with::serde_as, derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VecM<T, const MAX: u32 = { u32::MAX }>(Vec<T>);
 
@@ -924,6 +929,55 @@ impl<T: schemars::JsonSchema, const MAX: u32> schemars::JsonSchema for VecM<T, M
     }
 }
 
+#[cfg(feature = "schemars")]
+impl<T, TA, const MAX: u32> serde_with::schemars_0_8::JsonSchemaAs<VecM<T, MAX>> for VecM<TA, MAX>
+where
+    TA: serde_with::schemars_0_8::JsonSchemaAs<T>,
+{
+    fn schema_name() -> String {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <VecM<serde_with::Schema<T, TA>, MAX> as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, U, const MAX: u32> serde_with::SerializeAs<VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::SerializeAs<T>,
+{
+    fn serialize_as<S>(source: &VecM<T, MAX>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(source.iter().map(|item| serde_with::ser::SerializeAsWrap::<T, U>::new(item)))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, U, const MAX: u32> serde_with::DeserializeAs<'de, VecM<T, MAX>> for VecM<U, MAX>
+where
+    U: serde_with::DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<VecM<T, MAX>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
+        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+    }
+}
+
 impl<T, const MAX: u32> VecM<T, MAX> {
     pub const MAX_LEN: usize = { MAX as usize };
 
@@ -970,12 +1024,12 @@ impl<T: Clone, const MAX: u32> VecM<T, MAX> {
 
 impl<const MAX: u32> VecM<u8, MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1030,7 +1084,7 @@ impl<T> From<VecM<T, 1>> for Option<T> {
 impl<T, const MAX: u32> TryFrom<Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<T>) -> Result<Self> {
+    fn try_from(v: Vec<T>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1066,7 +1120,7 @@ impl<T, const MAX: u32> AsRef<Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<T>) -> Result<Self> {
+    fn try_from(v: &Vec<T>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1075,7 +1129,7 @@ impl<T: Clone, const MAX: u32> TryFrom<&Vec<T>> for VecM<T, MAX> {
 impl<T: Clone, const MAX: u32> TryFrom<&[T]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T]) -> Result<Self> {
+    fn try_from(v: &[T]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1102,7 +1156,7 @@ impl<T, const MAX: u32> AsRef<[T]> for VecM<T, MAX> {
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: [T; N]) -> Result<Self> {
+    fn try_from(v: [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1126,7 +1180,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<VecM<T, MAX>> for [T; N] 
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &[T; N]) -> Result<Self> {
+    fn try_from(v: &[T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.to_vec()))
@@ -1140,7 +1194,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&[T; N]> for VecM<T, MAX>
 impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM<T, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [T; N]) -> Result<Self> {
+    fn try_from(v: &'static [T; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v))
@@ -1154,7 +1208,7 @@ impl<T: Clone, const N: usize, const MAX: u32> TryFrom<&'static [T; N]> for VecM
 impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes().to_vec()))
@@ -1168,7 +1222,7 @@ impl<const MAX: u32> TryFrom<&String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1182,7 +1236,7 @@ impl<const MAX: u32> TryFrom<String> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1191,7 +1245,7 @@ impl<const MAX: u32> TryFrom<VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1200,7 +1254,7 @@ impl<const MAX: u32> TryFrom<&VecM<u8, MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.into()))
@@ -1214,7 +1268,7 @@ impl<const MAX: u32> TryFrom<&str> for VecM<u8, MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(VecM(v.as_bytes()))
@@ -1227,14 +1281,14 @@ impl<const MAX: u32> TryFrom<&'static str> for VecM<u8, MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a VecM<u8, MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self> {
+    fn try_from(v: &'a VecM<u8, MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1261,7 +1315,7 @@ impl<const MAX: u32> ReadXdr for VecM<u8, MAX> {
 
 impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1281,7 +1335,7 @@ impl<const MAX: u32> WriteXdr for VecM<u8, MAX> {
 
 impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len = u32::read_xdr(r)?;
             if len > MAX {
@@ -1301,7 +1355,7 @@ impl<T: ReadXdr, const MAX: u32> ReadXdr for VecM<T, MAX> {
 
 impl<T: WriteXdr, const MAX: u32> WriteXdr for VecM<T, MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1445,12 +1499,12 @@ impl<const MAX: u32> BytesM<MAX> {
 
 impl<const MAX: u32> BytesM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_string(&self) -> Result<String> {
+    pub fn to_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_string(self) -> Result<String> {
+    pub fn into_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1470,7 +1524,7 @@ impl<const MAX: u32> BytesM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1506,7 +1560,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1515,7 +1569,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1542,7 +1596,7 @@ impl<const MAX: u32> AsRef<[u8]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1566,7 +1620,7 @@ impl<const N: usize, const MAX: u32> TryFrom<BytesM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.to_vec()))
@@ -1580,7 +1634,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for BytesM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v))
@@ -1594,7 +1648,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes().to_vec()))
@@ -1608,7 +1662,7 @@ impl<const MAX: u32> TryFrom<&String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1622,7 +1676,7 @@ impl<const MAX: u32> TryFrom<String> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: BytesM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -1631,7 +1685,7 @@ impl<const MAX: u32> TryFrom<BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -1640,7 +1694,7 @@ impl<const MAX: u32> TryFrom<&BytesM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.into()))
@@ -1654,7 +1708,7 @@ impl<const MAX: u32> TryFrom<&str> for BytesM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(BytesM(v.as_bytes()))
@@ -1667,14 +1721,14 @@ impl<const MAX: u32> TryFrom<&'static str> for BytesM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a BytesM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a BytesM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a BytesM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -1701,7 +1755,7 @@ impl<const MAX: u32> ReadXdr for BytesM<MAX> {
 
 impl<const MAX: u32> WriteXdr for BytesM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -1848,12 +1902,12 @@ impl<const MAX: u32> StringM<MAX> {
 
 impl<const MAX: u32> StringM<MAX> {
     #[cfg(feature = "alloc")]
-    pub fn to_utf8_string(&self) -> Result<String> {
+    pub fn to_utf8_string(&self) -> Result<String, Error> {
         self.try_into()
     }
 
     #[cfg(feature = "alloc")]
-    pub fn into_utf8_string(self) -> Result<String> {
+    pub fn into_utf8_string(self) -> Result<String, Error> {
         self.try_into()
     }
 
@@ -1873,7 +1927,7 @@ impl<const MAX: u32> StringM<MAX> {
 impl<const MAX: u32> TryFrom<Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: Vec<u8>) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1909,7 +1963,7 @@ impl<const MAX: u32> AsRef<Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &Vec<u8>) -> Result<Self> {
+    fn try_from(v: &Vec<u8>) -> Result<Self, Error> {
         v.as_slice().try_into()
     }
 }
@@ -1918,7 +1972,7 @@ impl<const MAX: u32> TryFrom<&Vec<u8>> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&[u8]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8]) -> Result<Self> {
+    fn try_from(v: &[u8]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1945,7 +1999,7 @@ impl<const MAX: u32> AsRef<[u8]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: [u8; N]) -> Result<Self> {
+    fn try_from(v: [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1969,7 +2023,7 @@ impl<const N: usize, const MAX: u32> TryFrom<StringM<MAX>> for [u8; N] {
 impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &[u8; N]) -> Result<Self> {
+    fn try_from(v: &[u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.to_vec()))
@@ -1983,7 +2037,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&[u8; N]> for StringM<MAX> {
 impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static [u8; N]) -> Result<Self> {
+    fn try_from(v: &'static [u8; N]) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v))
@@ -1997,7 +2051,7 @@ impl<const N: usize, const MAX: u32> TryFrom<&'static [u8; N]> for StringM<MAX> 
 impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &String) -> Result<Self> {
+    fn try_from(v: &String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes().to_vec()))
@@ -2011,7 +2065,7 @@ impl<const MAX: u32> TryFrom<&String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: String) -> Result<Self> {
+    fn try_from(v: String) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2025,7 +2079,7 @@ impl<const MAX: u32> TryFrom<String> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: StringM<MAX>) -> Result<Self> {
+    fn try_from(v: StringM<MAX>) -> Result<Self, Error> {
         Ok(String::from_utf8(v.0)?)
     }
 }
@@ -2034,7 +2088,7 @@ impl<const MAX: u32> TryFrom<StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
     type Error = Error;
 
-    fn try_from(v: &StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?.to_owned())
     }
 }
@@ -2043,7 +2097,7 @@ impl<const MAX: u32> TryFrom<&StringM<MAX>> for String {
 impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &str) -> Result<Self> {
+    fn try_from(v: &str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.into()))
@@ -2057,7 +2111,7 @@ impl<const MAX: u32> TryFrom<&str> for StringM<MAX> {
 impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
     type Error = Error;
 
-    fn try_from(v: &'static str) -> Result<Self> {
+    fn try_from(v: &'static str) -> Result<Self, Error> {
         let len: u32 = v.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
         if len <= MAX {
             Ok(StringM(v.as_bytes()))
@@ -2070,14 +2124,14 @@ impl<const MAX: u32> TryFrom<&'static str> for StringM<MAX> {
 impl<'a, const MAX: u32> TryFrom<&'a StringM<MAX>> for &'a str {
     type Error = Error;
 
-    fn try_from(v: &'a StringM<MAX>) -> Result<Self> {
+    fn try_from(v: &'a StringM<MAX>) -> Result<Self, Error> {
         Ok(core::str::from_utf8(v.as_ref())?)
     }
 }
 
 impl<const MAX: u32> ReadXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let len: u32 = u32::read_xdr(r)?;
             if len > MAX {
@@ -2104,7 +2158,7 @@ impl<const MAX: u32> ReadXdr for StringM<MAX> {
 
 impl<const MAX: u32> WriteXdr for StringM<MAX> {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w| {
             let len: u32 = self.len().try_into().map_err(|_| Error::LengthExceedsMax)?;
             len.write_xdr(w)?;
@@ -2150,7 +2204,7 @@ where
     T: ReadXdr,
 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         // Read the frame header value that contains 1 flag-bit and a 33-bit length.
         //  - The 1 flag bit is 0 when there are more frames for the same record.
         //  - The 31-bit length is the length of the bytes within the frame that
@@ -2340,7 +2394,7 @@ mod test {
         a.write_xdr(&mut buf).unwrap();
 
         let mut dlr = Limited::new(Cursor::new(buf.inner.as_slice()), read_limits);
-        let res: Result<Option<Option<Option<u32>>>> = ReadXdr::read_xdr(&mut dlr);
+        let res: Result<Option<Option<Option<u32>>>, _> = ReadXdr::read_xdr(&mut dlr);
         match res {
             Err(Error::DepthLimitExceeded) => (),
             _ => panic!("expected DepthLimitExceeded got {res:?}"),
@@ -2874,7 +2928,7 @@ Self::Multi => "Multi",
         impl TryFrom<i32> for UnionKey {
             type Error = Error;
 
-            fn try_from(i: i32) -> Result<Self> {
+            fn try_from(i: i32) -> Result<Self, Error> {
                 let e = match i {
                     0 => UnionKey::Error,
 1 => UnionKey::Multi,
@@ -2894,7 +2948,7 @@ Self::Multi => "Multi",
 
         impl ReadXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let e = i32::read_xdr(r)?;
                     let v: Self = e.try_into()?;
@@ -2905,7 +2959,7 @@ Self::Multi => "Multi",
 
         impl WriteXdr for UnionKey {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     let i: i32 = (*self).into();
                     i.write_xdr(w)
@@ -2928,6 +2982,7 @@ Self::Multi => "Multi",
 /// ```
 ///
 // union with discriminant UnionKey
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
@@ -2938,7 +2993,7 @@ pub enum MyUnion {
     i32
   ),
   Multi(
-    VecM::<i32>
+    VecM<i32>
   ),
 }
 
@@ -2999,7 +3054,7 @@ Self::Multi(_) => UnionKey::Multi,
 
         impl ReadXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let dv: UnionKey = <UnionKey as ReadXdr>::read_xdr(r)?;
                     #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
@@ -3016,7 +3071,7 @@ UnionKey::Multi => Self::Multi(VecM::<i32>::read_xdr(r)?),
 
         impl WriteXdr for MyUnion {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     self.discriminant().write_xdr(w)?;
                     #[allow(clippy::match_same_arms)]
@@ -3043,9 +3098,10 @@ Self::Multi(v) => v.write_xdr(w)?,
 /// ```
 ///
 // union with discriminant i32
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[allow(clippy::large_enum_variant)]
 pub enum IntUnion {
@@ -3053,7 +3109,7 @@ pub enum IntUnion {
     i32
   ),
   V1(
-    VecM::<i32>
+    VecM<i32>
   ),
 }
 
@@ -3114,7 +3170,7 @@ Self::V1(_) => 1,
 
         impl ReadXdr for IntUnion {
             #[cfg(feature = "std")]
-            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+            fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
                 r.with_limited_depth(|r| {
                     let dv: i32 = <i32 as ReadXdr>::read_xdr(r)?;
                     #[allow(clippy::match_same_arms, clippy::match_wildcard_for_single_variants)]
@@ -3131,7 +3187,7 @@ Self::V1(_) => 1,
 
         impl WriteXdr for IntUnion {
             #[cfg(feature = "std")]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 w.with_limited_depth(|w| {
                     self.discriminant().write_xdr(w)?;
                     #[allow(clippy::match_same_arms)]
@@ -3150,9 +3206,10 @@ Self::V1(v) => v.write_xdr(w)?,
 /// typedef IntUnion IntUnion2;
 /// ```
 ///
+#[cfg_eval::cfg_eval]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), serde_with::serde_as, derive(serde::Serialize, serde::Deserialize), serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct IntUnion2(
@@ -3182,7 +3239,7 @@ impl AsRef<IntUnion> for IntUnion2 {
 
 impl ReadXdr for IntUnion2 {
     #[cfg(feature = "std")]
-    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self> {
+    fn read_xdr<R: Read>(r: &mut Limited<R>) -> Result<Self, Error> {
         r.with_limited_depth(|r| {
             let i = IntUnion::read_xdr(r)?;
             let v = IntUnion2(i);
@@ -3193,7 +3250,7 @@ impl ReadXdr for IntUnion2 {
 
 impl WriteXdr for IntUnion2 {
     #[cfg(feature = "std")]
-    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+    fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
         w.with_limited_depth(|w|{ self.0.write_xdr(w) })
     }
 }
@@ -3278,7 +3335,7 @@ Self::IntUnion2 => gen.into_root_schema_for::<IntUnion2>(),
         impl core::str::FromStr for TypeVariant {
             type Err = Error;
             #[allow(clippy::too_many_lines)]
-            fn from_str(s: &str) -> Result<Self> {
+            fn from_str(s: &str) -> Result<Self, Error> {
                 match s {
                     "SError" => Ok(Self::SError),
 "Multi" => Ok(Self::Multi),
@@ -3324,7 +3381,7 @@ TypeVariant::IntUnion2, ];
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::SError => r.with_limited_depth(|r| Ok(Self::SError(Box::new(SError::read_xdr(r)?)))),
 TypeVariant::Multi => r.with_limited_depth(|r| Ok(Self::Multi(Box::new(Multi::read_xdr(r)?)))),
@@ -3336,14 +3393,14 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr(v, &mut dec)?;
                 Ok(t)
             }
 
             #[cfg(feature = "std")]
-            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let s = Self::read_xdr(v, r)?;
                 // Check that any further reads, such as this read of one byte, read no
                 // data, indicating EOF. If a byte is read the data is invalid.
@@ -3355,7 +3412,7 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
             }
 
             #[cfg(feature = "base64")]
-            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self> {
+            pub fn read_xdr_base64_to_end<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Result<Self, Error> {
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD), r.limits.clone());
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
                 Ok(t)
@@ -3363,7 +3420,7 @@ TypeVariant::IntUnion2 => r.with_limited_depth(|r| Ok(Self::IntUnion2(Box::new(I
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::SError(Box::new(t))))),
 TypeVariant::Multi => Box::new(ReadXdrIter::<_, Multi>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Multi(Box::new(t))))),
@@ -3376,7 +3433,7 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(&mut r.inner
 
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_framed_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 match v {
                     TypeVariant::SError => Box::new(ReadXdrIter::<_, Frame<SError>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::SError(Box::new(t.0))))),
 TypeVariant::Multi => Box::new(ReadXdrIter::<_, Frame<Multi>>::new(&mut r.inner, r.limits.clone()).map(|r| r.map(|t| Self::Multi(Box::new(t.0))))),
@@ -3389,7 +3446,7 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, Frame<IntUnion2>>::new(&mut 
 
             #[cfg(feature = "base64")]
             #[allow(clippy::too_many_lines)]
-            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self>> + '_> {
+            pub fn read_xdr_base64_iter<R: Read>(v: TypeVariant, r: &mut Limited<R>) -> Box<dyn Iterator<Item=Result<Self, Error>> + '_> {
                 let dec = base64::read::DecoderReader::new(&mut r.inner, base64::STANDARD);
                 match v {
                     TypeVariant::SError => Box::new(ReadXdrIter::<_, SError>::new(dec, r.limits.clone()).map(|r| r.map(|t| Self::SError(Box::new(t))))),
@@ -3402,14 +3459,14 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.limit
             }
 
             #[cfg(feature = "std")]
-            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self> {
+            pub fn from_xdr<B: AsRef<[u8]>>(v: TypeVariant, bytes: B, limits: Limits) -> Result<Self, Error> {
                 let mut cursor = Limited::new(Cursor::new(bytes.as_ref()), limits);
                 let t = Self::read_xdr_to_end(v, &mut cursor)?;
                 Ok(t)
             }
 
             #[cfg(feature = "base64")]
-            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self> {
+            pub fn from_xdr_base64(v: TypeVariant, b64: impl AsRef<[u8]>, limits: Limits) -> Result<Self, Error> {
                 let mut b64_reader = Cursor::new(b64);
                 let mut dec = Limited::new(base64::read::DecoderReader::new(&mut b64_reader, base64::STANDARD), limits);
                 let t = Self::read_xdr_to_end(v, &mut dec)?;
@@ -3418,13 +3475,13 @@ TypeVariant::IntUnion2 => Box::new(ReadXdrIter::<_, IntUnion2>::new(dec, r.limit
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[deprecated(note = "use from_json")]
-            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn read_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 Self::from_json(v, r)
             }
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self> {
+            pub fn from_json(v: TypeVariant, r: impl Read) -> Result<Self, Error> {
                 match v {
                     TypeVariant::SError => Ok(Self::SError(Box::new(serde_json::from_reader(r)?))),
 TypeVariant::Multi => Ok(Self::Multi(Box::new(serde_json::from_reader(r)?))),
@@ -3437,7 +3494,7 @@ TypeVariant::IntUnion2 => Ok(Self::IntUnion2(Box::new(serde_json::from_reader(r)
 
             #[cfg(all(feature = "std", feature = "serde_json"))]
             #[allow(clippy::too_many_lines)]
-            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self> {
+            pub fn deserialize_json<'r, R: serde_json::de::Read<'r>>(v: TypeVariant, r: &mut serde_json::de::Deserializer<R>) -> Result<Self, Error> {
                 match v {
                     TypeVariant::SError => Ok(Self::SError(Box::new(serde::de::Deserialize::deserialize(r)?))),
 TypeVariant::Multi => Ok(Self::Multi(Box::new(serde::de::Deserialize::deserialize(r)?))),
@@ -3512,7 +3569,7 @@ Self::IntUnion2(_) => TypeVariant::IntUnion2,
         impl WriteXdr for Type {
             #[cfg(feature = "std")]
             #[allow(clippy::too_many_lines)]
-            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<()> {
+            fn write_xdr<W: Write>(&self, w: &mut Limited<W>) -> Result<(), Error> {
                 match self {
                     Self::SError(v) => v.write_xdr(w),
 Self::Multi(v) => v.write_xdr(w),

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -971,7 +971,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let vec = <Vec<U> as serde_with::DeserializeAs<Vec<T>>>::deserialize_as(deserializer)?;
-        Ok(vec.try_into().map_err(|e| serde::de::Error::custom(e))?)
+        Ok(vec.try_into().map_err(serde::de::Error::custom)?)
     }
 }
 
@@ -2242,7 +2242,7 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         D: serde::Deserializer<'de>,
     {
         struct Vis;
-        impl<'de> serde::de::Visitor<'de> for Vis {
+        impl serde::de::Visitor<'_> for Vis {
             type Value = i64;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -2250,27 +2250,27 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
@@ -2278,15 +2278,23 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)
@@ -2308,43 +2316,51 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
             }
 
             fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                Ok(v.into())
             }
 
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+                v.try_into().map_err(serde::de::Error::custom)
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
                 Ok(v)
             }
 
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
+                v.try_into().map_err(serde::de::Error::custom)
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+                v.parse().map_err(serde::de::Error::custom)
             }
         }
         deserializer.deserialize_any(Vis)

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -2373,8 +2373,7 @@ impl serde_with::SerializeAs<i64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 
@@ -2384,8 +2383,7 @@ impl serde_with::SerializeAs<u64> for NumberOrString {
     where
         S: serde::Serializer,
     {
-        use serde::Serialize;
-        source.to_string().serialize(serializer)
+        serializer.collect_str(source)
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -2241,63 +2241,17 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = i64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum I64OrString<'a> {
+            String(&'a str),
+            I64(i64),
         }
-        deserializer.deserialize_any(Vis)
+        match I64OrString::deserialize(deserializer)? {
+            I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            I64OrString::I64(v) => Ok(v),
+        }
     }
 }
 
@@ -2307,63 +2261,17 @@ impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
     where
         D: serde::Deserializer<'de>,
     {
-        struct Vis;
-        impl serde::de::Visitor<'_> for Vis {
-            type Value = u64;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                formatter.write_str("a number or number string")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v.into())
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
-                Ok(v)
-            }
-
-            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.try_into().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
-                v.parse().map_err(serde::de::Error::custom)
-            }
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum U64OrString<'a> {
+            String(&'a str),
+            U64(u64),
         }
-        deserializer.deserialize_any(Vis)
+        match U64OrString::deserialize(deserializer)? {
+            U64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            U64OrString::U64(v) => Ok(v),
+        }
     }
 }
 
@@ -3123,7 +3031,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: 0 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_number_max() {
         let json = format!(r#"{{"val": {}}}"#, i64::MAX);
@@ -3151,7 +3059,7 @@ mod tests_for_number_or_string {
         let expected = TestI64 { val: -101 };
         assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_i64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3205,7 +3113,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "123 "}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_both_whitespace() {
         let json = r#"{"val": " 123 "}"#;
@@ -3217,7 +3125,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "++123"}"#;
         assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
         let json = r#"{"val": "--123"}"#;
@@ -3254,7 +3162,7 @@ mod tests_for_number_or_string {
         let json = format!(r#"{{"val": "{overflow_val}"}}"#);
         assert!(serde_json::from_str::<TestI64>(&json).is_err());
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_underflow() {
         let underflow_val = i128::from(i64::MIN) - 1;
@@ -3265,71 +3173,81 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_i64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     #[test]
     fn deserialize_i64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
     }
 
     // -- Additional i64 String Format Tests --
     #[test]
     fn deserialize_i64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        // std::primitive::i64.from_str() does not support "0x"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0x"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Hex string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        // std::primitive::i64.from_str() does not support "0o"
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+                                         // std::primitive::i64.from_str() does not support "0o"
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Octal string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#; // "1000" in scientific
-        // std::primitive::i64.from_str() does not support scientific notation
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+                                        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Scientific notation string should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_invalid_scientific_notation_string() {
         let json = r#"{"val": "1e"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Invalid scientific notation string should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
         // std::primitive::i64.from_str() does not support underscores
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with underscores should fail parsing to i64"
+        );
     }
 
     #[test]
@@ -3337,34 +3255,51 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "000123"}"#;
         let expected = TestI64 { val: 123 };
         // std::primitive::i64.from_str() supports leading zeros
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse"
+        );
     }
 
     #[test]
     fn deserialize_i64_from_string_with_leading_zeros_negative() {
         let json = r#"{"val": "-000123"}"#;
         let expected = TestI64 { val: -123 };
-        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+        assert_eq!(
+            serde_json::from_str::<TestI64>(json).unwrap(),
+            expected,
+            "Negative string with leading zeros should parse"
+        );
     }
-    
+
     #[test]
     fn deserialize_i64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
         // std::primitive::i64.from_str() does not support decimals
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with decimal part should fail parsing to i64"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_string_with_internal_decimal() {
         let json = r#"{"val": "12.345"}"#;
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "String with internal decimal point should fail"
+        );
     }
 
     #[test]
     fn deserialize_i64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
         // std::primitive::i64.from_str() does not support commas
-        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+        assert!(
+            serde_json::from_str::<TestI64>(json).is_err(),
+            "Localized string with commas should fail parsing to i64"
+        );
     }
 
     // --- u64 Deserialization Tests ---
@@ -3374,7 +3309,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 123 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_number_zero() {
         let json = r#"{"val": 0}"#;
@@ -3395,7 +3330,7 @@ mod tests_for_number_or_string {
         let expected = TestU64 { val: 789 };
         assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_u64_from_json_string_zero() {
         let json = r#"{"val": "0"}"#;
@@ -3451,13 +3386,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_number_negative() {
         let json = r#"{"val": -1}"#; // Negative not allowed for u64
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_u64_error_from_string_not_a_number() {
         let json = r#"{"val": "abc"}"#;
@@ -3486,80 +3417,97 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_u64_error_from_json_float_number() {
         let json = r#"{"val": 123.45}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: floating point"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_bool_true() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_array() {
         let json = r#"{"val": []}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: sequence"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_object() {
         let json = r#"{"val": {}}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: map"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     #[test]
     fn deserialize_u64_error_from_json_null() {
         let json = r#"{"val": null}"#;
-        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: null"));
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
     }
 
     // -- Additional u64 String Format Tests --
     #[test]
     fn deserialize_u64_error_from_hex_string() {
         let json = r#"{"val": "0x1A"}"#; // Hex "26"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Hex string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_octal_string() {
         let json = r#"{"val": "0o77"}"#; // Octal "63"
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Octal string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_scientific_notation_string() {
         let json = r#"{"val": "1e3"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Scientific notation string should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_underscores() {
         let json = r#"{"val": "1_000_000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with underscores should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_from_string_with_leading_zeros() {
         let json = r#"{"val": "000123"}"#;
         let expected = TestU64 { val: 123 };
-        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+        assert_eq!(
+            serde_json::from_str::<TestU64>(json).unwrap(),
+            expected,
+            "String with leading zeros should parse to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_string_with_decimal_zeros() {
         let json = r#"{"val": "123.000"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "String with decimal part should fail parsing to u64"
+        );
     }
 
     #[test]
     fn deserialize_u64_error_from_localized_string_commas() {
         let json = r#"{"val": "1,234"}"#;
-        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+        assert!(
+            serde_json::from_str::<TestU64>(json).is_err(),
+            "Localized string with commas should fail parsing to u64"
+        );
     }
 
     // --- i64 Serialization Tests ---
@@ -3583,7 +3531,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_i64_max() {
         let data = TestI64 { val: i64::MAX };
@@ -3597,7 +3545,6 @@ mod tests_for_number_or_string {
         let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-
 
     // --- u64 Serialization Tests ---
     #[test]
@@ -3613,7 +3560,7 @@ mod tests_for_number_or_string {
         let expected_json = r#"{"val":"0"}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
-    
+
     #[test]
     fn serialize_u64_max() {
         let data = TestU64 { val: u64::MAX };
@@ -3626,21 +3573,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_i64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionI64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionI64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_i64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionI64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionI64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3652,10 +3608,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_option_i64_error_from_invalid_type() {
         let json = r#"{"val": true}"#;
-        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
     }
-    
+
     #[test]
     fn serialize_option_i64_some() {
         let data = TestOptionI64 { val: Some(123) };
@@ -3675,21 +3630,30 @@ mod tests_for_number_or_string {
     fn deserialize_option_u64_some_from_json_number() {
         let json = r#"{"val": 123}"#;
         let expected = TestOptionU64 { val: Some(123) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_some_from_json_string() {
         let json = r#"{"val": "456"}"#;
         let expected = TestOptionU64 { val: Some(456) };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
     fn deserialize_option_u64_none_from_json_null() {
         let json = r#"{"val": null}"#;
         let expected = TestOptionU64 { val: None };
-        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<TestOptionU64>(json).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -3697,7 +3661,7 @@ mod tests_for_number_or_string {
         let json = r#"{"val": "abc"}"#;
         assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
     }
-    
+
     #[test]
     fn deserialize_option_u64_error_from_negative_string() {
         let json = r#"{"val": "-1"}"#; // Invalid for u64
@@ -3729,7 +3693,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", -3, "-4"]}"#;
-        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        let expected = TestVecI64 {
+            val: vec![1, 2, -3, -4],
+        };
         assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
     }
 
@@ -3744,8 +3710,7 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_i64_error_if_item_is_invalid_type() {
         let json = r#"{"val": [1, true, 3]}"#;
-        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
-        assert!(err.to_string().contains("invalid type: boolean `true`"));
+        assert!(serde_json::from_str::<TestVecI64>(json).is_err());
     }
 
     #[test]
@@ -3757,7 +3722,9 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_vec_i64_with_values() {
-        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let data = TestVecI64 {
+            val: vec![1, -2, 0],
+        };
         let expected_json = r#"{"val":["1","-2","0"]}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
@@ -3773,7 +3740,9 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_vec_u64_from_numbers_and_strings() {
         let json = r#"{"val": [1, "2", 3, "4"]}"#;
-        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        let expected = TestVecU64 {
+            val: vec![1, 2, 3, 4],
+        };
         assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
     }
 
@@ -3790,15 +3759,11 @@ mod tests_for_number_or_string {
         let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
         assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
     }
-    
+
     #[test]
     fn deserialize_vec_u64_error_if_item_is_negative_number() {
         let json = r#"{"val": [1, -2, 3]}"#;
-        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
-        // Check for TryFrom conversion error, the exact message may vary by serde version
-        assert!(err.to_string().contains("out of range") || 
-                err.to_string().contains("negative integer") ||
-                err.to_string().contains("invalid value")); // try_into error
+        assert!(serde_json::from_str::<TestVecU64>(json).is_err());
     }
 
     #[test]
@@ -3819,14 +3784,20 @@ mod tests_for_number_or_string {
     #[test]
     fn deserialize_enum_variant_a_with_number() {
         let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
-        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_enum_variant_a_with_string_number() {
         let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
-        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        let expected = TestEnum::VariantA {
+            num_val: -45,
+            other_data: "data".to_string(),
+        };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
 
@@ -3843,7 +3814,7 @@ mod tests_for_number_or_string {
         let expected = TestEnum::VariantB { count: 1234567890 };
         assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
     }
-    
+
     #[test]
     fn deserialize_enum_variant_a_error_invalid_num_string() {
         let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
@@ -3852,7 +3823,10 @@ mod tests_for_number_or_string {
 
     #[test]
     fn serialize_enum_variant_a() {
-        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        let data = TestEnum::VariantA {
+            num_val: 123,
+            other_data: "test".to_string(),
+        };
         // Note: num_val will be serialized as a string by NumberOrString
         let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
         assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -43,9 +43,6 @@ use std::string::FromUtf8Error;
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
-#[cfg(feature = "serde")]
-use serde_with::DisplayFromStr;
-
 #[cfg(all(feature = "schemars", feature = "alloc", feature = "std"))]
 use std::borrow::Cow;
 #[cfg(all(feature = "schemars", feature = "alloc", not(feature = "std")))]
@@ -2223,6 +2220,180 @@ where
     }
 }
 
+// NumberOrString ---------------------------------------------------------------
+
+/// NumberOrString is a serde_as serializer/deserializer.
+///
+/// It deserializers any integer that fits into a 64-bit value into an i64 or u64 field from either
+/// a JSON Number or JSON String value.
+///
+/// It serializes always to a string.
+///
+/// It has a JsonSchema implementation that only advertises that the allowed format is a String.
+/// This is because the type is intended to soften the changing of fields from JSON Number to JSON
+/// String by permitting deserialization, but discourage new uses of JSON Number.
+#[cfg(feature = "serde")]
+struct NumberOrString;
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<i64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = i64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde_with::DeserializeAs<'de, u64> for NumberOrString {
+    fn deserialize_as<D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a number or number string")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.try_into().map_err(|e|serde::de::Error::custom(e))?)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                Ok(v.parse().map_err(|e| serde::de::Error::custom(e))?)
+            }
+        }
+        deserializer.deserialize_any(Vis)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<i64> for NumberOrString {
+    fn serialize_as<S>(source: &i64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde_with::SerializeAs<u64> for NumberOrString {
+    fn serialize_as<S>(source: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::Serialize;
+        source.to_string().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for NumberOrString {
+    fn schema_name() -> String {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <String as schemars::JsonSchema>::is_referenceable()
+    }
+}
+
+// Tests ------------------------------------------------------------------------
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use std::io::Cursor;
@@ -2845,6 +3016,839 @@ mod test {
     fn to_option_some() {
         let v: VecM<_, 1> = (&[1]).try_into().unwrap();
         assert_eq!(v.to_option(), Some(1));
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests_for_number_or_string {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use serde_with::serde_as;
+
+    // --- Helper Structs ---
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestI64 {
+        #[serde_as(as = "NumberOrString")]
+        val: i64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestU64 {
+        #[serde_as(as = "NumberOrString")]
+        val: u64,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionI64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestOptionU64 {
+        #[serde_as(as = "Option<NumberOrString>")]
+        val: Option<u64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecI64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<i64>,
+    }
+
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct TestVecU64 {
+        #[serde_as(as = "Vec<NumberOrString>")]
+        val: Vec<u64>,
+    }
+
+    // Helper Enum for testing field access within variants
+    #[serde_as]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")] // Added to make JSON keys distinct for variants
+    enum TestEnum {
+        VariantA {
+            #[serde(rename = "numVal")]
+            #[serde_as(as = "NumberOrString")]
+            num_val: i64,
+            #[serde(rename = "otherData")]
+            other_data: String,
+        },
+        VariantB {
+            #[serde_as(as = "NumberOrString")]
+            count: u64,
+        },
+        SimpleVariant,
+    }
+
+    // --- i64 Deserialization Tests ---
+    #[test]
+    fn deserialize_i64_from_json_number_positive() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_negative() {
+        let json = r#"{"val": -456}"#;
+        let expected = TestI64 { val: -456 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_number_min() {
+        let json = format!(r#"{{"val": {}}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_positive() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestI64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_negative() {
+        let json = r#"{"val": "-101"}"#;
+        let expected = TestI64 { val: -101 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_i64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MAX);
+        let expected = TestI64 { val: i64::MAX };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_min() {
+        let json = format!(r#"{{"val": "{}"}}"#, i64::MIN);
+        let expected = TestI64 { val: i64::MIN };
+        assert_eq!(serde_json::from_str::<TestI64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestI64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_from_json_string_with_minus_zero() {
+        let json = r#"{"val": "-0"}"#;
+        let expected = TestI64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_both_whitespace() {
+        let json = r#"{"val": " 123 "}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_minus_prefix() {
+        let json = r#"{"val": "--123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_string_with_invalid_mixed_prefix() {
+        let json = r#"{"val": "+-123"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#; // Not an integer
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_overflow() {
+        let overflow_val = (i64::MAX as i128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_underflow() {
+        let underflow_val = (i64::MIN as i128) - 1;
+        let json = format!(r#"{{"val": "{}"}}"#, underflow_val);
+        assert!(serde_json::from_str::<TestI64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional i64 String Format Tests --
+    #[test]
+    fn deserialize_i64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        // std::primitive::i64.from_str() does not support "0x"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Hex string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        // std::primitive::i64.from_str() does not support "0o"
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Octal string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#; // "1000" in scientific
+        // std::primitive::i64.from_str() does not support scientific notation
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Scientific notation string should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_invalid_scientific_notation_string() {
+        let json = r#"{"val": "1e"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Invalid scientific notation string should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        // std::primitive::i64.from_str() does not support underscores
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with underscores should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestI64 { val: 123 };
+        // std::primitive::i64.from_str() supports leading zeros
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "String with leading zeros should parse");
+    }
+
+    #[test]
+    fn deserialize_i64_from_string_with_leading_zeros_negative() {
+        let json = r#"{"val": "-000123"}"#;
+        let expected = TestI64 { val: -123 };
+        assert_eq!(serde_json::from_str::<TestI64>(json).unwrap(), expected, "Negative string with leading zeros should parse");
+    }
+    
+    #[test]
+    fn deserialize_i64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        // std::primitive::i64.from_str() does not support decimals
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with decimal part should fail parsing to i64");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_string_with_internal_decimal() {
+        let json = r#"{"val": "12.345"}"#;
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "String with internal decimal point should fail");
+    }
+
+    #[test]
+    fn deserialize_i64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        // std::primitive::i64.from_str() does not support commas
+        assert!(serde_json::from_str::<TestI64>(json).is_err(), "Localized string with commas should fail parsing to i64");
+    }
+
+    // --- u64 Deserialization Tests ---
+    #[test]
+    fn deserialize_u64_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_number_zero() {
+        let json = r#"{"val": 0}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_number_max() {
+        let json = format!(r#"{{"val": {}}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string() {
+        let json = r#"{"val": "789"}"#;
+        let expected = TestU64 { val: 789 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_u64_from_json_string_zero() {
+        let json = r#"{"val": "0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_max() {
+        let json = format!(r#"{{"val": "{}"}}"#, u64::MAX);
+        let expected = TestU64 { val: u64::MAX };
+        assert_eq!(serde_json::from_str::<TestU64>(&json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_prefix() {
+        let json = r#"{"val": "+123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_from_json_string_with_plus_zero() {
+        let json = r#"{"val": "+0"}"#;
+        let expected = TestU64 { val: 0 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_leading_whitespace() {
+        let json = r#"{"val": " 123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_trailing_whitespace() {
+        let json = r#"{"val": "123 "}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_string_with_invalid_plus_prefix() {
+        let json = r#"{"val": "++123"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_negative() {
+        let json = r#"{"val": "-123"}"#; // Negative not allowed for u64 string parse
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_number_negative() {
+        let json = r#"{"val": -1}"#; // Negative not allowed for u64
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value"));
+    }
+    
+    #[test]
+    fn deserialize_u64_error_from_string_not_a_number() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_float() {
+        let json = r#"{"val": "123.45"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_empty() {
+        let json = r#"{"val": ""}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_overflow() {
+        let overflow_val = (u64::MAX as u128) + 1;
+        let json = format!(r#"{{"val": "{}"}}"#, overflow_val);
+        assert!(serde_json::from_str::<TestU64>(&json).is_err());
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_float_number() {
+        let json = r#"{"val": 123.45}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: floating point"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_bool_true() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_array() {
+        let json = r#"{"val": []}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: sequence"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_object() {
+        let json = r#"{"val": {}}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: map"));
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let err = serde_json::from_str::<TestU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: null"));
+    }
+
+    // -- Additional u64 String Format Tests --
+    #[test]
+    fn deserialize_u64_error_from_hex_string() {
+        let json = r#"{"val": "0x1A"}"#; // Hex "26"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Hex string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_octal_string() {
+        let json = r#"{"val": "0o77"}"#; // Octal "63"
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Octal string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_scientific_notation_string() {
+        let json = r#"{"val": "1e3"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Scientific notation string should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_underscores() {
+        let json = r#"{"val": "1_000_000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with underscores should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_from_string_with_leading_zeros() {
+        let json = r#"{"val": "000123"}"#;
+        let expected = TestU64 { val: 123 };
+        assert_eq!(serde_json::from_str::<TestU64>(json).unwrap(), expected, "String with leading zeros should parse to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_string_with_decimal_zeros() {
+        let json = r#"{"val": "123.000"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "String with decimal part should fail parsing to u64");
+    }
+
+    #[test]
+    fn deserialize_u64_error_from_localized_string_commas() {
+        let json = r#"{"val": "1,234"}"#;
+        assert!(serde_json::from_str::<TestU64>(json).is_err(), "Localized string with commas should fail parsing to u64");
+    }
+
+    // --- i64 Serialization Tests ---
+    #[test]
+    fn serialize_i64_positive() {
+        let data = TestI64 { val: 123 };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_negative() {
+        let data = TestI64 { val: -456 };
+        let expected_json = r#"{"val":"-456"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_zero() {
+        let data = TestI64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_i64_max() {
+        let data = TestI64 { val: i64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_i64_min() {
+        let data = TestI64 { val: i64::MIN };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, i64::MIN);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+
+    // --- u64 Serialization Tests ---
+    #[test]
+    fn serialize_u64_positive() {
+        let data = TestU64 { val: 789 };
+        let expected_json = r#"{"val":"789"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_u64_zero() {
+        let data = TestU64 { val: 0 };
+        let expected_json = r#"{"val":"0"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+    
+    #[test]
+    fn serialize_u64_max() {
+        let data = TestU64 { val: u64::MAX };
+        let expected_json = format!(r#"{{"val":"{}"}}"#, u64::MAX);
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<i64> Tests ---
+    #[test]
+    fn deserialize_option_i64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionI64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionI64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionI64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionI64>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_option_i64_error_from_invalid_type() {
+        let json = r#"{"val": true}"#;
+        let err = serde_json::from_str::<TestOptionI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+    
+    #[test]
+    fn serialize_option_i64_some() {
+        let data = TestOptionI64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_i64_none() {
+        let data = TestOptionI64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Option<u64> Tests ---
+    #[test]
+    fn deserialize_option_u64_some_from_json_number() {
+        let json = r#"{"val": 123}"#;
+        let expected = TestOptionU64 { val: Some(123) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_some_from_json_string() {
+        let json = r#"{"val": "456"}"#;
+        let expected = TestOptionU64 { val: Some(456) };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_none_from_json_null() {
+        let json = r#"{"val": null}"#;
+        let expected = TestOptionU64 { val: None };
+        assert_eq!(serde_json::from_str::<TestOptionU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_option_u64_error_from_invalid_string() {
+        let json = r#"{"val": "abc"}"#;
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+    
+    #[test]
+    fn deserialize_option_u64_error_from_negative_string() {
+        let json = r#"{"val": "-1"}"#; // Invalid for u64
+        assert!(serde_json::from_str::<TestOptionU64>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_option_u64_some() {
+        let data = TestOptionU64 { val: Some(123) };
+        let expected_json = r#"{"val":"123"}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_option_u64_none() {
+        let data = TestOptionU64 { val: None };
+        let expected_json = r#"{"val":null}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<i64> Tests ---
+    #[test]
+    fn deserialize_vec_i64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecI64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", -3, "-4"]}"#;
+        let expected = TestVecI64 { val: vec![1, 2, -3, -4] };
+        assert_eq!(serde_json::from_str::<TestVecI64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        // The error will point to the specific failing element
+        assert!(err.to_string().contains("invalid digit found in string")); // From parse error
+    }
+
+    #[test]
+    fn deserialize_vec_i64_error_if_item_is_invalid_type() {
+        let json = r#"{"val": [1, true, 3]}"#;
+        let err = serde_json::from_str::<TestVecI64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid type: boolean `true`"));
+    }
+
+    #[test]
+    fn serialize_vec_i64_empty() {
+        let data = TestVecI64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_i64_with_values() {
+        let data = TestVecI64 { val: vec![1, -2, 0] };
+        let expected_json = r#"{"val":["1","-2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Vec<u64> Tests ---
+    #[test]
+    fn deserialize_vec_u64_empty() {
+        let json = r#"{"val": []}"#;
+        let expected = TestVecU64 { val: vec![] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_from_numbers_and_strings() {
+        let json = r#"{"val": [1, "2", 3, "4"]}"#;
+        let expected = TestVecU64 { val: vec![1, 2, 3, 4] };
+        assert_eq!(serde_json::from_str::<TestVecU64>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_invalid_string() {
+        let json = r#"{"val": [1, "abc", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string"));
+    }
+
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_string() {
+        let json = r#"{"val": [1, "-2", 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        assert!(err.to_string().contains("invalid digit found in string")); // u64 parse error
+    }
+    
+    #[test]
+    fn deserialize_vec_u64_error_if_item_is_negative_number() {
+        let json = r#"{"val": [1, -2, 3]}"#;
+        let err = serde_json::from_str::<TestVecU64>(json).unwrap_err();
+        // Check for TryFrom conversion error, the exact message may vary by serde version
+        assert!(err.to_string().contains("out of range") || 
+                err.to_string().contains("negative integer") ||
+                err.to_string().contains("invalid value")); // try_into error
+    }
+
+    #[test]
+    fn serialize_vec_u64_empty() {
+        let data = TestVecU64 { val: vec![] };
+        let expected_json = r#"{"val":[]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_vec_u64_with_values() {
+        let data = TestVecU64 { val: vec![1, 2, 0] };
+        let expected_json = r#"{"val":["1","2","0"]}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    // --- Enum with NumberOrString field Tests ---
+    #[test]
+    fn deserialize_enum_variant_a_with_number() {
+        let json = r#"{"variantA": {"numVal": 123, "otherData": "test"}}"#;
+        let expected = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_a_with_string_number() {
+        let json = r#"{"variantA": {"numVal": "-45", "otherData": "data"}}"#;
+        let expected = TestEnum::VariantA { num_val: -45, other_data: "data".to_string() };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_number() {
+        let json = r#"{"variantB": {"count": 7890}}"#;
+        let expected = TestEnum::VariantB { count: 7890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+
+    #[test]
+    fn deserialize_enum_variant_b_with_string_number() {
+        let json = r#"{"variantB": {"count": "1234567890"}}"#;
+        let expected = TestEnum::VariantB { count: 1234567890 };
+        assert_eq!(serde_json::from_str::<TestEnum>(json).unwrap(), expected);
+    }
+    
+    #[test]
+    fn deserialize_enum_variant_a_error_invalid_num_string() {
+        let json = r#"{"variantA": {"numVal": "abc", "otherData": "test"}}"#;
+        assert!(serde_json::from_str::<TestEnum>(json).is_err());
+    }
+
+    #[test]
+    fn serialize_enum_variant_a() {
+        let data = TestEnum::VariantA { num_val: 123, other_data: "test".to_string() };
+        // Note: num_val will be serialized as a string by NumberOrString
+        let expected_json = r#"{"variantA":{"numVal":"123","otherData":"test"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
+    }
+
+    #[test]
+    fn serialize_enum_variant_b() {
+        let data = TestEnum::VariantB { count: 7890 };
+        let expected_json = r#"{"variantB":{"count":"7890"}}"#;
+        assert_eq!(serde_json::to_string(&data).unwrap(), expected_json);
     }
 }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -3050,11 +3050,9 @@ Self::Multi(v) => v.write_xdr(w)?,
 #[allow(clippy::large_enum_variant)]
 pub enum IntUnion {
   V0(
-    
     i32
   ),
   V1(
-    
     VecM::<i32>
   ),
 }
@@ -3158,7 +3156,6 @@ Self::V1(v) => v.write_xdr(w)?,
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug)]
 pub struct IntUnion2(
-  
   pub IntUnion
 );
 


### PR DESCRIPTION
### What
Add handling for 64-bit integers in XDR structures to ensure they are serialized as strings in JSON. Adds the handling in the cases of struct fields, union (enum) fields, and typedef (unamed struct) fields.

### Why
JavaScript has limited precision for integers larger than 53 bits, requiring large integers to be represented as strings to prevent data loss. Today those integers are rendered as numbers which requires that folks use non-native JSON parsers in JavaScript runtimes.

Close #181