### PR TITLE
Rust: Fix string deser bug with i64 and streaming JSON

### DIFF
--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -2325,10 +2325,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -2335,10 +2335,12 @@ impl<'de> serde_with::DeserializeAs<'de, i64> for NumberOrString {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum I64OrString<'a> {
-            String(&'a str),
+            Str(&'a str),
+            String(String),
             I64(i64),
         }
         match I64OrString::deserialize(deserializer)? {
+            I64OrString::Str(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::String(s) => s.parse().map_err(serde::de::Error::custom),
             I64OrString::I64(v) => Ok(v),
         }


### PR DESCRIPTION
### What
  Add support for deserializing i64 from owned String type in I64OrString.

  ### Why
  Some JSON deserializers use owned String instead of borrowed &str when streaming. Without this change, deserializing i64 values from string representation fails in streaming scenarios where the deserialized type cannot take a reference to a string owned elsewhere.