### PR TITLE
Allow custom str deser impl fallback to their structure in JSON

### DIFF
--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -431,7 +431,7 @@ module Xdrgen
             }
         }
 
-        impl<'de> Deserialize<'de> for #{name struct} {
+        impl<'de> serde::Deserialize<'de> for #{name struct} {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: serde::Deserializer<'de> {
                 use serde::Deserialize;
                 #[derive(Deserialize)]

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -448,7 +448,7 @@ module Xdrgen
                     String(&'a str),
                     #{name struct}(#{name struct}),
                 }
-                match #{name struct}OrString::deserialize(deserializer) {
+                match #{name struct}OrString::deserialize(deserializer)? {
                     #{name struct}OrString::String(s) => s.parse(),
                     #{name struct}OrString::#{name struct}(#{name struct} {
                         #{struct.members.map do |m| "#{field_name(m)}," end.join(" ")}

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -457,6 +457,7 @@ module Xdrgen
                 }
             }
         }
+        EOS
         out.break
       end
 

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -448,7 +448,7 @@ module Xdrgen
                     String(&'a str),
                     #{name struct}(#{name struct}),
                 }
-                match #{name struct}OrString::deserialize(deserializer).map_err(|_| Error::Invalid)? {
+                match #{name struct}OrString::deserialize(deserializer) {
                     #{name struct}OrString::String(s) => s.parse(),
                     #{name struct}OrString::#{name struct}(#{name struct} {
                         #{struct.members.map do |m| "#{field_name(m)}," end.join(" ")}

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -448,7 +448,7 @@ module Xdrgen
                     String(&'a str),
                     #{name struct}(#{name struct}),
                 }
-                match #{name struct}OrString::deserialize(deserializer)? {
+                match #{name struct}OrString::deserialize(deserializer).map_err(Error::Json)? {
                     #{name struct}OrString::String(s) => s.parse(),
                     #{name struct}OrString::#{name struct}(#{name struct} {
                         #{struct.members.map do |m| "#{field_name(m)}," end.join(" ")}

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -434,7 +434,7 @@ module Xdrgen
         out.puts <<-EOS.strip_heredoc if @options[:rust_types_custom_str_impl].include?(name struct)
         #[cfg(all(feature = "serde", feature = "alloc"))]
         impl<'de> serde::Deserialize<'de> for #{name struct} {
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: serde::Deserializer<'de> {
+            fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error> where D: serde::Deserializer<'de> {
                 use serde::Deserialize;
                 #[derive(Deserialize)]
                 struct #{name struct} {

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -449,7 +449,7 @@ module Xdrgen
                     #{name struct}(#{name struct}),
                 }
                 match #{name struct}OrString::deserialize(deserializer)? {
-                    #{name struct}OrString::String(s) => s.parse(),
+                    #{name struct}OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
                     #{name struct}OrString::#{name struct}(#{name struct} {
                         #{struct.members.map do |m| "#{field_name(m)}," end.join(" ")}
                     }) => Ok(self::#{name struct} {

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -448,7 +448,7 @@ module Xdrgen
                     String(&'a str),
                     #{name struct}(#{name struct}),
                 }
-                match #{name struct}OrString::deserialize(deserializer).map_err(Error::Json)? {
+                match #{name struct}OrString::deserialize(deserializer).map_err(|_| Error::Invalid)? {
                     #{name struct}OrString::String(s) => s.parse(),
                     #{name struct}OrString::#{name struct}(#{name struct} {
                         #{struct.members.map do |m| "#{field_name(m)}," end.join(" ")}

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -431,6 +431,15 @@ module Xdrgen
             }
         }
         EOS
+        # Include a deserializer that will deserialize via the FromStr
+        # implementation, but also deserialize the original struct, present in
+        # the JSON as a map. The reason for the second option for
+        # deserialization is that types that we're adding string
+        # representations for were previously deserializable via a map to their
+        # struct, and so this improves the backwards compatibility.
+        # Note that this is only done for structs and not other types (typedef,
+        # enum, union), because struct is the only type that maps to JSON in a
+        # way that is unambiguous with a secondary form in string type.
         out.puts <<-EOS.strip_heredoc if @options[:rust_types_custom_str_impl].include?(name struct)
         #[cfg(all(feature = "serde", feature = "alloc"))]
         impl<'de> serde::Deserialize<'de> for #{name struct} {

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -432,6 +432,7 @@ module Xdrgen
         }
         EOS
         out.puts <<-EOS.strip_heredoc if @options[:rust_types_custom_str_impl].include?(name struct)
+        #[cfg(all(feature = "serde", feature = "alloc"))]
         impl<'de> serde::Deserialize<'de> for #{name struct} {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: serde::Deserializer<'de> {
                 use serde::Deserialize;
