### PR TITLE
Add note that .x files are trusted inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ protocol](https://github.com/stellar/stellar-xdr).
 >
 > The JavaScript and Go generators still live here at this time.
 
+> [!WARNING]
+> .x files to the parser and code generators in this repository are considered a
+> trusted input, and the parser and code generators are not defensive to injection.
+> Use only with trusted inputs.
+
 ## Usage as a library
 
 Add this line to your application's Gemfile:


### PR DESCRIPTION
### What

Add note that the .x files are trusted inputs.

### Why

This was implied by the use cases of the tooling, Stellar Protocol .x files, but not stated explicitly. The tooling is intended for use with .x files that the user has self authored or trusts and as such the tooling does not and won't prevent all forms of escape or injection that may exist in a third party .x file.

Eventually the code generators will be moved out of this repo, as they are unmaintained here, but until then this warning can serve to make this more explicit.