### PR TITLE
Allow concurrent-ruby >= 1.3.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,8 @@ PATH
   specs:
     xdrgen (0.1.3)
       activesupport (~> 6)
-      concurrent-ruby (<= 1.3.4)
+      concurrent-ruby (>= 1.3.7)
+      logger
       memoist (~> 0.11.0)
       slop (~> 3.4)
       treetop (~> 1.5.3)
@@ -18,7 +19,7 @@ GEM
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     coderay (1.1.3)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.3.7)
     diff-lcs (1.5.0)
     ffi (1.15.5)
     formatador (1.1.0)
@@ -41,6 +42,7 @@ GEM
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     lumberjack (1.2.8)
     memoist (0.11.0)
     method_source (1.0.0)

--- a/lib/xdrgen.rb
+++ b/lib/xdrgen.rb
@@ -1,4 +1,7 @@
 require "xdrgen/version"
+# activesupport 6 references ::Logger without requiring it, and
+# concurrent-ruby >= 1.3.5 no longer requires it either, so load it first.
+require "logger"
 require "active_support/all"
 require 'memoist'
 

--- a/xdrgen.gemspec
+++ b/xdrgen.gemspec
@@ -17,14 +17,16 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.1.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency "treetop", "~> 1.5.3"
   spec.add_dependency "activesupport", "~> 6"
   spec.add_dependency "slop", "~> 3.4"
   spec.add_dependency "memoist", "~> 0.11.0"
-  # https://stackoverflow.com/questions/79360526/uninitialized-constant-activesupportloggerthreadsafelevellogger-nameerror
-  spec.add_dependency "concurrent-ruby", "<= 1.3.4"
+  # >= 1.3.7 fixes GHSA-h8w8-99g7-qmvj, GHSA-wv3x-4vxv-whpp and GHSA-6wx8-w4f5-wwcr
+  spec.add_dependency "concurrent-ruby", ">= 1.3.7"
+  # required at load time by lib/xdrgen.rb; no longer a default gem on Ruby >= 3.5
+  spec.add_dependency "logger"
   
   spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
concurrent-ruby was pinned to `<= 1.3.4` in #206 because 1.3.5 stopped requiring `logger`, which activesupport 6 needs at load time (`uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger`).

concurrent-ruby `<= 1.3.4` is affected by [GHSA-h8w8-99g7-qmvj](https://github.com/advisories/GHSA-h8w8-99g7-qmvj) (high), [GHSA-wv3x-4vxv-whpp](https://github.com/advisories/GHSA-wv3x-4vxv-whpp) (low) and [GHSA-6wx8-w4f5-wwcr](https://github.com/advisories/GHSA-6wx8-w4f5-wwcr) (low), all fixed in 1.3.7. The pin propagates these Dependabot alerts to downstream consumers of xdrgen, including the Stellar SDK XDR generators.

Changes:

- require `logger` in `lib/xdrgen.rb` before activesupport, which resolves the original load error
- declare `logger` as a runtime dependency, since it is no longer a default gem on Ruby >= 3.5
- raise the concurrent-ruby constraint to `>= 1.3.7`
- set `required_ruby_version` to `>= 2.5.0`, matching the floor activesupport 6 already imposes
- update `Gemfile.lock` accordingly

Tested with `bundle exec rspec` on Ruby 2.7 and 3.3 (20 examples, 0 failures, no changes under `spec/output`), and validated against the stellar-ios-mac-sdk Swift XDR generator: full generation with concurrent-ruby 1.3.7 produces byte-identical output.