@@ -448,7 +449,7 @@ module Xdrgen
                     #{name struct}(#{name struct}),
                 }
                 match #{name struct}OrString::deserialize(deserializer)? {
-                    #{name struct}OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+                    #{name struct}OrString::String(s) => s.parse().map_err(|e| serde::de::Error::custom()),
                     #{name struct}OrString::#{name struct}(#{name struct} {
                         #{struct.members.map do |m| "#{field_name(m)}," end.join(" ")}
                     }) => Ok(self::#{name struct} {

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -454,10 +454,12 @@ module Xdrgen
                 #[derive(Deserialize)]
                 #[serde(untagged)]
                 enum #{name struct}OrString<'a> {
-                    String(&'a str),
+                    Str(&'a str),
+                    String(String),
                     #{name struct}(#{name struct}),
                 }
                 match #{name struct}OrString::deserialize(deserializer)? {
+                    #{name struct}OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
                     #{name struct}OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
                     #{name struct}OrString::#{name struct}(#{name struct} {
                         #{struct.members.map do |m| "#{field_name(m)}," end.join(" ")}

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -430,7 +430,8 @@ module Xdrgen
                 })
             }
         }
-
+        EOS
+        out.puts <<-EOS.strip_heredoc if @options[:rust_types_custom_str_impl].include?(name struct)
         impl<'de> serde::Deserialize<'de> for #{name struct} {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: serde::Deserializer<'de> {
                 use serde::Deserialize;
@@ -456,7 +457,6 @@ module Xdrgen
                 }
             }
         }
-        EOS
         out.break
       end
 

--- a/lib/xdrgen/generators/rust.rb
+++ b/lib/xdrgen/generators/rust.rb
@@ -449,7 +449,7 @@ module Xdrgen
                     #{name struct}(#{name struct}),
                 }
                 match #{name struct}OrString::deserialize(deserializer)? {
-                    #{name struct}OrString::String(s) => s.parse().map_err(|e| serde::de::Error::custom()),
+                    #{name struct}OrString::String(s) => s.parse(),
                     #{name struct}OrString::#{name struct}(#{name struct} {
                         #{struct.members.map do |m| "#{field_name(m)}," end.join(" ")}
                     }) => Ok(self::#{name struct} {

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -2815,7 +2815,7 @@ pub type Arr = [i32; 2];
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct HasOptions {
   pub first_option: Option<i32>,
@@ -2845,6 +2845,32 @@ self.second_option.write_xdr(w)?;
 self.third_option.write_xdr(w)?;
                     Ok(())
                 })
+            }
+        }
+        #[cfg(all(feature = "serde", feature = "alloc"))]
+        impl<'de> serde::Deserialize<'de> for HasOptions {
+            fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error> where D: serde::Deserializer<'de> {
+                use serde::Deserialize;
+                #[derive(Deserialize)]
+                struct HasOptions {
+                    first_option: Option<i32>,
+second_option: Option<i32>,
+third_option: Option<i32>,
+                }
+                #[derive(Deserialize)]
+                #[serde(untagged)]
+                enum HasOptionsOrString<'a> {
+                    String(&'a str),
+                    HasOptions(HasOptions),
+                }
+                match HasOptionsOrString::deserialize(deserializer)? {
+                    HasOptionsOrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+                    HasOptionsOrString::HasOptions(HasOptions {
+                        first_option, second_option, third_option,
+                    }) => Ok(self::HasOptions {
+                        first_option, second_option, third_option,
+                    }),
+                }
             }
         }
 

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -2860,10 +2860,12 @@ third_option: Option<i32>,
                 #[derive(Deserialize)]
                 #[serde(untagged)]
                 enum HasOptionsOrString<'a> {
