### PR TITLE
Rust: Fix bugs in error impl

### DIFF
--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -118,16 +118,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -118,16 +118,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -101,6 +101,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -95,7 +95,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -72,7 +72,16 @@ pub enum Error {
 impl PartialEq for Error {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
+            (Self::Invalid,          Self::Invalid)
+            | (Self::Unsupported,      Self::Unsupported)
+            | (Self::LengthExceedsMax, Self::LengthExceedsMax)
+            | (Self::LengthMismatch,   Self::LengthMismatch)
+            | (Self::NonZeroPadding,   Self::NonZeroPadding) => true,
+
             (Self::Utf8Error(l), Self::Utf8Error(r)) => l == r,
+
+            #[cfg(feature = "alloc")]
+            (Self::InvalidHex, Self::InvalidHex) => true,
 
             // IO errors cannot be compared, but in the absence of any more
             // meaningful way to compare the errors we compare the kind of error
@@ -83,10 +92,15 @@ impl PartialEq for Error {
             #[cfg(feature = "std")]
             (Self::Io(l), Self::Io(r)) => l.kind() == r.kind(),
 
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+
+            #[cfg(feature = "serde_json")]
+            (Self::Json(l), Self::Json(r)) => l == r,
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
-
-            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
         }
     }
 }
@@ -96,12 +110,21 @@ impl error::Error for Error {
     #[must_use]
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
+            Error::Invalid
+            | Error::Unsupported
+            | Error::LengthExceedsMax
+            | Error::LengthMismatch
+            | Error::NonZeroPadding => None,
+
+            Error::Utf8Error(e) => Some(e),
+
             Self::Io(e) => Some(e),
+
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),
-            _ => None,
         }
     }
 }
@@ -115,14 +138,20 @@ impl fmt::Display for Error {
             Error::LengthMismatch => write!(f, "xdr value length does not match"),
             Error::NonZeroPadding => write!(f, "xdr padding contains non-zero bytes"),
             Error::Utf8Error(e) => write!(f, "{e}"),
+
             #[cfg(feature = "alloc")]
             Error::InvalidHex => write!(f, "hex invalid"),
+
             #[cfg(feature = "std")]
             Error::Io(e) => write!(f, "{e}"),
+
             Error::DepthLimitExceeded => write!(f, "depth limit exceeded"),
+
             #[cfg(feature = "serde_json")]
             Error::Json(e) => write!(f, "{e}"),
+
             Error::LengthLimitExceeded => write!(f, "length limit exceeded"),
+
             #[cfg(feature = "arbitrary")]
             Error::Arbitrary(e) => write!(f, "{e}"),
         }

--- a/lib/xdrgen/generators/rust/src/types.rs
+++ b/lib/xdrgen/generators/rust/src/types.rs
@@ -118,10 +118,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/block_comments.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/const.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/enum.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/nesting.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/optional.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/struct.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/test.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust/union.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_default_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/block_comments.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/block_comments.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/block_comments.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/block_comments.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_default_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/block_comments.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_default_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/const.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/const.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/const.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/const.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_default_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/const.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_default_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/enum.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/enum.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/enum.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/enum.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_default_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/enum.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_default_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/nesting.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/nesting.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/nesting.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/nesting.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_default_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/nesting.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_default_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/optional.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/optional.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/optional.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/optional.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_default_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/optional.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_default_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/struct.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/struct.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/struct.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/struct.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_default_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/struct.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_default_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/test.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/test.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/test.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/test.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_default_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/test.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_default_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/union.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/union.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/union.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_default_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/union.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_default_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_default_impls/union.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/block_comments.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/const.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/enum.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/nesting.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/optional.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/struct.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/test.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_jsonschema_impls/union.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/block_comments.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/const.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/enum.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/nesting.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/optional.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/struct.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/test.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => true,
+            (Self::InvalidHex, Self::InvalidHex) => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -128,16 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
-            (Self::InvalidHex, Self::InvalidHex) => None,
+            Self::InvalidHex => None,
 
             Self::Io(e) => Some(e),
 
-            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => None,
+            Self::DepthLimitExceeded => None,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
 
-            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => None,
+            Self::LengthLimitExceeded => None,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -128,10 +128,16 @@ impl error::Error for Error {
 
             Error::Utf8Error(e) => Some(e),
 
+            (Self::InvalidHex, Self::InvalidHex) => true,
+
             Self::Io(e) => Some(e),
+
+            (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
             Self::Json(e) => Some(e),
+
+            (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 
             #[cfg(feature = "arbitrary")]
             Self::Arbitrary(e) => Some(e),

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -105,7 +105,7 @@ impl PartialEq for Error {
             (Self::DepthLimitExceeded, Self::DepthLimitExceeded) => true,
 
             #[cfg(feature = "serde_json")]
-            (Self::Json(l), Self::Json(r)) => l == r,
+            (Self::Json(l), Self::Json(r)) => l.classify() == r.classify(),
 
             (Self::LengthLimitExceeded, Self::LengthLimitExceeded) => true,
 

--- a/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
+++ b/spec/output/generator_spec_rust_custom_str_impls/union.x/MyXDR.rs
@@ -111,6 +111,8 @@ impl PartialEq for Error {
 
             #[cfg(feature = "arbitrary")]
             (Self::Arbitrary(l), Self::Arbitrary(r)) => l == r,
+
+            _ => false,
         }
     }
 }


### PR DESCRIPTION
### What
  Change the trait impls on the Error type in the Rust generated code to compare all types and offer sources for all types.

  ### Why
  The use of the `_` catch-all matches in the trait impls had led to missing cases being implemented over time and error impl is broken / inconsistent. For example, the Utf error condition didn't expose its source error. And the serde json error type was no compared properly.

This problem hasn't caused any big issues that we're aware, since we don't routinely compare XDR error types inside the environment or any tooling, but it's good practice to fix this.

As part of the fix, removed the catch all to reduce the chance we end up in this place again in the future.

Downstream:
- https://github.com/stellar/rs-stellar-xdr/pull/447