### PR TITLE
Add support for custom XDR generators

### DIFF
--- a/lib/xdrgen/compilation.rb
+++ b/lib/xdrgen/compilation.rb
@@ -2,11 +2,12 @@ module Xdrgen
   class Compilation
     extend Memoist
 
-    def initialize(source_paths, output_dir:".", language: :ruby, namespace: nil, options: {})
+    def initialize(source_paths, output_dir:".", language: :ruby, generator: nil, namespace: nil, options: {})
       @source_paths = source_paths
       @output_dir  = output_dir
       @namespace   = namespace
       @language    = language
+      @generator   = generator
       @options     = options
     end
 
@@ -22,8 +23,8 @@ module Xdrgen
     def compile
       output = Output.new(@source_paths, @output_dir)
 
-      
-      generator = Generators.for_language(@language).new(ast, output, @namespace, @options)
+      generator_class = @generator || Generators.for_language(@language)
+      generator = generator_class.new(ast, output, @namespace, @options)
       generator.generate
     ensure
       output.close

--- a/spec/lib/xdrgen/custom_generator_spec.rb
+++ b/spec/lib/xdrgen/custom_generator_spec.rb
@@ -1,22 +1,21 @@
 require 'spec_helper'
 
 describe Xdrgen::Generators do
-  generator_fixture_paths.each do |path|
-    it "can accept a custom generator to generate #{File.basename path}" do
-      expect(TestGenerator).to receive(:new).with(
-        an_instance_of(Xdrgen::AST::Top),
-        an_instance_of(Xdrgen::Output),
-        "namespace",
-        {},
-      ).and_call_original
-      expect_any_instance_of(TestGenerator).to receive(:generate).with(no_args)
-      Xdrgen::Compilation.new(
-        [path],
-        output_dir: "#{SPEC_ROOT}/output/custom_generator_spec/#{File.basename path}",
-        generator: TestGenerator,
-        namespace: "namespace",
-      ).compile
-    end
+  it "can accept a custom generator to generate" do
+    expect(TestGenerator).to receive(:new).with(
+      an_instance_of(Xdrgen::AST::Top),
+      an_instance_of(Xdrgen::Output),
+      "namespace",
+      { option: true },
+    ).and_call_original
+    expect_any_instance_of(TestGenerator).to receive(:generate).with(no_args)
+    Xdrgen::Compilation.new(
+      generator_fixture_paths,
+      output_dir: "output_dir/",
+      generator: TestGenerator,
+      namespace: "namespace",
+      options: { option: true }
+    ).compile
   end
 end
 

--- a/spec/lib/xdrgen/custom_generator_spec.rb
+++ b/spec/lib/xdrgen/custom_generator_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Xdrgen::Generators do
+  generator_fixture_paths.each do |path|
+    it "can accept a custom generator to generate #{File.basename path}" do
+      expect(TestGenerator).to receive(:new).with(
+        an_instance_of(Xdrgen::AST::Top),
+        an_instance_of(Xdrgen::Output),
+        "namespace",
+        {},
+      ).and_call_original
+      expect_any_instance_of(TestGenerator).to receive(:generate).with(no_args)
+      Xdrgen::Compilation.new(
+        [path],
+        output_dir: "#{SPEC_ROOT}/output/custom_generator_spec/#{File.basename path}",
+        generator: TestGenerator,
+        namespace: "namespace",
+      ).compile
+    end
+  end
+end
+
+class TestGenerator < Xdrgen::Generators::Base
+  def generate; end
+end


### PR DESCRIPTION
### What
  Add support for providing custom generators to the XDR compilation process.

  ### Why
  To make it possible to use the xdrgen library to generate xdr with generators not defined in the library. As a first step for moving the generators to their respective repos. Some generators, such as the Rust generator and the JS generator, are tightly coupled with the library they generate code for. Because of that the separation of the generator into the xdrgen repo makes for an awkward development cycle, and since the code generated is not particularly portable, little benefit.

Related:
- https://github.com/stellar/stellar-protocol/discussions/1738
- https://github.com/stellar/rs-stellar-xdr/pull/449
- https://github.com/stellar/xdrgen/pull/221