-                    String(&'a str),
+                    Str(&'a str),
+                    String(String),
                     HasOptions(HasOptions),
                 }
                 match HasOptionsOrString::deserialize(deserializer)? {
+                    HasOptionsOrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
                     HasOptionsOrString::String(s) => s.parse().map_err(serde::de::Error::custom),
                     HasOptionsOrString::HasOptions(HasOptions {
                         first_option, second_option, third_option,

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -2870,10 +2870,12 @@ max_string: StringM::<100>,
                 #[derive(Deserialize)]
                 #[serde(untagged)]
                 enum MyStructOrString<'a> {
-                    String(&'a str),
+                    Str(&'a str),
+                    String(String),
                     MyStruct(MyStruct),
                 }
                 match MyStructOrString::deserialize(deserializer)? {
+                    MyStructOrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
                     MyStructOrString::String(s) => s.parse().map_err(serde::de::Error::custom),
                     MyStructOrString::MyStruct(MyStruct {
                         some_int, a_big_int, some_opaque, some_string, max_string,

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -4005,10 +4005,12 @@ field7: bool,
                 #[derive(Deserialize)]
                 #[serde(untagged)]
                 enum MyStructOrString<'a> {
-                    String(&'a str),
+                    Str(&'a str),
+                    String(String),
                     MyStruct(MyStruct),
                 }
                 match MyStructOrString::deserialize(deserializer)? {
+                    MyStructOrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
                     MyStructOrString::String(s) => s.parse().map_err(serde::de::Error::custom),
                     MyStructOrString::MyStruct(MyStruct {
                         field1, field2, field3, field4, field5, field6, field7,
@@ -4067,10 +4069,12 @@ impl<'de> serde::Deserialize<'de> for LotsOfMyStructs {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum LotsOfMyStructsOrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             LotsOfMyStructs(LotsOfMyStructs),
         }
         match LotsOfMyStructsOrString::deserialize(deserializer)? {
+            LotsOfMyStructsOrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             LotsOfMyStructsOrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             LotsOfMyStructsOrString::LotsOfMyStructs(LotsOfMyStructs {
                 members,

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -3944,7 +3944,7 @@ pub type Int4 = u64;
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MyStruct {
   pub field1: Uint512,
@@ -3988,6 +3988,36 @@ self.field7.write_xdr(w)?;
                 })
             }
         }
+        #[cfg(all(feature = "serde", feature = "alloc"))]
+        impl<'de> serde::Deserialize<'de> for MyStruct {
+            fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error> where D: serde::Deserializer<'de> {
+                use serde::Deserialize;
+                #[derive(Deserialize)]
+                struct MyStruct {
+                    field1: Uint512,
+field2: OptHash1,
+field3: i32,
+field4: u32,
+field5: f32,
+field6: f64,
+field7: bool,
+                }
+                #[derive(Deserialize)]
+                #[serde(untagged)]
+                enum MyStructOrString<'a> {
+                    String(&'a str),
+                    MyStruct(MyStruct),
+                }
+                match MyStructOrString::deserialize(deserializer)? {
+                    MyStructOrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+                    MyStructOrString::MyStruct(MyStruct {
+                        field1, field2, field3, field4, field5, field6, field7,
+                    }) => Ok(self::MyStruct {
+                        field1, field2, field3, field4, field5, field6, field7,
+                    }),
+                }
+            }
+        }
 
 /// LotsOfMyStructs is an XDR Struct defines as:
 ///
@@ -4000,7 +4030,7 @@ self.field7.write_xdr(w)?;
 ///
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
+#[cfg_attr(all(feature = "serde", feature = "alloc"), derive(serde_with::SerializeDisplay))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct LotsOfMyStructs {
   pub members: VecM::<MyStruct>,
@@ -4024,6 +4054,30 @@ impl WriteXdr for LotsOfMyStructs {
             self.members.write_xdr(w)?;
             Ok(())
         })
+    }
+}
+#[cfg(all(feature = "serde", feature = "alloc"))]
+impl<'de> serde::Deserialize<'de> for LotsOfMyStructs {
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error> where D: serde::Deserializer<'de> {
+        use serde::Deserialize;
+        #[derive(Deserialize)]
+        struct LotsOfMyStructs {
+            members: VecM::<MyStruct>,
+        }
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum LotsOfMyStructsOrString<'a> {
+            String(&'a str),
+            LotsOfMyStructs(LotsOfMyStructs),
+        }
+        match LotsOfMyStructsOrString::deserialize(deserializer)? {
+            LotsOfMyStructsOrString::String(s) => s.parse().map_err(serde::de::Error::custom),
+            LotsOfMyStructsOrString::LotsOfMyStructs(LotsOfMyStructs {
+                members,
+            }) => Ok(self::LotsOfMyStructs {
+                members,
+            }),
+        }
     }
 }
 


### PR DESCRIPTION
### What
  Add custom string deserializers for structs to fallback to their structural form.

  ### Why
  Improves backward compatibility by allowing deserialization from both string representations and original struct JSON maps. At this point XDR-JSON is in use and while the format can always break between protocol versions, when we make significant widespread changes like changing Int128Parts to be a string, it creates a better experience for folks if previous forms like `{"hi":0,"lo":1}` continue to deserialize.

This is only supported for structs for now, because it's the only type of XDR type that we are currently adding a string form for (https://github.com/stellar/rs-stellar-xdr/pull/441), and structs are also the only form that can be defined generally in a way that is unambiguous between the two. XDR unions can serialize as a string already if they have a void arm body, enums serialize as strings, and typedefs are very flexible.

I considered introducing a derive to do the same as what is being code generated here, but a derive would need to be more general than what I wrote here, so this seemed like a narrower place to start. I did start this conversation about whether a derive that does the same thing would be a suitable contribution to the serde_with crate, because if so that would be a better place for such a derive implementation to live:
- https://github.com/jonasbb/serde_with/issues/840