### PR TITLE
Error on no .x source paths during compilation

### DIFF
--- a/lib/xdrgen/compilation.rb
+++ b/lib/xdrgen/compilation.rb
@@ -3,6 +3,7 @@ module Xdrgen
     extend Memoist
 
     def initialize(source_paths, output_dir:".", language: :ruby, generator: nil, namespace: nil, options: {})
+      raise "An empty list of source paths (.x files) provided. At least one source file must be provided to compile." if source_paths.empty?
       @source_paths = source_paths
       @output_dir  = output_dir
       @namespace   = namespace

--- a/spec/lib/xdrgen/compilation_spec.rb
+++ b/spec/lib/xdrgen/compilation_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Xdrgen::Compilation do
+  it "errors on empty list of source paths" do
+    expect {
+      Xdrgen::Compilation.new(
+        [], # Empty list of source paths
+        output_dir: "output_dir/",
+        generator: TestGenerator,
+        namespace: "namespace",
+        options: { option: true }
+      )
+    }.to raise_error(/empty list of source paths/)
+  end
+end
+
+class TestGenerator < Xdrgen::Generators::Base
+  def generate; end
+end


### PR DESCRIPTION
### What
  Add validation to ensure at least one source file is provided for compilation.

  ### Why
  Prevents silent failure when an empty list of source paths is provided.